### PR TITLE
Creator: Script Editor Status Bar

### DIFF
--- a/Polytoria/scenes/creator/tabs/text_editor/text_editor.tscn
+++ b/Polytoria/scenes/creator/tabs/text_editor/text_editor.tscn
@@ -27,7 +27,14 @@ content_margin_right = 8.0
 content_margin_bottom = 8.0
 bg_color = Color(0, 0, 0, 0.49803922)
 
-[node name="TextEditor" type="Control" unique_id=1712163761 node_paths=PackedStringArray("CodeEditor", "_finder", "_diagLabel")]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_07fmf"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+bg_color = Color(0.12156863, 0.12156863, 0.12156863, 1)
+
+[node name="TextEditor" type="Control" unique_id=1712163761 node_paths=PackedStringArray("CodeEditor", "_finder", "_diagLabel", "_statusBar")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -39,6 +46,7 @@ script = ExtResource("2_07fmf")
 CodeEditor = NodePath("VBoxContainer/CodeEdit")
 _finder = NodePath("Finder")
 _diagLabel = NodePath("VBoxContainer/DiagLabel")
+_statusBar = NodePath("VBoxContainer/StatusLabel")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1925503485]
 layout_mode = 1
@@ -74,6 +82,16 @@ layout_mode = 2
 theme_override_colors/font_color = Color(0.8666667, 0.33333334, 0.33333334, 1)
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_aql85")
+autowrap_mode = 3
+
+[node name="StatusLabel" type="Label" parent="VBoxContainer" unique_id=501714400]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 1
+theme_override_font_sizes/font_size = 14
+theme_override_styles/normal = SubResource("StyleBoxFlat_07fmf")
+text = "hello.luau: (0:0)"
+vertical_alignment = 1
 autowrap_mode = 3
 
 [node name="Finder" parent="." unique_id=495200113 instance=ExtResource("3_ypnaf")]

--- a/Polytoria/scenes/creator/tabs/text_editor/text_editor.tscn
+++ b/Polytoria/scenes/creator/tabs/text_editor/text_editor.tscn
@@ -27,13 +27,6 @@ content_margin_right = 8.0
 content_margin_bottom = 8.0
 bg_color = Color(0, 0, 0, 0.49803922)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_07fmf"]
-content_margin_left = 8.0
-content_margin_top = 8.0
-content_margin_right = 8.0
-content_margin_bottom = 8.0
-bg_color = Color(0.12156863, 0.12156863, 0.12156863, 1)
-
 [node name="TextEditor" type="Control" unique_id=1712163761 node_paths=PackedStringArray("CodeEditor", "_finder", "_diagLabel", "_statusBar")]
 layout_mode = 3
 anchors_preset = 15
@@ -89,7 +82,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 1
 theme_override_font_sizes/font_size = 14
-theme_override_styles/normal = SubResource("StyleBoxFlat_07fmf")
+theme_override_styles/normal = SubResource("StyleBoxFlat_aql85")
 text = "hello.luau: (0:0)"
 vertical_alignment = 1
 autowrap_mode = 3

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -309,8 +309,8 @@ public partial class TextEditorRoot : Node
 
 	private void UpdateStatusBar()
 	{
-		int lineIndex = CodeEditor.GetCaretLine();
-		int column = CodeEditor.GetCaretColumn();
+		int lineIndex = CodeEditor.GetCaretLine() + 1;
+		int column = CodeEditor.GetCaretColumn() + 1;
 		_statusBar.Text = $"{Container.OriginTabName}: ({lineIndex}:{column})";
 	}
 

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -28,6 +28,7 @@ public partial class TextEditorRoot : Node
 
 	[Export] private TextEditorFind _finder = null!;
 	[Export] private Label _diagLabel = null!;
+	[Export] private Label _statusBar = null!;
 
 	public static Color ColorDanger { get; private set; } = Color.FromString("D77C79", Colors.White);
 	public static Color ColorOrange { get; private set; } = Color.FromString("E6A472", Colors.White);
@@ -96,6 +97,8 @@ public partial class TextEditorRoot : Node
 		{
 			await _completion.OpenScriptAsync(Container.TargetFilePathAbsolute);
 		}
+
+		UpdateStatusBar();
 	}
 
 	private async void OnPublishDiagnostics(string path, List<LspDiagnostic> diagnostics)
@@ -181,6 +184,10 @@ public partial class TextEditorRoot : Node
 		else if (@event.IsActionPressed("ui_cancel"))
 		{
 			_finder.Close();
+		}
+		else
+		{
+			UpdateStatusBar();
 		}
 	}
 
@@ -298,6 +305,13 @@ public partial class TextEditorRoot : Node
 			CodeEditor.AddCodeCompletionOption(item.Kind, item.DisplayText, item.InsertText, icon: icon, location: -1);
 		}
 		CodeEditor.UpdateCodeCompletionOptions(false);
+	}
+
+	private void UpdateStatusBar()
+	{
+		int lineIndex = CodeEditor.GetCaretLine();
+		int column = CodeEditor.GetCaretColumn();
+		_statusBar.Text = $"{Container.OriginTabName}: ({lineIndex}:{column})";
 	}
 
 	public string GetWordBeforeCaret()


### PR DESCRIPTION
## Summary

This change implements a status bar located at the bottom of the built-in script editor that displays the current location of the primary caret, along with the file that's currently opened. This is implemented through a simple interpolated string that's updated after almost every input in the text editor.

Please note that tabs are counted as only one character due to the algorithm used. This is completely intentional.

## Related issue or discussion

Addresses Issue #53

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video


https://github.com/user-attachments/assets/00fef8ba-9bad-47da-aebe-c1f3329ec757


## AI/LLM use

No AI/LLMs were used in the making of this pull request.