### PR TITLE
Avoid using SceneTreeTImer for waiting

### DIFF
--- a/Polytoria/scripts/shared/Globals.cs
+++ b/Polytoria/scripts/shared/Globals.cs
@@ -474,7 +474,11 @@ public sealed partial class Globals : Node
 
 	public async Task WaitAsync(float time)
 	{
-		await ToSignal(GetTree().CreateTimer(time), "timeout");
+		var start = Time.GetTicksUsec();
+		var target = start + (ulong)(time * 1_000_000.0);
+
+		while (Time.GetTicksUsec() < target)
+			await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
 	}
 
 	public async Task WaitFrame()


### PR DESCRIPTION
## Summary

Replaces the SceneTreeTimer in Globals.WaitAsync with a manual scheduler. After debugging for a while, I wasn't able to get SceneTreeTimer (or the normal Timer) to not have a massive drift (which appeared to be rather random and not necessarily tied to performance).

```
[Lua] World.Players.Player1.Script Ran wait(2.8), took 2.800956999999471s, delta of 0.001s
[Lua] World.Players.Player1.Script Ran wait(2.9), took 2.9018815000308678s, delta of 0.002s
[Lua] World.Players.Player1.Script Ran wait(3), took 3.000070899957791s, delta of 0s
[Lua] World.Players.Player1.Script Ran wait(3.1), took 3.100459099980071s, delta of 0s
[Lua] World.Players.Player1.Script Ran wait(3.2), took 3.2015019000973552s, delta of 0.002s
[Lua] World.Players.Player1.Script Ran wait(3.3), took 3.3056511000031605s, delta of 0.006s
[Lua] World.Players.Player1.Script Ran wait(3.4), took 3.4026126000098884s, delta of 0.003s
[Lua] World.Players.Player1.Script Ran wait(3.5), took 3.504687999957241s, delta of 0.005s
[Lua] World.Players.Player1.Script Ran wait(3.6), took 3.6015367000363767s, delta of 0.002s
[Lua] World.Players.Player1.Script Ran wait(3.7), took 3.7052066000178456s, delta of 0.005s
[Lua] World.Players.Player1.Script Ran wait(3.8), took 3.8022848999826238s, delta of 0.002s
[Lua] World.Players.Player1.Script Ran wait(3.9), took 3.9051343000028282s, delta of 0.005s
[Lua] World.Players.Player1.Script Ran wait(4), took 4.002319999970496s, delta of 0.002s
[Lua] World.Players.Player1.Script Ran wait(4.1), took 4.105948499985971s, delta of 0.006s
[Lua] World.Players.Player1.Script Ran wait(4.2), took 4.201505000004545s, delta of 0.002s
[Lua] World.Players.Player1.Script Ran wait(4.3), took 4.305111299967393s, delta of 0.005s
[Lua] World.Players.Player1.Script Ran wait(4.4), took 4.40153030003421s, delta of 0.002s
[Lua] World.Players.Player1.Script Ran wait(4.5), took 4.50501990003977s, delta of 0.005s
[Lua] World.Players.Player1.Script Ran wait(4.6), took 4.60148370009847s, delta of 0.001s
```

As far as I was able to tell, this change doesn't impact performance significantly. The accuracy of wait came down to +-1 frame.

## Related issue or discussion

Fixes #14 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

not applicable, see logs above

## AI/LLM use

Used AI for debugging guidance to help determine the issue with SceneViewTimer / Code not affected