### PR TITLE
Implemented .Destroying PTSignal for NetworkedObjects

### DIFF
--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -341,6 +341,8 @@ public partial class NetworkedObject : IScriptObject
 	[ScriptProperty] public PTSignal TreeEntered { get; private set; } = new();
 	[ScriptProperty] public PTSignal TreeExited { get; private set; } = new();
 
+	[ScriptProperty] public PTSignal Destroying { get; private set; } = new();
+
 	public NetworkedObject()
 	{
 		InitializeRpcMethods();
@@ -1845,6 +1847,8 @@ public partial class NetworkedObject : IScriptObject
 		{
 			prei.ChildDeleting.Invoke(this);
 		}
+
+		Destroying.Invoke();
 
 		// Propagate deletion
 		foreach (NetworkedObject item in GetNetworkedChildren())


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion

Related to Issue #41 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video


https://github.com/user-attachments/assets/b9008a1e-4d30-42b4-ab36-387fc3dcec08



## AI/LLM use

None