### PR TITLE
Fix Legacy World Importing on MacOS

### DIFF
--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -620,21 +620,21 @@ public partial class CreatorInterface : Control, IScriptObject
 			dialog.QueueFree();
 		}
 
-		dialog.FileSelected  += path  => OnPathsSelected([path]);
-		dialog.DirSelected   += path  => OnPathsSelected([path]);
+		dialog.FileSelected += path => OnPathsSelected([path]);
+		dialog.DirSelected += path => OnPathsSelected([path]);
 		dialog.FilesSelected += paths => OnPathsSelected(paths);
-		dialog.Canceled      += ()    => { onCancel?.Invoke(); dialog.QueueFree(); };
+		dialog.Canceled += () => { onCancel?.Invoke(); dialog.QueueFree(); };
 
 		dialog.PopupCentered(new Vector2I(800, 600));
 	}
-	
+
 	private static FileDialog.FileModeEnum MapFileMode(DisplayServer.FileDialogMode mode) => mode switch
 	{
-		DisplayServer.FileDialogMode.OpenFile  => FileDialog.FileModeEnum.OpenFile,
+		DisplayServer.FileDialogMode.OpenFile => FileDialog.FileModeEnum.OpenFile,
 		DisplayServer.FileDialogMode.OpenFiles => FileDialog.FileModeEnum.OpenFiles,
-		DisplayServer.FileDialogMode.OpenDir   => FileDialog.FileModeEnum.OpenDir,
-		DisplayServer.FileDialogMode.SaveFile  => FileDialog.FileModeEnum.SaveFile,
-		_                                      => FileDialog.FileModeEnum.OpenFile,
+		DisplayServer.FileDialogMode.OpenDir => FileDialog.FileModeEnum.OpenDir,
+		DisplayServer.FileDialogMode.SaveFile => FileDialog.FileModeEnum.SaveFile,
+		_ => FileDialog.FileModeEnum.OpenFile,
 	};
 
 	public static void ToggleFullscreen()

--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -591,29 +591,51 @@ public partial class CreatorInterface : Control, IScriptObject
 		return InsertMenu;
 	}
 
-	public void PromptFileSelect(FileSelectPromptPayload data, Action<string[]> callback)
+	public void PromptFileSelect(FileSelectPromptPayload data, Action<string[]> callback, Action? onCancel = null)
 	{
-		bool replaceCur = false;
-		if (data.CurrentDirectory == "")
+		bool replaceCur = string.IsNullOrEmpty(data.CurrentDirectory);
+		string currentDir = replaceCur ? LastFilePromptFolder : data.CurrentDirectory;
+
+		FileDialog dialog = new()
 		{
-			replaceCur = true;
-			data.CurrentDirectory = LastFilePromptFolder;
+			Title = data.Title,
+			CurrentDir = currentDir,
+			CurrentFile = data.FileName,
+			ShowHiddenFiles = data.ShowHidden,
+			FileMode = MapFileMode(data.DialogMode),
+			Access = FileDialog.AccessEnum.Filesystem,
+			UseNativeDialog = true,
+		};
+
+		if (data.Filters is { Length: > 0 })
+			dialog.Filters = data.Filters;
+
+		AddChild(dialog);
+
+		void OnPathsSelected(string[] paths)
+		{
+			if (replaceCur)
+				LastFilePromptFolder = paths[0].GetBaseDir();
+			callback.Invoke(paths);
+			dialog.QueueFree();
 		}
-		DisplayServer.FileDialogShow(
-			data.Title,
-			data.CurrentDirectory,
-			data.FileName,
-			data.ShowHidden,
-			data.DialogMode,
-			data.Filters,
-			Callable.From<bool, string[], int>((status, paths, index) =>
-			{
-				if (!status) return;
-				if (replaceCur) LastFilePromptFolder = paths[0].GetBaseDir();
-				callback.Invoke(paths);
-			})
-		);
+
+		dialog.FileSelected  += path  => OnPathsSelected([path]);
+		dialog.DirSelected   += path  => OnPathsSelected([path]);
+		dialog.FilesSelected += paths => OnPathsSelected(paths);
+		dialog.Canceled      += ()    => { onCancel?.Invoke(); dialog.QueueFree(); };
+
+		dialog.PopupCentered(new Vector2I(800, 600));
 	}
+	
+	private static FileDialog.FileModeEnum MapFileMode(DisplayServer.FileDialogMode mode) => mode switch
+	{
+		DisplayServer.FileDialogMode.OpenFile  => FileDialog.FileModeEnum.OpenFile,
+		DisplayServer.FileDialogMode.OpenFiles => FileDialog.FileModeEnum.OpenFiles,
+		DisplayServer.FileDialogMode.OpenDir   => FileDialog.FileModeEnum.OpenDir,
+		DisplayServer.FileDialogMode.SaveFile  => FileDialog.FileModeEnum.SaveFile,
+		_                                      => FileDialog.FileModeEnum.OpenFile,
+	};
 
 	public static void ToggleFullscreen()
 	{
@@ -655,4 +677,3 @@ public struct FileSelectPromptPayload()
 	public DisplayServer.FileDialogMode DialogMode;
 	public string[] Filters = [];
 }
-


### PR DESCRIPTION
## Summary

Replaced the old `PromptFileSelect` method in `CreatorInterfaces.cs` to use a `FileDialog` node, instead of `DisplayServer.ShowFileDialog`. The original method's file dialog callback wouldn't fire properly on macOS, thus breaking things like legacy world file importing. Legacy world importing in specific wouldn't error or log anything, the callback would just never be fired and so the conversion never took place.

I am unable to test on Windows or Linux, so that would be extremely helpful if someone could double check.

## Related issue or discussion

Fixes #38 
Related to #38 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

No visual changes.

## AI/LLM use

Claude was used to debug the issue, and write the new method. I reviewed the method manually, and did not notice any issues in code quality or formatting, nor did I notice any issues in an export of the creator with the new method implemented. No agent was used, and was only fed relevant information via a web interface. All pre-reqs were fulfilled by me, same with all testing. Hope this is okay, and in line with the AI usage policy. If not, I apologize.