### PR TITLE
Add cone preview gizmo for SpotLight in creator

### DIFF
--- a/Polytoria/scripts/creator/spatial/gizmos/ConeSpatial.cs
+++ b/Polytoria/scripts/creator/spatial/gizmos/ConeSpatial.cs
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Godot;
+using Polytoria.Shared;
+namespace Polytoria.Creator.Spatial;
+
+public partial class ConeSpatial : Node3D
+{
+	private MeshInstance3D _meshInstance = null!;
+	private float _range = 30;
+	private float _angle = 30;
+
+	public float Range
+	{
+		get => _range;
+		set
+		{
+			_range = value;
+			RenderGizmo();
+		}
+	}
+
+	public float Angle
+	{
+		get => _angle;
+		set
+		{
+			_angle = value;
+			RenderGizmo();
+		}
+	}
+
+	public float Segments { get; set; } = 32;
+
+	[Export]
+	public Color GizmoColor { get; set; } = new(1f, 0.5f, 0f);
+
+	public override void _Ready()
+	{
+		if (Globals.CurrentAppEntry != Globals.AppEntryEnum.Creator) { Visible = false; return; }
+		_meshInstance = new MeshInstance3D();
+		AddChild(_meshInstance);
+		RenderGizmo();
+	}
+
+	private void RenderGizmo()
+	{
+		if (_meshInstance == null)
+			return;
+
+		float radAngle = Mathf.DegToRad(Angle);
+		float baseRadius = Range * Mathf.Tan(radAngle);
+
+		SurfaceTool st = new();
+		st.Begin(Mesh.PrimitiveType.Lines);
+
+		for (int i = 0; i < Segments; i++)
+		{
+			float a1 = 2 * Mathf.Pi * i / Segments;
+			float a2 = 2 * Mathf.Pi * (i + 1) / Segments;
+
+			Vector3 p1 = new(baseRadius * Mathf.Cos(a1), baseRadius * Mathf.Sin(a1), Range);
+			Vector3 p2 = new(baseRadius * Mathf.Cos(a2), baseRadius * Mathf.Sin(a2), Range);
+
+			st.AddVertex(p1);
+			st.AddVertex(p2);
+		}
+
+		int edgeCount = 4;
+		for (int i = 0; i < edgeCount; i++)
+		{
+			float a = 2 * Mathf.Pi * i / edgeCount;
+			Vector3 basePoint = new(baseRadius * Mathf.Cos(a), baseRadius * Mathf.Sin(a), Range);
+
+			st.AddVertex(Vector3.Zero);
+			st.AddVertex(basePoint);
+		}
+
+		StandardMaterial3D mat = new()
+		{
+			ShadingMode = BaseMaterial3D.ShadingModeEnum.Unshaded,
+			AlbedoColor = GizmoColor,
+			Transparency = BaseMaterial3D.TransparencyEnum.Alpha
+		};
+
+		st.SetMaterial(mat);
+		_meshInstance.Mesh = st.Commit();
+		_meshInstance.CastShadow = GeometryInstance3D.ShadowCastingSetting.Off;
+	}
+}

--- a/Polytoria/scripts/datamodel/SpotLight.cs
+++ b/Polytoria/scripts/datamodel/SpotLight.cs
@@ -4,6 +4,9 @@
 
 using Godot;
 using Polytoria.Attributes;
+#if CREATOR
+using Polytoria.Creator.Spatial;
+#endif
 
 namespace Polytoria.Datamodel;
 
@@ -12,10 +15,17 @@ public sealed partial class SpotLight : Light
 {
 	private float _range = 30;
 	private float _angle = 30;
+#if CREATOR
+	private ConeSpatial _cone = null!;
+#endif
 
 	public override void Init()
 	{
 		LightNode = GDNode.GetNode<SpotLight3D>("SpotLight3D");
+
+#if CREATOR
+		GDNode.AddChild(_cone = new() { Visible = false }, @internal: Node.InternalMode.Back);
+#endif
 
 		base.Init();
 	}
@@ -35,6 +45,9 @@ public sealed partial class SpotLight : Light
 		{
 			_range = value;
 			((SpotLight3D)LightNode).SpotRange = value;
+#if CREATOR
+			_cone.Range = value;
+#endif
 			OnPropertyChanged();
 		}
 	}
@@ -47,7 +60,24 @@ public sealed partial class SpotLight : Light
 		{
 			_angle = value;
 			((SpotLight3D)LightNode).SpotAngle = value;
+#if CREATOR
+			_cone.Angle = value;
+#endif
 			OnPropertyChanged();
 		}
 	}
+
+#if CREATOR
+	public override void CreatorSelected()
+	{
+		_cone.Visible = true;
+		base.CreatorSelected();
+	}
+
+	public override void CreatorDeselected()
+	{
+		_cone.Visible = false;
+		base.CreatorDeselected();
+	}
+#endif
 }


### PR DESCRIPTION
## Summary

I'm shocked this wasn't already in the editor lol!
Adds a wireframe cone gizmo to SpotLight in the creator, shown when the light is selected. Updates live as Range and Angle change.

## Related issue or discussion

N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="1128" height="551" alt="image" src="https://github.com/user-attachments/assets/35868d0b-1710-48e8-840a-0a3f05ccd8e7" />
<img width="1166" height="542" alt="image" src="https://github.com/user-attachments/assets/a7e7e9d2-c296-4594-8d72-949aba81481b" />

## AI/LLM use

None
