### PR TITLE
Creator: Add indentation settings to script editor

### DIFF
--- a/Polytoria/scripts/creator/CreatorSettings.cs
+++ b/Polytoria/scripts/creator/CreatorSettings.cs
@@ -54,7 +54,11 @@ public sealed partial class CreatorSettings : Node
 					Name = "CodeEditor",
 					DisplayName = "Code Editor",
 					Settings = [
-						new("PreferredEditor", "Preferred Editor", PreferredEditorEnum.BuiltIn)
+						new("PreferredEditor", "Preferred Editor", PreferredEditorEnum.BuiltIn),
+						new("IndentationMode", "Indentation Mode", IndentationModeEnum.Tabs),
+						// TODO: Cap IndentationSize between 1 and 8. IndentationSize can be negative.
+						// MinValue and MaxValue is bugged for integer settings.
+						new("IndentationSize", "Indentation Size (In Spaces)", 2) { MinValue = 1, MaxValue = 8 },
 					]
 				},
 				new() {
@@ -296,6 +300,12 @@ public enum PreferredEditorEnum
 	Zed
 }
 
+public enum IndentationModeEnum
+{
+	Tabs,
+	Spaces
+}
+
 public enum RenderingMethodEnum
 {
 	Standard,
@@ -313,5 +323,6 @@ public enum RenderingMethodEnum
 [JsonSerializable(typeof(object))]
 
 [JsonSerializable(typeof(PreferredEditorEnum))]
+[JsonSerializable(typeof(IndentationModeEnum))]
 [JsonSerializable(typeof(RenderingMethodEnum))]
 public partial class CreatorSettingsGenerationContext : JsonSerializerContext { }

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -80,7 +80,7 @@ public partial class TextEditorRoot : Node
 
 		CreatorSettings.Singleton.GetSettingProperty("CodeEditor.IndentationMode")!.ValueChanged += OnIndentSettingsChanged;
 		CreatorSettings.Singleton.GetSettingProperty("CodeEditor.IndentationSize")!.ValueChanged += OnIndentSettingsChanged;
-		OnIndentSettingsChanged(new object());
+		OnIndentSettingsChanged();
 
 		CodeEditor.CodeCompletionPrefixes = [".", ":", "\n", ",", " ", "("];
 		CodeEditor.CodeCompletionEnabled = true;
@@ -106,7 +106,7 @@ public partial class TextEditorRoot : Node
 		}
 	}
 
-	private void OnIndentSettingsChanged(object _)
+	private void OnIndentSettingsChanged(object? _ = null)
 	{
 		IndentationModeEnum indentationMode = CreatorSettings.Singleton.GetSetting<IndentationModeEnum>("CodeEditor.IndentationMode");
 		int indentationSize = CreatorSettings.Singleton.GetSetting<int>("CodeEditor.IndentationSize");

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -57,6 +57,10 @@ public partial class TextEditorRoot : Node
 			await _completion.CloseScriptAsync(Container.TargetFilePathAbsolute);
 			_completion.PublishDiagnostics -= OnPublishDiagnostics;
 		}
+
+		CreatorSettings.Singleton.GetSettingProperty("CodeEditor.IndentationMode")!.ValueChanged -= OnIndentSettingsChanged;
+		CreatorSettings.Singleton.GetSettingProperty("CodeEditor.IndentationSize")!.ValueChanged -= OnIndentSettingsChanged;
+
 		base._ExitTree();
 	}
 
@@ -73,6 +77,10 @@ public partial class TextEditorRoot : Node
 		CodeEditor.ClearUndoHistory();
 		CodeEditor.TextChanged += OnCodeEditTextChanged;
 		InitSyntaxHighlighter();
+
+		CreatorSettings.Singleton.GetSettingProperty("CodeEditor.IndentationMode")!.ValueChanged += OnIndentSettingsChanged;
+		CreatorSettings.Singleton.GetSettingProperty("CodeEditor.IndentationSize")!.ValueChanged += OnIndentSettingsChanged;
+		OnIndentSettingsChanged(new object());
 
 		CodeEditor.CodeCompletionPrefixes = [".", ":", "\n", ",", " ", "("];
 		CodeEditor.CodeCompletionEnabled = true;
@@ -96,6 +104,14 @@ public partial class TextEditorRoot : Node
 		{
 			await _completion.OpenScriptAsync(Container.TargetFilePathAbsolute);
 		}
+	}
+
+	private void OnIndentSettingsChanged(object _)
+	{
+		IndentationModeEnum indentationMode = CreatorSettings.Singleton.GetSetting<IndentationModeEnum>("CodeEditor.IndentationMode");
+		int indentationSize = CreatorSettings.Singleton.GetSetting<int>("CodeEditor.IndentationSize");
+		CodeEditor.IndentUseSpaces = indentationMode == IndentationModeEnum.Spaces;
+		CodeEditor.IndentSize = indentationSize;
 	}
 
 	private async void OnPublishDiagnostics(string path, List<LspDiagnostic> diagnostics)


### PR DESCRIPTION
## Summary

Two new settings have been implemented in the creator: "Indentation Mode", and "Indentation Size". "Indentation Mode" controls whether to use tabs or spaces for indentation, and "Indentation Size" controls the size of each tab in spaces. Internally, I've hooked the built-in script editor to the engine settings, allowing me to change indentation live without having to leave the script editor. So far, things are working relatively well, and I think these changes should (hopefully) be ready for production.

## Related issue or discussion

Addresses Issue #33

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video


https://github.com/user-attachments/assets/ba955a59-e5cc-41fb-851e-659cdfaabe1b


## AI/LLM use

No AI/LLMs were used in the making of this pull request. This was my first time using C# in a long, long time.