### PR TITLE
Flip Dynamic.GetBounds

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -938,7 +938,7 @@ public sealed partial class Camera : Dynamic
 		{
 			if (t is Dynamic dyn)
 			{
-				Aabb bounds = dyn.GetBounds();
+				Aabb bounds = dyn.CalculateBounds();
 				if (first)
 				{
 					combinedBounds = bounds;

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -954,10 +954,14 @@ public partial class Dynamic : Instance
 		return false;
 	}
 
+	/// <summary>
+	/// GetBounds for scripting uses, for internal use. use CalculateBounds
+	/// </summary>
+	/// <returns></returns>
 	[ScriptMethod]
 	public Aabb GetBounds()
 	{
-		return CalculateBounds();
+		return CalculateBounds().Flip();
 	}
 
 	internal void SetVisualMaskLayer(int layer, bool to)

--- a/Polytoria/scripts/utils/MathUtils.cs
+++ b/Polytoria/scripts/utils/MathUtils.cs
@@ -89,4 +89,9 @@ public static class MathUtilsExtensions
 	{
 		return MathUtils.FlipQuat(q);
 	}
+
+	public static Aabb Flip(this Aabb a)
+	{
+		return new Aabb(new Vector3(-a.End.X, a.Position.Y, a.Position.Z), a.Size);
+	}
 }


### PR DESCRIPTION
## Summary

Flipped `Dynamic.GetBounds` to match the left-handed coordinate system.

- Added `Flip` to Aabb extensions
- Flip `Dynamic.GetBounds`
- Change Camera to use internal `dyn.CalculateBounds`

## Related issue or discussion

Fixes #22 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="706" height="76" alt="image" src="https://github.com/user-attachments/assets/25c70b26-09aa-49d5-9724-e05313427b30" />

The bound position should be in a left-handed coordinate system now.

## AI/LLM use

Claude helped with flipping it 👍 