### PR TITLE
Fix Vector2.Normalized

### DIFF
--- a/Polytoria/scripts/scripting/datatypes/PTVector2.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTVector2.cs
@@ -24,7 +24,7 @@ public class PTVector2 : IScriptGDObject
 	[ScriptProperty] public static PTVector2 Up { get; private set; } = new() { X = 0, Y = 1 };
 
 	[ScriptProperty] public float Magnitude => vector.Length();
-	[ScriptProperty] public PTVector2 Normalized => FromGDClass(-vector.Normalized());
+	[ScriptProperty] public PTVector2 Normalized => FromGDClass(vector.Normalized());
 	[ScriptProperty] public float SqrMagnitude => vector.LengthSquared();
 
 	public static PTVector2 FromGDClass(Vector2 vec)


### PR DESCRIPTION
## Summary

Fixes Vector2.Normalized being flipped

<img width="431" height="191" alt="image" src="https://github.com/user-attachments/assets/2ff93369-66e2-4850-b554-47f385bf1a73" />

Reported by LuauHater

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="428" height="700" alt="image" src="https://github.com/user-attachments/assets/58868af0-b7aa-4e46-bc0b-03e321117fd2" />

## AI/LLM use

None