### PR TITLE
Duplicate WarpMouse on Windows to mitigate position issues

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -653,7 +653,7 @@ public sealed partial class Camera : Dynamic
 			Root.Input.OverrideMousePos = false;
 			GDNode.GetViewport().WarpMouse(_turnStartPos);
 #if GODOT_WINDOWS
-			GDNode.GetViewport().WarpMouse(_turnStartPos); // Calling this twice fixes issues when releasing while dragging the mouse
+			GDNode.GetViewport().WarpMouse(_turnStartPos); // Workaround for godotengine/godot#119205
 #endif
 		}
 	}
@@ -749,7 +749,7 @@ public sealed partial class Camera : Dynamic
 					Vector2 globalMousePos = GDNode.GetViewport().GetScreenTransform().Origin + _lastMousePosition;
 					Input.WarpMouse(globalMousePos);
 #if GODOT_WINDOWS
-					Input.WarpMouse(globalMousePos); // Calling this twice fixes issues when releasing while dragging the mouse
+					Input.WarpMouse(globalMousePos); // Workaround for godotengine/godot#119205
 #endif
 
 					_currentMovement = Vector3.Zero;

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -652,9 +652,9 @@ public sealed partial class Camera : Dynamic
 			Input.MouseMode = Input.MouseModeEnum.Visible;
 			Root.Input.OverrideMousePos = false;
 			GDNode.GetViewport().WarpMouse(_turnStartPos);
-			#if GODOT_WINDOWS
+#if GODOT_WINDOWS
 			GDNode.GetViewport().WarpMouse(_turnStartPos); // Calling this twice fixes issues when releasing while dragging the mouse
-			#endif
+#endif
 		}
 	}
 
@@ -748,9 +748,9 @@ public sealed partial class Camera : Dynamic
 					Input.MouseMode = Input.MouseModeEnum.Visible;
 					Vector2 globalMousePos = GDNode.GetViewport().GetScreenTransform().Origin + _lastMousePosition;
 					Input.WarpMouse(globalMousePos);
-					#if GODOT_WINDOWS
+#if GODOT_WINDOWS
 					Input.WarpMouse(globalMousePos); // Calling this twice fixes issues when releasing while dragging the mouse
-					#endif
+#endif
 
 					_currentMovement = Vector3.Zero;
 					_currentRotation = Vector2.Zero;

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -652,6 +652,7 @@ public sealed partial class Camera : Dynamic
 			Input.MouseMode = Input.MouseModeEnum.Visible;
 			Root.Input.OverrideMousePos = false;
 			GDNode.GetViewport().WarpMouse(_turnStartPos);
+			GDNode.GetViewport().WarpMouse(_turnStartPos); // Calling this twice fixes issues when releasing while dragging the mouse
 		}
 	}
 
@@ -745,6 +746,7 @@ public sealed partial class Camera : Dynamic
 					Input.MouseMode = Input.MouseModeEnum.Visible;
 					Vector2 globalMousePos = GDNode.GetViewport().GetScreenTransform().Origin + _lastMousePosition;
 					Input.WarpMouse(globalMousePos);
+					Input.WarpMouse(globalMousePos); // Calling this twice fixes issues when releasing while dragging the mouse
 
 					_currentMovement = Vector3.Zero;
 					_currentRotation = Vector2.Zero;

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -652,7 +652,9 @@ public sealed partial class Camera : Dynamic
 			Input.MouseMode = Input.MouseModeEnum.Visible;
 			Root.Input.OverrideMousePos = false;
 			GDNode.GetViewport().WarpMouse(_turnStartPos);
+			#if GODOT_WINDOWS
 			GDNode.GetViewport().WarpMouse(_turnStartPos); // Calling this twice fixes issues when releasing while dragging the mouse
+			#endif
 		}
 	}
 
@@ -746,7 +748,9 @@ public sealed partial class Camera : Dynamic
 					Input.MouseMode = Input.MouseModeEnum.Visible;
 					Vector2 globalMousePos = GDNode.GetViewport().GetScreenTransform().Origin + _lastMousePosition;
 					Input.WarpMouse(globalMousePos);
+					#if GODOT_WINDOWS
 					Input.WarpMouse(globalMousePos); // Calling this twice fixes issues when releasing while dragging the mouse
+					#endif
 
 					_currentMovement = Vector3.Zero;
 					_currentRotation = Vector2.Zero;

--- a/Polytoria/scripts/shared/FreeLook.cs
+++ b/Polytoria/scripts/shared/FreeLook.cs
@@ -95,9 +95,9 @@ public sealed partial class FreeLook : Camera3D
 					Input.MouseMode = Input.MouseModeEnum.Visible;
 					Vector2 globalMousePos = GetViewport().GetScreenTransform().Origin + _lastMousePosition;
 					Input.WarpMouse(globalMousePos);
-					#if GODOT_WINDOWS
+#if GODOT_WINDOWS
 					Input.WarpMouse(globalMousePos); // Calling this twice fixes issues when releasing while dragging the mouse
-					#endif
+#endif
 
 					_currentMovement = Vector3.Zero;
 					_currentRotation = Vector2.Zero;

--- a/Polytoria/scripts/shared/FreeLook.cs
+++ b/Polytoria/scripts/shared/FreeLook.cs
@@ -95,6 +95,7 @@ public sealed partial class FreeLook : Camera3D
 					Input.MouseMode = Input.MouseModeEnum.Visible;
 					Vector2 globalMousePos = GetViewport().GetScreenTransform().Origin + _lastMousePosition;
 					Input.WarpMouse(globalMousePos);
+					Input.WarpMouse(globalMousePos); // Calling this twice fixes issues when releasing while dragging the mouse
 
 					_currentMovement = Vector3.Zero;
 					_currentRotation = Vector2.Zero;

--- a/Polytoria/scripts/shared/FreeLook.cs
+++ b/Polytoria/scripts/shared/FreeLook.cs
@@ -96,7 +96,7 @@ public sealed partial class FreeLook : Camera3D
 					Vector2 globalMousePos = GetViewport().GetScreenTransform().Origin + _lastMousePosition;
 					Input.WarpMouse(globalMousePos);
 #if GODOT_WINDOWS
-					Input.WarpMouse(globalMousePos); // Calling this twice fixes issues when releasing while dragging the mouse
+					Input.WarpMouse(globalMousePos); // Workaround for godotengine/godot#119205
 #endif
 
 					_currentMovement = Vector3.Zero;

--- a/Polytoria/scripts/shared/FreeLook.cs
+++ b/Polytoria/scripts/shared/FreeLook.cs
@@ -95,7 +95,9 @@ public sealed partial class FreeLook : Camera3D
 					Input.MouseMode = Input.MouseModeEnum.Visible;
 					Vector2 globalMousePos = GetViewport().GetScreenTransform().Origin + _lastMousePosition;
 					Input.WarpMouse(globalMousePos);
+					#if GODOT_WINDOWS
 					Input.WarpMouse(globalMousePos); // Calling this twice fixes issues when releasing while dragging the mouse
+					#endif
 
 					_currentMovement = Vector3.Zero;
 					_currentRotation = Vector2.Zero;


### PR DESCRIPTION
## Summary

Calls to `Input.WarpMouse` and `Viewport.WarpMouse` were doubled only when compiling for Windows. This fixes #36 for reasons unknown, but is likely the most efficient approach.

From what I could tell, this issue might be specific to Godot running on Windows, so no changes need to be made for other OSs. If someone can attest otherwise, I'll remove the check.

## Related issue or discussion

Fixes #36

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [X] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

[polytoria-dragging-fixed.webm](https://github.com/user-attachments/assets/a09dbf21-7389-430c-91b7-7f053b220d6b)


## AI/LLM use

None