### PR TITLE
Add drag threshold to select tool to prevent accidental moves

### DIFF
--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -24,6 +24,9 @@ public sealed partial class Gizmos : Node
 	private float _gizmoScale;
 	private bool _isMouseDragging;
 	private bool _isDraggingDyn;
+	private bool _isDragPending;
+	private Vector2 _dragStartPos;
+	private const float DragThreshold = 8f;
 	private Dynamic? _lastHovered;
 	private SelectionBox _paintBox = null!;
 	private SelectionBox _hoverBox = null!;
@@ -492,13 +495,14 @@ public sealed partial class Gizmos : Node
 			if (button.Pressed)
 			{
 				_isMouseDragging = true;
+				_dragStartPos = button.Position;
 			}
 			else
 			{
 				_isMouseDragging = false;
+				_isDragPending = false;
 				if (_isDraggingDyn)
 				{
-					// Stopped dragging
 					_isDraggingDyn = false;
 					CommitHistorySelectedTransform();
 				}
@@ -550,14 +554,7 @@ public sealed partial class Gizmos : Node
 					if (toolMode == ToolModeEnum.Select)
 					{
 						DragSelected.Add(targetDyn);
-
-						if (!_isDraggingDyn)
-						{
-							// Drag started
-							_isDraggingDyn = true;
-							_history.NewAction("Select Drag Transform");
-							RecordHistoryUndo();
-						}
+						_isDragPending = true;
 					}
 				}
 			}
@@ -569,8 +566,20 @@ public sealed partial class Gizmos : Node
 				}
 			}
 		}
-		else if (@event is InputEventMouseMotion)
+		else if (@event is InputEventMouseMotion motion)
 		{
+			if (_isDragPending && !_isDraggingDyn)
+			{
+				float distance = motion.Position.DistanceTo(_dragStartPos);
+				if (distance >= DragThreshold)
+				{
+					_isDraggingDyn = true;
+					_isDragPending = false;
+					_history.NewAction("Select Drag Transform");
+					RecordHistoryUndo();
+				}
+			}
+
 			if (_isDraggingDyn)
 			{
 				DragSelectedDynamics();


### PR DESCRIPTION
## Summary

Adds a drag threshold to the select tool so clicking a part to select it doesn't accidentally move it. The drag only activates once the mouse has moved far enough from the initial click position.

## Related issue or discussion

Fixes #4

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

None
