### PR TITLE
(Old) - Moved to new PR #94

### DIFF
--- a/Polytoria/scripts/creator/ui/docks/explorer/ExplorerTree.cs
+++ b/Polytoria/scripts/creator/ui/docks/explorer/ExplorerTree.cs
@@ -78,11 +78,52 @@ public partial class ExplorerTree : Tree
 				}
 			}
 		}
-		else if (@event.IsActionPressed("rename"))
-		{
-			EditSelected();
-		}
 		base._GuiInput(@event);
+	}
+
+
+	// Less Priority Input Calls
+	public override void _UnhandledKeyInput(InputEvent @event)
+	{
+
+		if (@event is not InputEventKey key)
+		{
+			base._UnhandledKeyInput(@event);
+			return;
+		}
+
+		bool renamePressed = @event.IsActionPressed("rename") ||
+			(key.Keycode == Key.F2 && key.Pressed && !key.Echo);
+
+		if (!renamePressed)
+		{
+			base._UnhandledKeyInput(@event);
+			return;
+		}
+
+		if (GetSelected() == null)
+		{
+			List<Instance> selectedInstances = Root.CreatorContext.Selections.SelectedInstances;
+			if (selectedInstances.Count != 1)
+			{
+				base._UnhandledKeyInput(@event);
+				return;
+			}
+
+			Instance selectedInstance = selectedInstances[0];
+
+			TreeItem? treeItem = Explorer.GetTreeItemFromInstance(selectedInstance);
+			if (treeItem == null)
+			{
+				base._UnhandledKeyInput(@event);
+				return;
+			}
+
+			treeItem.Select(0);
+		}
+
+		AcceptEvent();
+		EditSelected(true);
 	}
 
 	private void OnItemActivated()

--- a/Polytoria/scripts/creator/ui/docks/files/FileBrowserTree.cs
+++ b/Polytoria/scripts/creator/ui/docks/files/FileBrowserTree.cs
@@ -96,6 +96,11 @@ public partial class FileBrowserTree : Tree
 			AcceptEvent();
 			CreatorService.Interface.PromptDeleteFiles(GetSelectedFiles());
 		}
+		else if (@event.IsActionPressed("rename"))
+		{
+			AcceptEvent();
+			EditSelected(true);
+		}
 		base._GuiInput(@event);
 	}
 

--- a/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
@@ -118,7 +118,6 @@ public class PTQuaternion : IScriptGDObject
 		return FromGDClass(Quaternion.FromEuler(euler));
 	}
 
-
 	[ScriptMethod(ConvertParamsToGD = false)]
 	public static Vector3 ToEuler(PTQuaternion euler)
 	{

--- a/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
@@ -109,13 +109,13 @@ public class PTQuaternion : IScriptGDObject
 	[ScriptMethod]
 	public static PTQuaternion Euler(float x, float y, float z)
 	{
-		return FromGDClass(Quaternion.FromEuler(MathUtils.Vector3DegToRad(new(x, y, z)).FlipEuler()));
+		return FromGDClass(Quaternion.FromEuler(new(x, y, z)));
 	}
 
 	[ScriptMethod]
 	public static PTQuaternion Euler(Vector3 euler)
 	{
-		return FromGDClass(Quaternion.FromEuler(euler.DegToRad().FlipEuler()));
+		return FromGDClass(Quaternion.FromEuler(euler));
 	}
 
 

--- a/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
@@ -109,13 +109,14 @@ public class PTQuaternion : IScriptGDObject
 	[ScriptMethod]
 	public static PTQuaternion Euler(float x, float y, float z)
 	{
-		return FromGDClass(Quaternion.FromEuler(new(x, y, z)));
+		return FromGDClass(Quaternion.FromEuler(MathUtils.Vector3DegToRad(new(x, y, z)).FlipEuler()));
+
 	}
 
 	[ScriptMethod]
 	public static PTQuaternion Euler(Vector3 euler)
 	{
-		return FromGDClass(Quaternion.FromEuler(euler));
+		return FromGDClass(Quaternion.FromEuler(euler.DegToRad().FlipEuler()));
 	}
 
 	[ScriptMethod(ConvertParamsToGD = false)]

--- a/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
@@ -109,13 +109,13 @@ public class PTQuaternion : IScriptGDObject
 	[ScriptMethod]
 	public static PTQuaternion Euler(float x, float y, float z)
 	{
-		return FromGDClass(Quaternion.FromEuler(new(x, y, z)));
+		return FromGDClass(Quaternion.FromEuler(MathUtils.Vector3DegToRad(new(x, y, z)).FlipEuler()));
 	}
 
 	[ScriptMethod]
 	public static PTQuaternion Euler(Vector3 euler)
 	{
-		return FromGDClass(Quaternion.FromEuler(euler));
+		return FromGDClass(Quaternion.FromEuler(euler.DegToRad().FlipEuler()));
 	}
 
 

--- a/Polytoria/scripts/utils/MathUtils.cs
+++ b/Polytoria/scripts/utils/MathUtils.cs
@@ -12,6 +12,13 @@ namespace Polytoria.Utils;
 /// </summary>
 public static class MathUtils
 {
+
+	// Prevent -0 from returning to be sure no unexpected behavior occurs and because people complain
+	public static float NormalizeZero(float value)
+	{
+		return value == 0f ? 0f : value;
+	}
+
 	public static Vector3 FlipVector3(Vector3 vector3)
 	{
 		vector3.X = -vector3.X;
@@ -32,19 +39,19 @@ public static class MathUtils
 	public static Vector3 FlipEuler(Vector3 polyRot)
 	{
 		Vector3 godotEuler = new(
-			polyRot.X,
-			-polyRot.Y,
-			-polyRot.Z
+			NormalizeZero(polyRot.X),
+			NormalizeZero(-polyRot.Y),
+			NormalizeZero(-polyRot.Z)
 		);
 		return godotEuler;
 	}
 
 	public static Vector3 Vector3RadToDeg(Vector3 v)
 	{
-		return new(
-			Mathf.RadToDeg(v.X),
-			Mathf.RadToDeg(v.Y),
-			Mathf.RadToDeg(v.Z)
+		return new Vector3(
+			NormalizeZero(Mathf.RadToDeg(v.X)),
+			NormalizeZero(Mathf.RadToDeg(v.Y)),
+			NormalizeZero(Mathf.RadToDeg(v.Z))
 		);
 	}
 

--- a/Polytoria/scripts/utils/MathUtils.cs
+++ b/Polytoria/scripts/utils/MathUtils.cs
@@ -12,6 +12,12 @@ namespace Polytoria.Utils;
 /// </summary>
 public static class MathUtils
 {
+	// Prevent -0 from returning to be sure no unexpected behavior occurs and because people complain
+	public static float NormalizeZero(float value)
+	{
+		return value == 0f ? 0f : value;
+	}
+
 	public static Vector3 FlipVector3(Vector3 vector3)
 	{
 		vector3.X = -vector3.X;
@@ -32,19 +38,19 @@ public static class MathUtils
 	public static Vector3 FlipEuler(Vector3 polyRot)
 	{
 		Vector3 godotEuler = new(
-			polyRot.X,
-			-polyRot.Y,
-			-polyRot.Z
+			NormalizeZero(polyRot.X),
+ 			NormalizeZero(-polyRot.Y),
+			NormalizeZero(-polyRot.Z)
 		);
 		return godotEuler;
 	}
 
 	public static Vector3 Vector3RadToDeg(Vector3 v)
 	{
-		return new(
-			Mathf.RadToDeg(v.X),
-			Mathf.RadToDeg(v.Y),
-			Mathf.RadToDeg(v.Z)
+		return new Vector3(
+			NormalizeZero(Mathf.RadToDeg(v.X)),
+			NormalizeZero(Mathf.RadToDeg(v.Y)),
+			NormalizeZero(Mathf.RadToDeg(v.Z))
 		);
 	}
 

--- a/Polytoria/scripts/utils/MathUtils.cs
+++ b/Polytoria/scripts/utils/MathUtils.cs
@@ -12,12 +12,6 @@ namespace Polytoria.Utils;
 /// </summary>
 public static class MathUtils
 {
-	// Prevent -0 from returning to be sure no unexpected behavior occurs and because people complain
-	public static float NormalizeZero(float value)
-	{
-		return value == 0f ? 0f : value;
-	}
-
 	public static Vector3 FlipVector3(Vector3 vector3)
 	{
 		vector3.X = -vector3.X;
@@ -38,19 +32,19 @@ public static class MathUtils
 	public static Vector3 FlipEuler(Vector3 polyRot)
 	{
 		Vector3 godotEuler = new(
-			NormalizeZero(polyRot.X),
- 			NormalizeZero(-polyRot.Y),
-			NormalizeZero(-polyRot.Z)
+			polyRot.X,
+			-polyRot.Y,
+			-polyRot.Z
 		);
 		return godotEuler;
 	}
 
 	public static Vector3 Vector3RadToDeg(Vector3 v)
 	{
-		return new Vector3(
-			NormalizeZero(Mathf.RadToDeg(v.X)),
-			NormalizeZero(Mathf.RadToDeg(v.Y)),
-			NormalizeZero(Mathf.RadToDeg(v.Z))
+		return new(
+			Mathf.RadToDeg(v.X),
+			Mathf.RadToDeg(v.Y),
+			Mathf.RadToDeg(v.Z)
 		);
 	}
 

--- a/Polytoria/scripts/utils/MathUtils.cs
+++ b/Polytoria/scripts/utils/MathUtils.cs
@@ -48,6 +48,7 @@ public static class MathUtils
 		);
 	}
 
+
 	public static Vector3 Vector3DegToRad(Vector3 v)
 	{
 		return new(


### PR DESCRIPTION
## Summary

### Bugfix
Quaternion.Euler() expected radians internally, but degree values were passed directly, causing incorrect rotations when converting back with Quaternion.ToEuler()

The fix converts degree input to radians before creating the quaternion, so:

```lua
local EulerQuaternion = Quaternion.Euler(0, 90, 0)
local EulerRotation = Quaternion.ToEuler(EulerQuaternion)
```

now correctly returns:
```--(0, 90, 0) --```

when converted back to Euler angles.

### Feature Added: F2 Renaming in the Creator

In the File Browser and the Explorer Selected Objects can be Renamed directly with the press of the Button F2

## Related issue or discussion

Fixes #26 
Related to #26 (Bugfix), Related to #60 (Feature added)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

Gemini
Help with whats wrong with the Math.
