### PR TITLE
Luau: Allow missing args on null params

### DIFF
--- a/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
@@ -956,7 +956,15 @@ public class LuaMetatable : LuaObject
 
 			// All fixed params beyond args must have defaults
 			for (int i = args.Length; i < fixedCount; i++)
-				if (!eligible[i].HasDefaultValue) { compatible = false; break; }
+			{
+				if (!eligible[i].HasDefaultValue)
+				{
+					// Allow missing args if the param accepts null
+					Type pt = eligible[i].ParameterType;
+					bool acceptsNull = !pt.IsValueType || Nullable.GetUnderlyingType(pt) != null;
+					if (!acceptsNull) { compatible = false; break; }
+				}
+			}
 
 			for (int i = 0; i < args.Length; i++)
 			{


### PR DESCRIPTION
## Summary

Luau doesn't push trailing nils onto the stack, so this PR adds logic that fills in the null params if it is accepted.

## Related issue or discussion

Related to #9 , should resolve `json.isNull` failing

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

Claude helped with the overload checking code 👍  