### PR TITLE
Creator: Implement zoom in and zoom out functionality for text editor and console

### DIFF
--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -397,6 +397,16 @@ freelook_shift={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+textedit_zoom_in={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"button_mask":8,"position":Vector2(157, 15),"global_position":Vector2(166, 63),"factor":1.0,"button_index":4,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
+textedit_zoom_out={
+"deadzone": 0.2,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"button_mask":16,"position":Vector2(141, 11),"global_position":Vector2(150, 59),"factor":1.0,"button_index":5,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
 
 [input_devices]
 

--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -397,16 +397,6 @@ freelook_shift={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
-textedit_zoom_in={
-"deadzone": 0.2,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"button_mask":8,"position":Vector2(157, 15),"global_position":Vector2(166, 63),"factor":1.0,"button_index":4,"canceled":false,"pressed":true,"double_click":false,"script":null)
-]
-}
-textedit_zoom_out={
-"deadzone": 0.2,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"button_mask":16,"position":Vector2(141, 11),"global_position":Vector2(150, 59),"factor":1.0,"button_index":5,"canceled":false,"pressed":true,"double_click":false,"script":null)
-]
-}
 
 [input_devices]
 

--- a/Polytoria/scripts/creator/ui/docks/bottombar/console/DebugConsole.cs
+++ b/Polytoria/scripts/creator/ui/docks/bottombar/console/DebugConsole.cs
@@ -22,15 +22,15 @@ public partial class DebugConsole : Control
 
 	private const int MaxLogLength = 16384;
 
+	private const int FontSizeStep = 2;
+	private const int MinFontSize = 8;
+	private const int MaxFontSize = 72;
+	
 	private readonly StringBuilder _textBuilder = new();
 
 	[Export] private RichTextLabel _richLabel = null!;
 	[Export] private LineEdit _searchEdit = null!;
 	[Export] private Button _clearBtn = null!;
-	private int _currentFontSize = 14;
-	[Export] public int FontSizeStep { get; set; } = 2;
-	[Export] public int MinFontSize { get; set; } = 8;
-	[Export] public int MaxFontSize { get; set; } = 72;
 
 	public static DebugConsole Singleton { get; private set; } = null!;
 
@@ -42,6 +42,7 @@ public partial class DebugConsole : Control
 	private int _lastRenderedIndex = 0;
 	private bool _needsFullRebuild = false;
 	private bool _hasPendingAppend = false;
+	private int _currentFontSize = 14;
 
 	private bool IsFiltering => !string.IsNullOrEmpty(SearchQuery);
 

--- a/Polytoria/scripts/creator/ui/docks/bottombar/console/DebugConsole.cs
+++ b/Polytoria/scripts/creator/ui/docks/bottombar/console/DebugConsole.cs
@@ -27,6 +27,10 @@ public partial class DebugConsole : Control
 	[Export] private RichTextLabel _richLabel = null!;
 	[Export] private LineEdit _searchEdit = null!;
 	[Export] private Button _clearBtn = null!;
+	private int _currentFontSize = 14;
+	[Export] public int FontSizeStep { get; set; } = 2;
+	[Export] public int MinFontSize { get; set; } = 8;
+	[Export] public int MaxFontSize { get; set; } = 72;
 
 	public static DebugConsole Singleton { get; private set; } = null!;
 
@@ -52,6 +56,8 @@ public partial class DebugConsole : Control
 		_clearBtn.Pressed += Clear;
 		_searchEdit.TextChanged += _ => OnSearch();
 		_richLabel.Text = "";
+		int size = _richLabel.GetThemeFontSize("normal_font_size", "Label");
+    	_currentFontSize = size > 0 ? size : 16;
 	}
 
 	public override void _Process(double delta)
@@ -68,6 +74,27 @@ public partial class DebugConsole : Control
 			AppendPendingLogs();
 
 		base._Process(delta);
+	}
+	
+	public override void _Input(InputEvent @event)
+	{
+		if (@event is InputEventMouseButton mb && mb.Pressed)
+		{
+			if (!GetGlobalRect().HasPoint(mb.GlobalPosition)) return;
+			
+			if (mb.CtrlPressed && mb.ButtonIndex == MouseButton.WheelUp)
+			{
+				_currentFontSize = Mathf.Clamp(_currentFontSize + FontSizeStep, MinFontSize, MaxFontSize);
+				_richLabel.AddThemeFontSizeOverride("normal_font_size", _currentFontSize);
+				GetViewport().SetInputAsHandled();
+			}
+			else if (mb.CtrlPressed && mb.ButtonIndex == MouseButton.WheelDown)
+			{
+				_currentFontSize = Mathf.Clamp(_currentFontSize - FontSizeStep, MinFontSize, MaxFontSize);
+				_richLabel.AddThemeFontSizeOverride("normal_font_size", _currentFontSize);
+				GetViewport().SetInputAsHandled();
+			}
+		}
 	}
 
 	private void OnSearch()

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorField.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorField.cs
@@ -10,6 +10,35 @@ public sealed partial class TextEditorField : CodeEdit
 {
 	public TextEditorRoot Root = null!;
 
+	[Export] public int FontSizeStep { get; set; } = 2;
+	[Export] public int MinFontSize { get; set; } = 8;
+	[Export] public int MaxFontSize { get; set; } = 72;
+	private int _currentFontSize = 16;
+
+	public override void _Ready()
+	{
+		int size = GetThemeFontSize("font_size", "Label");
+    	_currentFontSize = size > 0 ? size : 16;
+		base._Ready();
+	}
+
+	public override void _Process(double delta)
+	{
+		if (Input.IsActionJustPressed("textedit_zoom_in"))
+		{
+			_currentFontSize = Mathf.Clamp(_currentFontSize + FontSizeStep, MinFontSize, MaxFontSize);
+			AddThemeFontSizeOverride("font_size", _currentFontSize);
+		}
+
+		if (Input.IsActionJustPressed("textedit_zoom_out"))
+		{
+			_currentFontSize = Mathf.Clamp(_currentFontSize - FontSizeStep, MinFontSize, MaxFontSize);
+			AddThemeFontSizeOverride("font_size", _currentFontSize);
+		}
+
+		base._Process(delta);
+	}
+
 	public override void _ConfirmCodeCompletion(bool replace)
 	{
 		int index = GetCodeCompletionSelectedIndex();

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorField.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorField.cs
@@ -22,21 +22,25 @@ public sealed partial class TextEditorField : CodeEdit
 		base._Ready();
 	}
 
-	public override void _Process(double delta)
+	public override void _GuiInput(InputEvent @event)
 	{
-		if (Input.IsActionJustPressed("textedit_zoom_in"))
+		if (@event is InputEventMouseButton mb && mb.Pressed)
 		{
-			_currentFontSize = Mathf.Clamp(_currentFontSize + FontSizeStep, MinFontSize, MaxFontSize);
-			AddThemeFontSizeOverride("font_size", _currentFontSize);
+			if (mb.CtrlPressed && mb.ButtonIndex == MouseButton.WheelUp)
+			{
+				_currentFontSize = Mathf.Clamp(_currentFontSize + FontSizeStep, MinFontSize, MaxFontSize);
+				AddThemeFontSizeOverride("font_size", _currentFontSize);
+				AcceptEvent();
+			}
+			else if (mb.CtrlPressed && mb.ButtonIndex == MouseButton.WheelDown)
+			{
+				_currentFontSize = Mathf.Clamp(_currentFontSize - FontSizeStep, MinFontSize, MaxFontSize);
+				AddThemeFontSizeOverride("font_size", _currentFontSize);
+				AcceptEvent();
+			}
 		}
 
-		if (Input.IsActionJustPressed("textedit_zoom_out"))
-		{
-			_currentFontSize = Mathf.Clamp(_currentFontSize - FontSizeStep, MinFontSize, MaxFontSize);
-			AddThemeFontSizeOverride("font_size", _currentFontSize);
-		}
-
-		base._Process(delta);
+		base._GuiInput(@event);
 	}
 
 	public override void _ConfirmCodeCompletion(bool replace)

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorField.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorField.cs
@@ -8,11 +8,12 @@ namespace Polytoria.Creator.UI.TextEditor;
 
 public sealed partial class TextEditorField : CodeEdit
 {
-	public TextEditorRoot Root = null!;
+	private const int FontSizeStep = 2;
+	private const int MinFontSize = 8;
+	private const int MaxFontSize = 72;
 
-	[Export] public int FontSizeStep { get; set; } = 2;
-	[Export] public int MinFontSize { get; set; } = 8;
-	[Export] public int MaxFontSize { get; set; } = 72;
+	public TextEditorRoot Root = null!;
+	
 	private int _currentFontSize = 16;
 
 	public override void _Ready()


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Implement zoom in and zoom out functionality for script editor and console with 
`Ctrl + WheelUp` to zoom in and
`Ctrl + WheelDown` to zoom out

## Related issue or discussion

Fixes N/A
Related to N/A

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->
[New project.webm](https://github.com/user-attachments/assets/7cc69e78-65f9-452a-998d-59b282f0a222)

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None