### PR TITLE
add Highlight datamodel object And UIDragDetector

### DIFF
--- a/Polytoria/scripts/creator/ui/ctxmenus/InsertMenuPopup.cs
+++ b/Polytoria/scripts/creator/ui/ctxmenus/InsertMenuPopup.cs
@@ -59,6 +59,7 @@ public partial class InsertMenuPopup : PopupPanel
 			"Tool",
 			"Marker3D",
 			"Camera",
+			"Highlight",
 		},
 		[new() { Title = "Character", RecommendOn = [typeof(CharacterModel)] }] = new()
 		{

--- a/Polytoria/scripts/creator/ui/ctxmenus/InsertMenuPopup.cs
+++ b/Polytoria/scripts/creator/ui/ctxmenus/InsertMenuPopup.cs
@@ -121,6 +121,7 @@ public partial class InsertMenuPopup : PopupPanel
 			"UIGridLayout",
 			"UIScrollView",
 			"UIViewport",
+			"UIDragDetector",
 		},
 		[new() { Title = "Stats", RecommendOn = [typeof(Stats)] }] = new()
 		{

--- a/Polytoria/scripts/datamodel/Highlight.cs
+++ b/Polytoria/scripts/datamodel/Highlight.cs
@@ -24,9 +24,17 @@ public partial class Highlight : Instance
 	private DepthModeEnum _depthMode = DepthModeEnum.AlwaysOnTop;
 	private int _renderPriority = 1;
 
-	private readonly List<(MeshInstance3D outline, MeshInstance3D fill)> _overlays = [];
+	// src stored so we can detect mesh resource swaps (shape changes etc)
+	private readonly List<(MeshInstance3D src, MeshInstance3D outline, MeshInstance3D fill)> _overlays = [];
 	private ShaderMaterial? _outlineMat;
 	private StandardMaterial3D? _fillMat;
+
+	// used to detect size changes when no real src mesh exists (multimesh parts)
+	private Vector3 _lastFallbackSize = Vector3.Zero;
+	private bool _usingFallback = false;
+
+	// tag put on overlay nodes so CollectMeshes doesnt accidentally collect them
+	private const string OverlayTag = "_hl_overlay";
 
 	public enum DepthModeEnum
 	{
@@ -111,7 +119,7 @@ public partial class Highlight : Instance
 		set
 		{
 			_fillVisible = value;
-			foreach (var (_, fill) in _overlays)
+			foreach (var (_, outline, fill) in _overlays)
 				if (Node.IsInstanceValid(fill)) fill.Visible = value;
 			OnPropertyChanged();
 		}
@@ -124,7 +132,7 @@ public partial class Highlight : Instance
 		set
 		{
 			_outlineVisible = value;
-			foreach (var (outline, _) in _overlays)
+			foreach (var (_, outline, fill) in _overlays)
 				if (Node.IsInstanceValid(outline)) outline.Visible = value;
 			OnPropertyChanged();
 		}
@@ -151,7 +159,32 @@ public partial class Highlight : Instance
 		if (_enabled && _adornee != null)
 			TryApply();
 
+		SetProcess(true);
 		base.Ready();
+	}
+
+	public override void Process(double delta)
+	{
+		base.Process(delta);
+		if (!_enabled || _adornee == null) return;
+
+		// fallback path: part uses multimesh so there's no real mesh node
+		// we just track the bounds size and rebuild if it changed
+		if (_usingFallback)
+		{
+			Vector3 currentSize = _adornee.CalculateBounds().Size;
+			if (!currentSize.IsEqualApprox(_lastFallbackSize))
+				ApplyHighlight();
+			return;
+		}
+
+		// normal path: check if any source mesh swapped its mesh resource (shape change)
+		// its just a reference compare so nearly free
+		foreach (var (src, outline, _) in _overlays)
+		{
+			if (!Node.IsInstanceValid(src)) { ApplyHighlight(); return; }
+			if (src.Mesh != outline.Mesh) { ApplyHighlight(); return; }
+		}
 	}
 
 	public override void PostReparent()
@@ -223,61 +256,92 @@ public partial class Highlight : Instance
 
 		if (sources.Count > 0)
 		{
+			_usingFallback = false;
 			foreach (MeshInstance3D src in sources)
 			{
 				if (src.Mesh == null) continue;
-				Node parent = src.GetParent() ?? root;
-				SpawnOverlay(src.Mesh, parent, src.Position, src.Rotation, src.Scale);
+				SpawnOverlay(src);
 			}
 		}
 		else
 		{
-			// no meshes found so just slap a box around the bounds
+			// no real mesh found (multimesh part) so box around the bounds
+			_usingFallback = true;
 			Aabb b = _adornee!.CalculateBounds();
+			_lastFallbackSize = b.Size;
 			Vector3 sz = b.Size == Vector3.Zero ? Vector3.One : b.Size;
 			BoxMesh box = new() { Size = sz };
 			Vector3 center = root.IsInsideTree() ? root.ToLocal(b.GetCenter()) : Vector3.Zero;
-			SpawnOverlay(box, root, center, Vector3.Zero, Vector3.One);
+			SpawnFallbackOverlay(box, root, center);
 		}
 
 		SyncMaterials();
 	}
 
-	private void SpawnOverlay(Godot.Mesh mesh, Node parent, Vector3 pos, Vector3 rot, Vector3 scale)
+	// overlays are children of src so they follow transforms automatically
+	private void SpawnOverlay(MeshInstance3D src)
 	{
 		MeshInstance3D outline = new()
 		{
-			Mesh = mesh,
+			Mesh = src.Mesh,
 			MaterialOverride = _outlineMat,
-			Position = pos,
-			Rotation = rot,
-			Scale = scale,
 			CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
 			Visible = _outlineVisible,
 		};
-
 		MeshInstance3D fill = new()
 		{
-			Mesh = mesh,
+			Mesh = src.Mesh,
 			MaterialOverride = _fillMat,
-			Position = pos,
-			Rotation = rot,
-			Scale = scale,
 			CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
 			Visible = _fillVisible,
 		};
 
-		parent.AddChild(outline);
-		parent.AddChild(fill);
-		_overlays.Add((outline, fill));
+		// tag them so CollectMeshes wont pick them up on next rebuild
+		outline.SetMeta(OverlayTag, true);
+		fill.SetMeta(OverlayTag, true);
+
+		src.AddChild(outline);
+		src.AddChild(fill);
+		_overlays.Add((src, outline, fill));
+	}
+
+	private void SpawnFallbackOverlay(Godot.Mesh mesh, Node3D root, Vector3 center)
+	{
+		MeshInstance3D fakeSrc = new() { Mesh = mesh, Position = center };
+		fakeSrc.SetMeta(OverlayTag, true);
+
+		MeshInstance3D outline = new()
+		{
+			Mesh = mesh,
+			MaterialOverride = _outlineMat,
+			CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
+			Visible = _outlineVisible,
+		};
+		MeshInstance3D fill = new()
+		{
+			Mesh = mesh,
+			MaterialOverride = _fillMat,
+			CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
+			Visible = _fillVisible,
+		};
+
+		outline.SetMeta(OverlayTag, true);
+		fill.SetMeta(OverlayTag, true);
+
+		root.AddChild(fakeSrc);
+		fakeSrc.AddChild(outline);
+		fakeSrc.AddChild(fill);
+		_overlays.Add((fakeSrc, outline, fill));
 	}
 
 	private void RemoveHighlight()
 	{
-		foreach (var (o, f) in _overlays)
+		foreach (var (src, outline, fill) in _overlays)
 		{
-			if (Node.IsInstanceValid(o)) o.QueueFree();
-			if (Node.IsInstanceValid(f)) f.QueueFree();
+			if (Node.IsInstanceValid(outline)) outline.QueueFree();
+			if (Node.IsInstanceValid(fill)) fill.QueueFree();
+			// only free fakeSrc nodes we made ourselves not real part meshes
+			if (Node.IsInstanceValid(src) && src.HasMeta(OverlayTag)) src.QueueFree();
 		}
 		_overlays.Clear();
 		_outlineMat = null;
@@ -307,6 +371,7 @@ public partial class Highlight : Instance
 	}
 
 	// iterative so it doesnt blow the stack on deep node trees
+	// skips nodes tagged as overlays so we dont collect our own nodes on rebuild
 	private static List<MeshInstance3D> CollectMeshes(Node root)
 	{
 		List<MeshInstance3D> result = [];
@@ -316,6 +381,7 @@ public partial class Highlight : Instance
 		while (stack.Count > 0)
 		{
 			Node node = stack.Pop();
+			if (node.HasMeta(OverlayTag)) continue; // skip our own overlay nodes
 			if (node is MeshInstance3D m && m.Mesh != null)
 				result.Add(m);
 			foreach (Node child in node.GetChildren(true))
@@ -337,11 +403,11 @@ public partial class Highlight : Instance
 			"\n" +
 			"void vertex() {\n" +
 			"    vec4 clip = PROJECTION_MATRIX * (MODELVIEW_MATRIX * vec4(VERTEX, 1.0));\n" +
-			"    vec3 clip_nrm = mat3(PROJECTION_MATRIX) * (mat3(MODELVIEW_MATRIX) * NORMAL);\n" +
-			"    vec2 nrm2d = clip_nrm.xy;\n" +
-			"    float len = length(nrm2d);\n" +
-			"    if (len > 0.0001) nrm2d /= len;\n" +
-			"    clip.xy += nrm2d / VIEWPORT_SIZE * outline_size * clip.w * 2.0;\n" +
+			// project vertex+normal into clip space and diff to get true screen-space extrusion dir
+			// works correctly at any distance and angle
+			"    vec4 clip_npos = PROJECTION_MATRIX * (MODELVIEW_MATRIX * vec4(VERTEX + NORMAL * 0.01, 1.0));\n" +
+			"    vec2 offset = normalize(clip_npos.xy / clip_npos.w - clip.xy / clip.w);\n" +
+			"    clip.xy += offset / VIEWPORT_SIZE * outline_size * clip.w * 2.0;\n" +
 			"    if (always_on_top > 0.5) clip.z = clip.w * 0.0001;\n" +
 			"    POSITION = clip;\n" +
 			"}\n" +
@@ -352,4 +418,4 @@ public partial class Highlight : Instance
 			"}\n";
 		return s;
 	}
-}
+}a

--- a/Polytoria/scripts/datamodel/Highlight.cs
+++ b/Polytoria/scripts/datamodel/Highlight.cs
@@ -1,0 +1,355 @@
+using Godot;
+using Polytoria.Attributes;
+using Polytoria.Shared;
+using System.Collections.Generic;
+
+namespace Polytoria.Datamodel;
+// if there is any bugs i am sorry i treid my best wehn making this 
+//try impoving it but i did everything
+[Instantiable]
+public partial class Highlight : Instance
+{
+	private static readonly Shader _outlineShader = BuildShader();
+
+	private Entity? _adornee;
+	private Color _outlineColor = new(1, 1, 1);
+	private Color _fillColor = new(1, 1, 1);
+	private float _fillTransparency = 0.7f; // 0.7 feels right not too invisible
+	private float _outlineTransparency = 0f;
+	private float _outlineSize = 2f;
+	private bool _enabled = true;
+	private bool _fillVisible = true;
+	private bool _outlineVisible = true;
+	private bool _meshSignalConnected = false;
+	private DepthModeEnum _depthMode = DepthModeEnum.AlwaysOnTop;
+	private int _renderPriority = 1;
+
+	private readonly List<(MeshInstance3D outline, MeshInstance3D fill)> _overlays = [];
+	private ShaderMaterial? _outlineMat;
+	private StandardMaterial3D? _fillMat;
+
+	public enum DepthModeEnum
+	{
+		AlwaysOnTop,
+		Occluded
+	}
+
+	[Editable, ScriptProperty]
+	public Entity? Adornee
+	{
+		get => _adornee;
+		set
+		{
+			if (_adornee == value) return;
+			DetachMeshSignal();
+			RemoveHighlight();
+			_adornee = value;
+			if (_enabled) TryApply();
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool Enabled
+	{
+		get => _enabled;
+		set
+		{
+			if (_enabled == value) return;
+			_enabled = value;
+			if (_enabled) TryApply(); else RemoveHighlight();
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public Color OutlineColor
+	{
+		get => _outlineColor;
+		set { _outlineColor = value; SyncMaterials(); OnPropertyChanged(); }
+	}
+
+	[Editable, ScriptProperty]
+	public Color FillColor
+	{
+		get => _fillColor;
+		set { _fillColor = value; SyncMaterials(); OnPropertyChanged(); }
+	}
+
+	[Editable, ScriptProperty, DefaultValue(0.7f)]
+	public float FillTransparency
+	{
+		get => _fillTransparency;
+		set { _fillTransparency = Mathf.Clamp(value, 0f, 1f); SyncMaterials(); OnPropertyChanged(); }
+	}
+
+	[Editable, ScriptProperty, DefaultValue(0f)]
+	public float OutlineTransparency
+	{
+		get => _outlineTransparency;
+		set { _outlineTransparency = Mathf.Clamp(value, 0f, 1f); SyncMaterials(); OnPropertyChanged(); }
+	}
+
+	[Editable, ScriptProperty, DefaultValue(2f)]
+	public float OutlineSize
+	{
+		get => _outlineSize;
+		set { _outlineSize = Mathf.Clamp(value, 0f, 20f); SyncMaterials(); OnPropertyChanged(); }
+	}
+
+	[Editable, ScriptProperty, DefaultValue(DepthModeEnum.AlwaysOnTop)]
+	public DepthModeEnum DepthMode
+	{
+		get => _depthMode;
+		set { _depthMode = value; SyncDepth(); OnPropertyChanged(); }
+	}
+
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool FillVisible
+	{
+		get => _fillVisible;
+		set
+		{
+			_fillVisible = value;
+			foreach (var (_, fill) in _overlays)
+				if (Node.IsInstanceValid(fill)) fill.Visible = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool OutlineVisible
+	{
+		get => _outlineVisible;
+		set
+		{
+			_outlineVisible = value;
+			foreach (var (outline, _) in _overlays)
+				if (Node.IsInstanceValid(outline)) outline.Visible = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(1)]
+	public int RenderPriority
+	{
+		get => _renderPriority;
+		set
+		{
+			_renderPriority = Mathf.Clamp(value, -128, 127);
+			if (_fillMat != null) _fillMat.RenderPriority = _renderPriority;
+			OnPropertyChanged();
+		}
+	}
+
+	public override void Ready()
+	{
+		// auto assign adornee to parent if nothing set
+		if (_adornee == null && Parent is Entity e)
+			_adornee = e;
+
+		if (_enabled && _adornee != null)
+			TryApply();
+
+		base.Ready();
+	}
+
+	public override void PostReparent()
+	{
+		base.PostReparent();
+		if (_adornee == null && Parent is Entity e)
+			Adornee = e;
+	}
+
+	public override void PreDelete()
+	{
+		DetachMeshSignal();
+		RemoveHighlight();
+		base.PreDelete();
+	}
+
+	private void TryApply()
+	{
+		if (_adornee == null) return;
+
+		// wait for mesh to finish loading before doing anything
+		if (_adornee is Mesh meshEntity && meshEntity.Loading)
+		{
+			if (!_meshSignalConnected)
+			{
+				meshEntity.Loaded.Connect(OnMeshLoaded);
+				_meshSignalConnected = true;
+			}
+			return;
+		}
+
+		ApplyHighlight();
+	}
+
+	private void OnMeshLoaded()
+	{
+		_meshSignalConnected = false;
+		ApplyHighlight();
+	}
+
+	private void DetachMeshSignal()
+	{
+		if (_meshSignalConnected && _adornee is Mesh m)
+		{
+			m.Loaded.Disconnect(OnMeshLoaded);
+			_meshSignalConnected = false;
+		}
+	}
+
+	private void ApplyHighlight()
+	{
+		if (_adornee?.GDNode3D is not Node3D root) return;
+		if (!root.IsInsideTree()) return;
+
+		RemoveHighlight();
+
+		_outlineMat = new ShaderMaterial { Shader = _outlineShader };
+		_fillMat = new StandardMaterial3D
+		{
+			Transparency = BaseMaterial3D.TransparencyEnum.Alpha,
+			ShadingMode = BaseMaterial3D.ShadingModeEnum.Unshaded,
+			CullMode = BaseMaterial3D.CullModeEnum.Back,
+			RenderPriority = _renderPriority,
+		};
+
+		SyncDepth();
+
+		List<MeshInstance3D> sources = CollectMeshes(root);
+
+		if (sources.Count > 0)
+		{
+			foreach (MeshInstance3D src in sources)
+			{
+				if (src.Mesh == null) continue;
+				Node parent = src.GetParent() ?? root;
+				SpawnOverlay(src.Mesh, parent, src.Position, src.Rotation, src.Scale);
+			}
+		}
+		else
+		{
+			// no meshes found so just slap a box around the bounds
+			Aabb b = _adornee!.CalculateBounds();
+			Vector3 sz = b.Size == Vector3.Zero ? Vector3.One : b.Size;
+			BoxMesh box = new() { Size = sz };
+			Vector3 center = root.IsInsideTree() ? root.ToLocal(b.GetCenter()) : Vector3.Zero;
+			SpawnOverlay(box, root, center, Vector3.Zero, Vector3.One);
+		}
+
+		SyncMaterials();
+	}
+
+	private void SpawnOverlay(Godot.Mesh mesh, Node parent, Vector3 pos, Vector3 rot, Vector3 scale)
+	{
+		MeshInstance3D outline = new()
+		{
+			Mesh = mesh,
+			MaterialOverride = _outlineMat,
+			Position = pos,
+			Rotation = rot,
+			Scale = scale,
+			CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
+			Visible = _outlineVisible,
+		};
+
+		MeshInstance3D fill = new()
+		{
+			Mesh = mesh,
+			MaterialOverride = _fillMat,
+			Position = pos,
+			Rotation = rot,
+			Scale = scale,
+			CastShadow = GeometryInstance3D.ShadowCastingSetting.Off,
+			Visible = _fillVisible,
+		};
+
+		parent.AddChild(outline);
+		parent.AddChild(fill);
+		_overlays.Add((outline, fill));
+	}
+
+	private void RemoveHighlight()
+	{
+		foreach (var (o, f) in _overlays)
+		{
+			if (Node.IsInstanceValid(o)) o.QueueFree();
+			if (Node.IsInstanceValid(f)) f.QueueFree();
+		}
+		_overlays.Clear();
+		_outlineMat = null;
+		_fillMat = null;
+	}
+
+	private void SyncDepth()
+	{
+		if (_fillMat == null || _outlineMat == null) return;
+		bool top = _depthMode == DepthModeEnum.AlwaysOnTop;
+		_fillMat.NoDepthTest = top;
+		_outlineMat.SetShaderParameter("always_on_top", top ? 1f : 0f);
+	}
+
+	private void SyncMaterials()
+	{
+		if (_outlineMat != null)
+		{
+			_outlineMat.SetShaderParameter("outline_color",
+				new Color(_outlineColor.R, _outlineColor.G, _outlineColor.B, 1f - _outlineTransparency));
+			_outlineMat.SetShaderParameter("outline_size", _outlineSize);
+		}
+
+		// transparency is now used directly as alpha so 0.7 = 0.7 opacity (actually visible)
+		if (_fillMat != null)
+			_fillMat.AlbedoColor = new Color(_fillColor.R, _fillColor.G, _fillColor.B, _fillTransparency);
+	}
+
+	// iterative so it doesnt blow the stack on deep node trees
+	private static List<MeshInstance3D> CollectMeshes(Node root)
+	{
+		List<MeshInstance3D> result = [];
+		Stack<Node> stack = new();
+		stack.Push(root);
+
+		while (stack.Count > 0)
+		{
+			Node node = stack.Pop();
+			if (node is MeshInstance3D m && m.Mesh != null)
+				result.Add(m);
+			foreach (Node child in node.GetChildren(true))
+				stack.Push(child);
+		}
+
+		return result;
+	}
+
+	private static Shader BuildShader()
+	{
+		Shader s = new();
+		s.Code =
+			"shader_type spatial;\n" +
+			"render_mode cull_front, unshaded, depth_draw_never;\n" +
+			"uniform vec4 outline_color : source_color = vec4(1.0);\n" +
+			"uniform float outline_size : hint_range(0.0, 20.0, 0.1) = 2.0;\n" +
+			"uniform float always_on_top : hint_range(0.0, 1.0, 1.0) = 1.0;\n" +
+			"\n" +
+			"void vertex() {\n" +
+			"    vec4 clip = PROJECTION_MATRIX * (MODELVIEW_MATRIX * vec4(VERTEX, 1.0));\n" +
+			"    vec3 clip_nrm = mat3(PROJECTION_MATRIX) * (mat3(MODELVIEW_MATRIX) * NORMAL);\n" +
+			"    vec2 nrm2d = clip_nrm.xy;\n" +
+			"    float len = length(nrm2d);\n" +
+			"    if (len > 0.0001) nrm2d /= len;\n" +
+			"    clip.xy += nrm2d / VIEWPORT_SIZE * outline_size * clip.w * 2.0;\n" +
+			"    if (always_on_top > 0.5) clip.z = clip.w * 0.0001;\n" +
+			"    POSITION = clip;\n" +
+			"}\n" +
+			"\n" +
+			"void fragment() {\n" +
+			"    ALBEDO = outline_color.rgb;\n" +
+			"    ALPHA = outline_color.a;\n" +
+			"}\n";
+		return s;
+	}
+}

--- a/Polytoria/scripts/datamodel/Highlight.cs
+++ b/Polytoria/scripts/datamodel/Highlight.cs
@@ -4,8 +4,7 @@ using Polytoria.Shared;
 using System.Collections.Generic;
 
 namespace Polytoria.Datamodel;
-// if there is any bugs i am sorry i treid my best wehn making this 
-//try impoving it but i did everything
+
 [Instantiable]
 public partial class Highlight : Instance
 {
@@ -24,16 +23,13 @@ public partial class Highlight : Instance
 	private DepthModeEnum _depthMode = DepthModeEnum.AlwaysOnTop;
 	private int _renderPriority = 1;
 
-	// src stored so we can detect mesh resource swaps (shape changes etc)
 	private readonly List<(MeshInstance3D src, MeshInstance3D outline, MeshInstance3D fill)> _overlays = [];
 	private ShaderMaterial? _outlineMat;
 	private StandardMaterial3D? _fillMat;
 
-	// used to detect size changes when no real src mesh exists (multimesh parts)
 	private Vector3 _lastFallbackSize = Vector3.Zero;
 	private bool _usingFallback = false;
 
-	// tag put on overlay nodes so CollectMeshes doesnt accidentally collect them
 	private const string OverlayTag = "_hl_overlay";
 
 	public enum DepthModeEnum
@@ -265,7 +261,6 @@ public partial class Highlight : Instance
 		}
 		else
 		{
-			// no real mesh found (multimesh part) so box around the bounds
 			_usingFallback = true;
 			Aabb b = _adornee!.CalculateBounds();
 			_lastFallbackSize = b.Size;
@@ -340,7 +335,7 @@ public partial class Highlight : Instance
 		{
 			if (Node.IsInstanceValid(outline)) outline.QueueFree();
 			if (Node.IsInstanceValid(fill)) fill.QueueFree();
-			// only free fakeSrc nodes we made ourselves not real part meshes
+			// only free fakeSrc nodes we made ourselves, not real part meshes
 			if (Node.IsInstanceValid(src) && src.HasMeta(OverlayTag)) src.QueueFree();
 		}
 		_overlays.Clear();
@@ -365,13 +360,10 @@ public partial class Highlight : Instance
 			_outlineMat.SetShaderParameter("outline_size", _outlineSize);
 		}
 
-		// transparency is now used directly as alpha so 0.7 = 0.7 opacity (actually visible)
 		if (_fillMat != null)
 			_fillMat.AlbedoColor = new Color(_fillColor.R, _fillColor.G, _fillColor.B, _fillTransparency);
 	}
 
-	// iterative so it doesnt blow the stack on deep node trees
-	// skips nodes tagged as overlays so we dont collect our own nodes on rebuild
 	private static List<MeshInstance3D> CollectMeshes(Node root)
 	{
 		List<MeshInstance3D> result = [];
@@ -381,7 +373,7 @@ public partial class Highlight : Instance
 		while (stack.Count > 0)
 		{
 			Node node = stack.Pop();
-			if (node.HasMeta(OverlayTag)) continue; // skip our own overlay nodes
+			if (node.HasMeta(OverlayTag)) continue; // skip overlay nodes
 			if (node is MeshInstance3D m && m.Mesh != null)
 				result.Add(m);
 			foreach (Node child in node.GetChildren(true))
@@ -403,8 +395,6 @@ public partial class Highlight : Instance
 			"\n" +
 			"void vertex() {\n" +
 			"    vec4 clip = PROJECTION_MATRIX * (MODELVIEW_MATRIX * vec4(VERTEX, 1.0));\n" +
-			// project vertex+normal into clip space and diff to get true screen-space extrusion dir
-			// works correctly at any distance and angle
 			"    vec4 clip_npos = PROJECTION_MATRIX * (MODELVIEW_MATRIX * vec4(VERTEX + NORMAL * 0.01, 1.0));\n" +
 			"    vec2 offset = normalize(clip_npos.xy / clip_npos.w - clip.xy / clip.w);\n" +
 			"    clip.xy += offset / VIEWPORT_SIZE * outline_size * clip.w * 2.0;\n" +
@@ -418,4 +408,4 @@ public partial class Highlight : Instance
 			"}\n";
 		return s;
 	}
-}a
+}

--- a/Polytoria/scripts/datamodel/Highlight.cs.uid
+++ b/Polytoria/scripts/datamodel/Highlight.cs.uid
@@ -1,0 +1,1 @@
+uid://bagss44w58mqa

--- a/Polytoria/scripts/datamodel/UIDragDetector.cs
+++ b/Polytoria/scripts/datamodel/UIDragDetector.cs
@@ -1,0 +1,234 @@
+using Godot;
+using Polytoria.Attributes;
+using Polytoria.Scripting;
+
+namespace Polytoria.Datamodel;
+
+[Instantiable]
+public partial class UIDragDetector : Instance
+{
+	private bool _enabled = true;
+	private DragAxisEnum _dragAxis = DragAxisEnum.XY;
+	private Vector2 _minimumDragTranslation = new(-9999999f, -9999999f);
+	private Vector2 _maximumDragTranslation = new(9999999f, 9999999f);
+	private Vector2 _dragUIDelta = Vector2.Zero;
+
+	private UIField? _parentField;
+	private bool _inputConnected = false;
+	private bool _dragging = false;
+	private Vector2 _mouseStartGlobal = Vector2.Zero;
+	private Vector2 _offsetAtDragStart = Vector2.Zero;
+	private Vector2 _screenPosAtDragStart = Vector2.Zero;
+	private Rect2 _viewportCache = default;
+
+	[ScriptProperty] public PTSignal DragStart { get; private set; } = new();
+	[ScriptProperty] public PTSignal DragEnd { get; private set; } = new();
+	[ScriptProperty] public PTSignal DragContinue { get; private set; } = new();
+
+	[ScriptProperty] public Vector2 DragUIDelta => _dragUIDelta;
+	[ScriptProperty] public bool IsDragging => _dragging;
+
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool Enabled
+	{
+		get => _enabled;
+		set
+		{
+			if (_enabled == value) return;
+			_enabled = value;
+			if (!_enabled && _dragging) StopDrag();
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(DragAxisEnum.XY)]
+	public DragAxisEnum DragAxis
+	{
+		get => _dragAxis;
+		set { _dragAxis = value; OnPropertyChanged(); }
+	}
+
+	[Editable, ScriptProperty]
+	public Vector2 MinimumDragTranslation
+	{
+		get => _minimumDragTranslation;
+		set { _minimumDragTranslation = value; OnPropertyChanged(); }
+	}
+
+	[Editable, ScriptProperty]
+	public Vector2 MaximumDragTranslation
+	{
+		get => _maximumDragTranslation;
+		set { _maximumDragTranslation = value; OnPropertyChanged(); }
+	}
+
+	public override void Init()
+	{
+		SetProcess(true);
+		base.Init();
+	}
+
+	public override void EnterTree()
+	{
+		TryAttach();
+		base.EnterTree();
+	}
+
+	public override void ExitTree()
+	{
+		Detach();
+		base.ExitTree();
+	}
+
+	public override void Process(double delta)
+	{
+		base.Process(delta);
+		if (!_dragging || _parentField == null) return;
+
+		if (!Input.IsMouseButtonPressed(MouseButton.Left))
+		{
+			StopDrag();
+			return;
+		}
+
+		UpdateDrag(_parentField.NodeControl.GetGlobalMousePosition());
+	}
+
+	public override void PostReparent()
+	{
+		base.PostReparent();
+		Detach();
+		TryAttach();
+	}
+
+	public override void PreDelete()
+	{
+		Detach();
+		base.PreDelete();
+	}
+
+	private void TryAttach()
+	{
+		if (Parent is not UIField ui) return;
+		if (_inputConnected) return;
+
+		_parentField = ui;
+		ui.NodeControl.GuiInput += OnGuiInput;
+		ui.NodeControl.TreeExiting += Detach;
+		ui.NodeControl.ChildEnteredTree += OnChildEnteredTree;
+		ConnectChildren(ui.NodeControl);
+		_inputConnected = true;
+	}
+
+	private void ConnectChildren(Control parent)
+	{
+		foreach (Node child in parent.GetChildren(true))
+		{
+			if (child is Control c)
+			{
+				c.GuiInput += OnGuiInput;
+				ConnectChildren(c);
+			}
+		}
+	}
+
+	private void OnChildEnteredTree(Node child)
+	{
+		if (child is Control c)
+		{
+			c.GuiInput += OnGuiInput;
+			ConnectChildren(c);
+		}
+	}
+
+	private void Detach()
+	{
+		if (_dragging) StopDrag();
+
+		if (_inputConnected && _parentField != null && GodotObject.IsInstanceValid(_parentField.NodeControl))
+		{
+			_parentField.NodeControl.GuiInput -= OnGuiInput;
+			_parentField.NodeControl.TreeExiting -= Detach;
+			_parentField.NodeControl.ChildEnteredTree -= OnChildEnteredTree;
+			DisconnectChildren(_parentField.NodeControl);
+		}
+
+		_inputConnected = false;
+		_parentField = null;
+	}
+
+	private void DisconnectChildren(Control parent)
+	{
+		foreach (Node child in parent.GetChildren(true))
+		{
+			if (child is Control c)
+			{
+				c.GuiInput -= OnGuiInput;
+				DisconnectChildren(c);
+			}
+		}
+	}
+
+	private void OnGuiInput(InputEvent ev)
+	{
+		if (!_enabled || _parentField == null) return;
+
+		if (ev is InputEventMouseButton mb && mb.ButtonIndex == MouseButton.Left && mb.Pressed && !_dragging)
+			StartDrag(mb.GlobalPosition);
+	}
+
+	private void StartDrag(Vector2 globalMousePos)
+	{
+		if (_parentField == null) return;
+		_dragging = true;
+		_mouseStartGlobal = globalMousePos;
+		_offsetAtDragStart = _parentField.PositionOffset;
+		_screenPosAtDragStart = _parentField.NodeControl.GlobalPosition;
+		_viewportCache = _parentField.NodeControl.GetViewportRect();
+		_dragUIDelta = Vector2.Zero;
+		DragStart.Invoke();
+	}
+
+	private void UpdateDrag(Vector2 mouseGlobal)
+	{
+		if (_parentField == null) return;
+
+		Vector2 rawDelta = mouseGlobal - _mouseStartGlobal;
+
+		Vector2 size = _parentField.NodeControl.Size;
+		Vector2 newScreenPos = _screenPosAtDragStart + rawDelta;
+		newScreenPos.X = Mathf.Clamp(newScreenPos.X, 0f, _viewportCache.Size.X - size.X);
+		newScreenPos.Y = Mathf.Clamp(newScreenPos.Y, 0f, _viewportCache.Size.Y - size.Y);
+
+		Vector2 clampedDelta = newScreenPos - _screenPosAtDragStart;
+
+		Vector2 delta = ApplyAxis(new Vector2(clampedDelta.X, -clampedDelta.Y));
+
+		delta.X = Mathf.Clamp(delta.X, _minimumDragTranslation.X, _maximumDragTranslation.X);
+		delta.Y = Mathf.Clamp(delta.Y, _minimumDragTranslation.Y, _maximumDragTranslation.Y);
+
+		_dragUIDelta = delta;
+		_parentField.PositionOffset = _offsetAtDragStart + delta;
+		DragContinue.Invoke();
+	}
+
+	private void StopDrag()
+	{
+		_dragging = false;
+		DragEnd.Invoke();
+	}
+
+	public void ResetDrag()
+	{
+		if (_parentField == null) return;
+		_parentField.PositionOffset = _offsetAtDragStart;
+		_dragUIDelta = Vector2.Zero;
+	}
+
+	private Vector2 ApplyAxis(Vector2 delta) => _dragAxis switch
+	{
+		DragAxisEnum.X => new Vector2(delta.X, 0f),
+		DragAxisEnum.Y => new Vector2(0f, delta.Y),
+		_ => delta,
+	};
+}


### PR DESCRIPTION
## Summary
Adds two new datamodel objects:

**`Highlight`** puts an outline and fill overlay on any `Entity`. You can change the fill color, outline color, transparency, outline size, depth mode, and render priority.

**`UIDragDetector`** lets any `UIField` be dragged around. Supports locking to X, Y, or both axes, translation limits, and keeps the element inside the viewport. Has `DragStart`, `DragEnd`, and `DragContinue` signals. Connections are properly cleaned up when the object is removed or reparented.

## Related issue or discussion
Fixes N/A

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected
- [x] Datamodel

## Checklist
- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
N/A

## AI/LLM use
only on debugging