### PR TITLE
Fix math for MousePosition and its consumers to orient at bottom

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -848,7 +848,7 @@ public sealed partial class Camera : Dynamic
 	{
 		Viewport viewport = GDNode.GetViewport();
 		Vector2 size = viewport.GetVisibleRect().Size;
-		Vector2 screenPos = new(pos.X * size.X, pos.Y * size.Y);
+		Vector2 screenPos = new(pos.X * size.X, (1 - pos.Y) * (size.Y - 1));
 		Vector3 rayOrigin = Camera3D.ProjectRayOrigin(screenPos);
 		Vector3 rayDir = Camera3D.ProjectRayNormal(screenPos);
 		return Root.Environment.Raycast(rayOrigin.Flip(), rayDir.Flip(), maxDistance, ignoreList);
@@ -857,7 +857,7 @@ public sealed partial class Camera : Dynamic
 	[ScriptMethod]
 	public RayResult? ScreenPointToRay(Vector2 pos, Instance[]? ignoreList = null, float maxDistance = 10000f)
 	{
-		pos = pos.Flip();
+		pos = pos.Reorient(GDNode.GetViewport().GetVisibleRect().Size.Y - 1);
 		Vector3 rayOrigin = Camera3D.ProjectRayOrigin(pos);
 		Vector3 rayDir = Camera3D.ProjectRayNormal(pos);
 		return Root.Environment.Raycast(rayOrigin.Flip(), rayDir.Flip(), maxDistance, ignoreList);
@@ -868,7 +868,7 @@ public sealed partial class Camera : Dynamic
 	{
 		Viewport viewport = GDNode.GetViewport();
 		Vector2 size = viewport.GetVisibleRect().Size;
-		return new Vector2(pos.X * size.X, pos.Y * size.Y).Flip();
+		return new Vector2(pos.X * size.X, pos.Y * (size.Y - 1));
 	}
 
 	[ScriptMethod]
@@ -876,7 +876,7 @@ public sealed partial class Camera : Dynamic
 	{
 		Viewport viewport = GDNode.GetViewport();
 		Vector2 size = viewport.GetVisibleRect().Size;
-		Vector2 screenPos = new(pos.X * size.X, pos.Y * size.Y);
+		Vector2 screenPos = new(pos.X * size.X, (1 - pos.Y) * (size.Y - 1));
 		Vector3 origin = Camera3D.ProjectRayOrigin(screenPos);
 		Vector3 direction = Camera3D.ProjectRayNormal(screenPos);
 		return (origin + direction * Camera3D.Near).Flip();
@@ -889,7 +889,7 @@ public sealed partial class Camera : Dynamic
 		Viewport viewport = GDNode.GetViewport();
 		Vector2 screenPos = Camera3D.UnprojectPosition(pos);
 		Vector2 size = viewport.GetVisibleRect().Size;
-		return new Vector2(screenPos.X / size.X, screenPos.Y / size.Y);
+		return new Vector2(screenPos.X / size.X, 1 - screenPos.Y / (size.Y - 1));
 	}
 
 	[ScriptMethod]
@@ -897,27 +897,26 @@ public sealed partial class Camera : Dynamic
 	{
 		pos = pos.Flip();
 		Vector2 unprojected = Camera3D.UnprojectPosition(pos);
-		return unprojected.Flip();
+		return unprojected.Reorient(GDNode.GetViewport().GetVisibleRect().Size.Y - 1);
 	}
 
 	[ScriptMethod]
 	public Vector2 ScreenToViewportPoint(Vector2 pos)
 	{
-		pos = pos.Flip();
 		Viewport viewport = GDNode.GetViewport();
 		if (viewport == null)
 			return Vector2.Zero;
 
 		Vector2 size = viewport.GetVisibleRect().Size;
-		return new Vector2(pos.X / size.X, pos.Y / size.Y);
+		return new Vector2(pos.X / size.X, pos.Y / (size.Y - 1));
 	}
 
 	[ScriptMethod]
 	public Vector3 ScreenToWorldPoint(Vector2 pos)
 	{
-		pos = pos.Flip();
-		Vector3 rayOrigin = Camera3D.ProjectRayOrigin(new(pos.X, pos.Y));
-		Vector3 rayDir = Camera3D.ProjectRayNormal(new(pos.X, pos.Y));
+		pos = pos.Reorient(GDNode.GetViewport().GetVisibleRect().Size.Y - 1);
+		Vector3 rayOrigin = Camera3D.ProjectRayOrigin(pos);
+		Vector3 rayDir = Camera3D.ProjectRayNormal(pos);
 		return (rayOrigin + rayDir * Camera3D.Near).Flip();
 	}
 

--- a/Polytoria/scripts/datamodel/services/InputService.cs
+++ b/Polytoria/scripts/datamodel/services/InputService.cs
@@ -70,8 +70,8 @@ public sealed partial class InputService : Instance
 		}
 	}
 
-	[ScriptProperty] public Vector2 MousePosition => OverrideMousePos ? OverrideMousePosTo : GDNode.GetViewport().GetMousePosition().Flip();
-	[ScriptLegacyProperty("MousePosition")] public Vector3 LegacyMousePosition => new(MousePosition.X, ScreenHeight - MousePosition.Y, 0);
+	[ScriptProperty] public Vector2 MousePosition => OverrideMousePos ? OverrideMousePosTo : GDNode.GetViewport().GetMousePosition().Reorient(ScreenHeight - 1);
+	[ScriptLegacyProperty("MousePosition")] public Vector3 LegacyMousePosition => new(MousePosition.X, MousePosition.Y, 0);
 	[ScriptProperty] public int ScreenWidth => (int)GDNode.GetViewport().GetVisibleRect().Size.X;
 	[ScriptProperty] public int ScreenHeight => (int)GDNode.GetViewport().GetVisibleRect().Size.Y;
 
@@ -563,7 +563,7 @@ public sealed partial class InputService : Instance
 		if (camera == null || viewport == null)
 			return Vector3.Zero;
 
-		Vector2 mousePos = MousePosition.Flip();
+		Vector2 mousePos = MousePosition.Reorient(ScreenHeight - 1);
 		Vector3 rayOrigin = camera.ProjectRayOrigin(mousePos);
 		Vector3 rayDir = camera.ProjectRayNormal(mousePos);
 

--- a/Polytoria/scripts/utils/MathUtils.cs
+++ b/Polytoria/scripts/utils/MathUtils.cs
@@ -24,6 +24,15 @@ public static class MathUtils
 		return vector2;
 	}
 
+	/// <summary>
+	/// Helper to perform the math for converting between Godot and Polytoria screen units
+	/// </summary>
+	public static Vector2 ReorientVector2(Vector2 vector2, float y)
+	{
+		vector2.Y = y - vector2.Y;
+		return vector2;
+	}
+
 	public static Quaternion FlipQuat(Quaternion quat)
 	{
 		return new(-quat.X, -quat.Y, quat.Z, quat.W);
@@ -63,6 +72,11 @@ public static class MathUtilsExtensions
 	public static Vector2 Flip(this Vector2 v)
 	{
 		return MathUtils.FlipVector2(v);
+	}
+
+	public static Vector2 Reorient(this Vector2 v, float y)
+	{
+		return MathUtils.ReorientVector2(v, y);
 	}
 
 	public static Vector3 Flip(this Vector3 v)


### PR DESCRIPTION
## Summary

Reorients `Input.MousePosition` to origin at the bottom of the screen. Replicates quirks of 1.0 (range is 0 to `ScreenHeight - 1` instead of 1 to `ScreenHeight`).

This also modifies methods that consume these values (Screen/Viewport) to work with this system.

This introduces breaking changes for those who have adjusted to the current system.

I would appreciate feedback on whether I'm allowed to use `Root.Input.ScreenHeight` instead of getting screen height the way presented here.

## Related issue or discussion

Fixes #79, fixes #68

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
<details><summary>2.0 Test code</summary>

```lua
while true do
	wait(1)
	local mp = Input.MousePosition
	local cc:Camera = Environment.CurrentCamera
	local vp = cc:ScreenToViewportPoint(Input.MousePosition)
	print("MousePosition", mp)
	print("ViewportToScreenPoint", cc:ViewportToScreenPoint(vp))
	print("ViewportPosition", vp)
	print("ScreenToViewportPoint", cc:ScreenToViewportPoint(mp))
	local vwp = cc:ViewportToWorldPoint(vp)
	local mwp = cc:ScreenToWorldPoint(mp)
	print("ViewportToWorldPoint", vwp)
	print("ScreenToWorldPoint", mwp)
	print("WorldToScreenPoint", cc:WorldToScreenPoint(mwp))
	print("WorldToViewportPoint", cc:WorldToViewportPoint(vwp))
end
```
</details>
<details><summary>1.0 Test code</summary>

```lua
while true do
	wait(1)
	local mp = Input.MousePosition
	local vp = Input:ScreenToViewportPoint(Input.MousePosition)
	print("MousePosition", mp)
	print("ViewportToScreenPoint", Input:ViewportToScreenPoint(vp))
	print("ViewportPosition", vp)
	print("ScreenToViewportPoint", Input:ScreenToViewportPoint(mp))
	local vwp = Input:ViewportToWorldPoint(vp)
	local mwp = Input:ScreenToWorldPoint(mp)
	print("ViewportToWorldPoint", vwp)
	print("ScreenToWorldPoint", mwp)
	print("WorldToScreenPoint", Input:WorldToScreenPoint(mwp))
	print("WorldToViewportPoint", Input:WorldToViewportPoint(vwp))
end
```
</details> 

## AI/LLM use

None