### PR TITLE
Add normal map support to part shader

### DIFF
--- a/Polytoria/resources/materials/parts/Brick.tres
+++ b/Polytoria/resources/materials/parts/Brick.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_0s8vh"]
 [ext_resource type="Texture2D" uid="uid://bfswjptlde67c" path="res://assets/textures/parts/Brick/albedo.jpg" id="1_p863x"]
 [ext_resource type="Texture2D" uid="uid://cjdwf77wue4u8" path="res://assets/textures/parts/Brick/orm.jpg" id="3_7l8jb"]
+[ext_resource type="Texture2D" uid="uid://c5nevvfyjfowi" path="res://assets/textures/parts/Brick/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2000000095
 shader_parameter/roughness = 0.850000040375
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Concrete.tres
+++ b/Polytoria/resources/materials/parts/Concrete.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_afpo8"]
 [ext_resource type="Texture2D" uid="uid://bumhrxo5hi5gx" path="res://assets/textures/parts/Concrete/albedo.jpg" id="1_bnkc5"]
 [ext_resource type="Texture2D" uid="uid://bxqnl72j64oid" path="res://assets/textures/parts/Concrete/orm.jpg" id="3_wd0ed"]
+[ext_resource type="Texture2D" uid="uid://dsvtk570njb7d" path="res://assets/textures/parts/Concrete/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.150000007125
 shader_parameter/roughness = 0.90000004275
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Dirt.tres
+++ b/Polytoria/resources/materials/parts/Dirt.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_hodyu"]
 [ext_resource type="Texture2D" uid="uid://b7b4oqatm2ao5" path="res://assets/textures/parts/Dirt/albedo.jpg" id="1_vilg5"]
 [ext_resource type="Texture2D" uid="uid://cgfeficn86n1t" path="res://assets/textures/parts/Dirt/orm.jpg" id="3_kwoy7"]
+[ext_resource type="Texture2D" uid="uid://dgc6pqm18rxhj" path="res://assets/textures/parts/Dirt/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2000000095
 shader_parameter/roughness = 0.75
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Fabric.tres
+++ b/Polytoria/resources/materials/parts/Fabric.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://bntvtnqpldp6a" path="res://assets/textures/parts/Fabric/albedo.jpg" id="1_uj6ow"]
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_yb1qv"]
 [ext_resource type="Texture2D" uid="uid://csd0v57tigfxf" path="res://assets/textures/parts/Fabric/orm.jpg" id="3_4etkd"]
+[ext_resource type="Texture2D" uid="uid://bmy6qygv8fqd2" path="res://assets/textures/parts/Fabric/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.150000007125
 shader_parameter/roughness = 0.8
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Grass.tres
+++ b/Polytoria/resources/materials/parts/Grass.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://cuqjo8w3o0wmh" path="res://assets/textures/parts/Grass/albedo.jpg" id="1_g14c0"]
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_o55v0"]
 [ext_resource type="Texture2D" uid="uid://c8qn6dnhdtpo5" path="res://assets/textures/parts/Grass/orm.jpg" id="3_asc4g"]
+[ext_resource type="Texture2D" uid="uid://buda8o4msdo2m" path="res://assets/textures/parts/Grass/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.10000000475
 shader_parameter/roughness = 0.90000004275
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Ice.tres
+++ b/Polytoria/resources/materials/parts/Ice.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://6w30m46txlae" path="res://assets/textures/parts/Ice/albedo.jpg" id="1_dgx6w"]
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_h34au"]
 [ext_resource type="Texture2D" uid="uid://cy0oexjal40gd" path="res://assets/textures/parts/Ice/orm.jpg" id="3_vbyqn"]
+[ext_resource type="Texture2D" uid="uid://br03rbyc3awrh" path="res://assets/textures/parts/Ice/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.800000038
 shader_parameter/roughness = 0.15
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Marble.tres
+++ b/Polytoria/resources/materials/parts/Marble.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_n6agm"]
 [ext_resource type="Texture2D" uid="uid://bd1rxfnd3sysk" path="res://assets/textures/parts/Marble/albedo.jpg" id="1_ninq6"]
 [ext_resource type="Texture2D" uid="uid://dj7ob7cge1x35" path="res://assets/textures/parts/Marble/orm.jpg" id="3_n0jwj"]
+[ext_resource type="Texture2D" uid="uid://bt04cn0bofylh" path="res://assets/textures/parts/Marble/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.450000021375
 shader_parameter/roughness = 0.6000000285
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Metal.tres
+++ b/Polytoria/resources/materials/parts/Metal.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://c73qdy128y3r1" path="res://assets/textures/parts/Metal/albedo.jpg" id="1_ajs75"]
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_n12of"]
 [ext_resource type="Texture2D" uid="uid://b04ptso5l3fxm" path="res://assets/textures/parts/Metal/orm.jpg" id="3_g5hof"]
+[ext_resource type="Texture2D" uid="uid://cbpy6mxkv04vg" path="res://assets/textures/parts/Metal/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.30000001425
 shader_parameter/roughness = 0.650000030875
 shader_parameter/metallic = 0.70000003325
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/MetalGrid.tres
+++ b/Polytoria/resources/materials/parts/MetalGrid.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_j50tp"]
 [ext_resource type="Texture2D" uid="uid://bg8wir6uingk" path="res://assets/textures/parts/MetalGrid/albedo.jpg" id="1_t8vh6"]
 [ext_resource type="Texture2D" uid="uid://dcfyee41q7lba" path="res://assets/textures/parts/MetalGrid/orm.jpg" id="3_r8yqw"]
+[ext_resource type="Texture2D" uid="uid://bwodafhvccffr" path="res://assets/textures/parts/MetalGrid/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2
 shader_parameter/roughness = 0.7
 shader_parameter/metallic = 0.6000000285
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/MetalPlate.tres
+++ b/Polytoria/resources/materials/parts/MetalPlate.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_gpnht"]
 [ext_resource type="Texture2D" uid="uid://c77sa0fy287db" path="res://assets/textures/parts/MetalPlate/albedo.jpg" id="1_vk4ct"]
 [ext_resource type="Texture2D" uid="uid://dtnbsjqnddvxp" path="res://assets/textures/parts/MetalPlate/orm.jpg" id="3_gde4x"]
+[ext_resource type="Texture2D" uid="uid://d172fn5vj7wel" path="res://assets/textures/parts/MetalPlate/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2
 shader_parameter/roughness = 0.6
 shader_parameter/metallic = 0.70000003325
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Planks.tres
+++ b/Polytoria/resources/materials/parts/Planks.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_7uewk"]
 [ext_resource type="Texture2D" uid="uid://cxsxmitcxu58t" path="res://assets/textures/parts/Planks/albedo.jpg" id="1_u7k2d"]
 [ext_resource type="Texture2D" uid="uid://8jdinhv4hfm3" path="res://assets/textures/parts/Planks/orm.jpg" id="3_cmlj0"]
+[ext_resource type="Texture2D" uid="uid://dtwu6jip401xr" path="res://assets/textures/parts/Planks/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.10000000475
 shader_parameter/roughness = 0.800000038
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Plastic.tres
+++ b/Polytoria/resources/materials/parts/Plastic.tres
@@ -1,6 +1,7 @@
 [gd_resource type="ShaderMaterial" format=3 uid="uid://dcuvqhbcxjfwo"]
 
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_2en81"]
+[ext_resource type="Texture2D" uid="uid://bse0djs3rlw5" path="res://assets/textures/parts/Plastic/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -13,4 +14,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2
 shader_parameter/roughness = 0.7
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Plywood.tres
+++ b/Polytoria/resources/materials/parts/Plywood.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_1nh6e"]
 [ext_resource type="Texture2D" uid="uid://cbnanao6ntgv1" path="res://assets/textures/parts/Plywood/albedo.jpg" id="1_dfoi1"]
 [ext_resource type="Texture2D" uid="uid://bhpu1ddonesoh" path="res://assets/textures/parts/Plywood/orm.jpg" id="3_qs0no"]
+[ext_resource type="Texture2D" uid="uid://ctalu6w021how" path="res://assets/textures/parts/Plywood/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.150000007125
 shader_parameter/roughness = 0.6000000285
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/RustyIron.tres
+++ b/Polytoria/resources/materials/parts/RustyIron.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://chb5vrsoj0svr" path="res://assets/textures/parts/RustyIron/albedo.jpg" id="1_etbd3"]
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_fff5x"]
 [ext_resource type="Texture2D" uid="uid://cpjffqnvcfu2c" path="res://assets/textures/parts/RustyIron/orm.jpg" id="3_56c2k"]
+[ext_resource type="Texture2D" uid="uid://dql7rylal0hxq" path="res://assets/textures/parts/RustyIron/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2
 shader_parameter/roughness = 0.750000035625
 shader_parameter/metallic = 0.800000038
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Sand.tres
+++ b/Polytoria/resources/materials/parts/Sand.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://b13etqv03akf7" path="res://assets/textures/parts/Sand/albedo.jpg" id="1_63rxi"]
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_nqa41"]
 [ext_resource type="Texture2D" uid="uid://dlv44p4i08sdm" path="res://assets/textures/parts/Sand/orm.jpg" id="3_g0a3o"]
+[ext_resource type="Texture2D" uid="uid://v0yay6f2esr" path="res://assets/textures/parts/Sand/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2
 shader_parameter/roughness = 0.7
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Sandstone.tres
+++ b/Polytoria/resources/materials/parts/Sandstone.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_6w6ex"]
 [ext_resource type="Texture2D" uid="uid://dvpf7d8rl5um8" path="res://assets/textures/parts/Sandstone/albedo.jpg" id="1_y4t3f"]
 [ext_resource type="Texture2D" uid="uid://bavbsxt8pg1w0" path="res://assets/textures/parts/Sandstone/orm.jpg" id="2_pjsih"]
+[ext_resource type="Texture2D" uid="uid://cagbf2ay3qkfd" path="res://assets/textures/parts/Sandstone/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2
 shader_parameter/roughness = 0.7
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Snow.tres
+++ b/Polytoria/resources/materials/parts/Snow.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_48jsp"]
 [ext_resource type="Texture2D" uid="uid://cddkfxb8mrr88" path="res://assets/textures/parts/Snow/albedo.jpg" id="1_ti61s"]
 [ext_resource type="Texture2D" uid="uid://cmmrfrpg8rcl0" path="res://assets/textures/parts/Snow/orm.jpg" id="3_81iri"]
+[ext_resource type="Texture2D" uid="uid://dsfpjkpxnyyqa" path="res://assets/textures/parts/Snow/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.2
 shader_parameter/roughness = 0.7
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Stone.tres
+++ b/Polytoria/resources/materials/parts/Stone.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_6f6ms"]
 [ext_resource type="Texture2D" uid="uid://dvpf7d8rl5um8" path="res://assets/textures/parts/Sandstone/albedo.jpg" id="2_6essf"]
 [ext_resource type="Texture2D" uid="uid://bavbsxt8pg1w0" path="res://assets/textures/parts/Sandstone/orm.jpg" id="3_ju1me"]
+[ext_resource type="Texture2D" uid="uid://cnet0syg0jay2" path="res://assets/textures/parts/Stone/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.10000000475
 shader_parameter/roughness = 0.90000004275
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/materials/parts/Wood.tres
+++ b/Polytoria/resources/materials/parts/Wood.tres
@@ -3,6 +3,7 @@
 [ext_resource type="Shader" uid="uid://dylteiumvf3c7" path="res://resources/shaders/part/part.gdshader" id="1_4eegw"]
 [ext_resource type="Texture2D" uid="uid://csooo1hu87qfb" path="res://assets/textures/parts/Wood/albedo.jpg" id="1_m307m"]
 [ext_resource type="Texture2D" uid="uid://bhpu1ddonesoh" path="res://assets/textures/parts/Plywood/orm.jpg" id="3_vhd34"]
+[ext_resource type="Texture2D" uid="uid://ddfbxrbek5n54" path="res://assets/textures/parts/Wood/normal.jpg" id="4_norm"]
 
 [resource]
 resource_local_to_scene = true
@@ -17,4 +18,6 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/metallic_specular = 0.10000000475
 shader_parameter/roughness = 0.90000004275
 shader_parameter/metallic = 0.0
+shader_parameter/normal_tex = ExtResource("4_norm")
+shader_parameter/use_normal_texture = true
 shader_parameter/studs_per_tile = 2.0

--- a/Polytoria/resources/shaders/part/part.gdshader
+++ b/Polytoria/resources/shaders/part/part.gdshader
@@ -9,6 +9,9 @@ uniform bool use_albedo_texture = true;
 uniform sampler2D orm;
 uniform bool use_orm_texture = true;
 
+uniform sampler2D normal_tex : hint_normal;
+uniform bool use_normal_texture = false;
+
 uniform float emissive_strength : hint_range(0.0, 5.0) = 0.0;
 
 uniform float metallic_specular : hint_range(0.0, 1.0) = 0.2;
@@ -76,6 +79,10 @@ void fragment() {
 		vec3 orm_values = texture(orm, uv).rgb;
 		roughness_tex = orm_values.g;
 		metallic_tex = orm_values.b;
+	}
+
+	if (use_normal_texture) {
+		NORMAL_MAP = texture(normal_tex, uv).rgb;
 	}
 
 	ALBEDO = albedo_color.rgb * COLOR.rgb;

--- a/Polytoria/scripts/client/settings/ClientSettingKeys.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingKeys.cs
@@ -39,6 +39,7 @@ public static class ClientSettingKeys
 		public const string Ssr = "graphics.post_processing.ssr";
 		public const string Ssil = "graphics.post_processing.ssil";
 		public const string Sdfgi = "graphics.post_processing.sdfgi";
+		public const string NormalMaps = "graphics.post_processing.normal_maps";
 
 		public const string SdfgiCellSize = "graphics.post_processing.sdfgi_cell_size";
 		public const string SdfgiCascades = "graphics.post_processing.sdfgi_cascades";

--- a/Polytoria/scripts/client/settings/ClientSettingsRegistry.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingsRegistry.cs
@@ -328,6 +328,19 @@ public static class ClientSettingsRegistry
 				}
 			},
 			{
+				ClientSettingKeys.PostProcessing.NormalMaps,
+				new SettingDef<bool>
+				{
+					Key = ClientSettingKeys.PostProcessing.NormalMaps,
+					SectionKey = "post_processing",
+					Label = "Normal Maps",
+					Description = "Toggle normal maps on part materials.",
+					ValueKind = SettingValueKind.Bool,
+					ControlKind = SettingControlKind.Toggle,
+					DefaultValue = true,
+				}
+			},
+			{
 				ClientSettingKeys.Advanced.ShowAdvancedSettings,
 				new SettingDef<bool>
 				{

--- a/Polytoria/scripts/client/settings/GraphicsPresetManager.cs
+++ b/Polytoria/scripts/client/settings/GraphicsPresetManager.cs
@@ -13,7 +13,8 @@ public static class GraphicsPresetManager
 			|| key == ClientSettingKeys.PostProcessing.Ssao
 			|| key == ClientSettingKeys.PostProcessing.Ssr
 			|| key == ClientSettingKeys.PostProcessing.Ssil
-			|| key == ClientSettingKeys.PostProcessing.Sdfgi;
+			|| key == ClientSettingKeys.PostProcessing.Sdfgi
+			|| key == ClientSettingKeys.PostProcessing.NormalMaps;
 	}
 
 	public static void ApplyPreset(GraphicsPreset preset)
@@ -32,6 +33,7 @@ public static class GraphicsPresetManager
 				settings.Set(ClientSettingKeys.PostProcessing.Ssr, false);
 				settings.Set(ClientSettingKeys.PostProcessing.Ssil, false);
 				settings.Set(ClientSettingKeys.PostProcessing.Sdfgi, false);
+				settings.Set(ClientSettingKeys.PostProcessing.NormalMaps, false);
 				break;
 			case GraphicsPreset.Medium:
 				settings.Set(ClientSettingKeys.Graphics.RenderScale, 1.0f);
@@ -43,6 +45,7 @@ public static class GraphicsPresetManager
 				settings.Set(ClientSettingKeys.PostProcessing.Ssr, false);
 				settings.Set(ClientSettingKeys.PostProcessing.Ssil, false);
 				settings.Set(ClientSettingKeys.PostProcessing.Sdfgi, false);
+				settings.Set(ClientSettingKeys.PostProcessing.NormalMaps, true);
 				break;
 			case GraphicsPreset.High:
 				settings.Set(ClientSettingKeys.Graphics.RenderScale, 1.0f);
@@ -54,6 +57,7 @@ public static class GraphicsPresetManager
 				settings.Set(ClientSettingKeys.PostProcessing.Ssr, true);
 				settings.Set(ClientSettingKeys.PostProcessing.Ssil, false);
 				settings.Set(ClientSettingKeys.PostProcessing.Sdfgi, false);
+				settings.Set(ClientSettingKeys.PostProcessing.NormalMaps, true);
 				break;
 			case GraphicsPreset.Ultra:
 				settings.Set(ClientSettingKeys.Graphics.RenderScale, 1.0f);
@@ -65,6 +69,7 @@ public static class GraphicsPresetManager
 				settings.Set(ClientSettingKeys.PostProcessing.Ssr, true);
 				settings.Set(ClientSettingKeys.PostProcessing.Ssil, true);
 				settings.Set(ClientSettingKeys.PostProcessing.Sdfgi, false);
+				settings.Set(ClientSettingKeys.PostProcessing.NormalMaps, true);
 				break;
 			case GraphicsPreset.Photo:
 				settings.Set(ClientSettingKeys.Graphics.RenderScale, 1.0f);
@@ -76,6 +81,7 @@ public static class GraphicsPresetManager
 				settings.Set(ClientSettingKeys.PostProcessing.Ssr, true);
 				settings.Set(ClientSettingKeys.PostProcessing.Ssil, true);
 				settings.Set(ClientSettingKeys.PostProcessing.Sdfgi, true);
+				settings.Set(ClientSettingKeys.PostProcessing.NormalMaps, true);
 				break;
 			case GraphicsPreset.Custom:
 			default:

--- a/Polytoria/scripts/client/settings/appliers/GraphicsSettingsApplier.cs
+++ b/Polytoria/scripts/client/settings/appliers/GraphicsSettingsApplier.cs
@@ -1,5 +1,6 @@
 using Godot;
 using Polytoria.Datamodel;
+using Polytoria.Shared;
 using Polytoria.Shared.Settings;
 
 namespace Polytoria.Client.Settings.Appliers;
@@ -14,7 +15,11 @@ public sealed partial class GraphicsSettingsApplier : Node
 
 	private void OnChanged(SettingChangedEvent change)
 	{
-		if (change.Key.StartsWith("graphics.post_processing."))
+		if (change.Key == ClientSettingKeys.PostProcessing.NormalMaps)
+		{
+			ApplyNormalMaps();
+		}
+		else if (change.Key.StartsWith("graphics.post_processing."))
 		{
 			ApplyPostProcessing();
 		}
@@ -49,9 +54,20 @@ public sealed partial class GraphicsSettingsApplier : Node
 		world.Lighting.ApplyGraphicsSettings();
 	}
 
+	private void ApplyNormalMaps()
+	{
+		bool enabled = ClientSettingsService.Instance.Get<bool>(ClientSettingKeys.PostProcessing.NormalMaps);
+		if (Globals.IsMobileBuild)
+		{
+			enabled = false;
+		}
+		Globals.SetNormalMapsEnabled(enabled);
+	}
+
 	private void ApplyAll()
 	{
 		ApplyPostProcessing();
+		ApplyNormalMaps();
 		ApplyRenderScale();
 		ApplyMsaa();
 		ApplyShadowQuality();

--- a/Polytoria/scripts/shared/Globals.cs
+++ b/Polytoria/scripts/shared/Globals.cs
@@ -348,6 +348,17 @@ public sealed partial class Globals : Node
 		return mat;
 	}
 
+	public static void SetNormalMapsEnabled(bool enabled)
+	{
+		foreach (var mat in _materialCache.Values)
+		{
+			if (mat is ShaderMaterial shaderMat)
+			{
+				shaderMat.SetShaderParameter("use_normal_texture", enabled);
+			}
+		}
+	}
+
 	public static Material LoadSkybox(string materialName)
 	{
 		return ForceLoadResource(_skyboxesCache, materialName, $"{SkyboxesPath}{materialName}.tres");


### PR DESCRIPTION
## Summary

Adds normal map sampling to the part shader, using the existing triplanar UV projection. All 19 textured part materials already had `normal.jpg` assets sitting unused; this wires them up. A "Normal Maps" toggle is added to client graphics settings under Post Processing (off on Low, on for Medium+). They are disabled on mobile like all other Post Processing effects.

## Related issue or discussion

Issue #3

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Disabled
<img width="769" height="451" alt="normal maps disabled" src="https://github.com/user-attachments/assets/d3adc523-e720-4eda-9db2-25066ef3b32d" />

Enabled
<img width="624" height="415" alt="normal maps enabled" src="https://github.com/user-attachments/assets/afc56627-772c-49f6-b5f4-33a1822f2097" />

Toggle in settings
<img width="940" height="506" alt="toggle" src="https://github.com/user-attachments/assets/08d7001a-c0dc-4d39-a19f-23570c691eb7" />

## AI/LLM use

None
