### PR TITLE
Added size property to lights.

### DIFF
--- a/Polytoria/scripts/datamodel/Light.cs
+++ b/Polytoria/scripts/datamodel/Light.cs
@@ -22,7 +22,7 @@ public partial class Light : Dynamic
 	private bool _enabled = true;
 	private Color _color = new(1, 1, 1);
 	private float _brightness = 2;
-	private float _size = 0;
+	private float _lightSize = 0;
 	private float _specular = 0.5f;
 	private bool _shadows = false;
 
@@ -71,12 +71,12 @@ public partial class Light : Dynamic
 	}
 
 	[Editable, ScriptProperty]
-	public float Size
+	public float LightSize
 	{
-		get => _size;
+		get => _lightSize;
 		set
 		{
-			_size = value;
+			_lightSize = value;
 			LightNode.LightSize = value;
 			OnPropertyChanged();
 		}

--- a/Polytoria/scripts/datamodel/Light.cs
+++ b/Polytoria/scripts/datamodel/Light.cs
@@ -22,6 +22,7 @@ public partial class Light : Dynamic
 	private bool _enabled = true;
 	private Color _color = new(1, 1, 1);
 	private float _brightness = 2;
+	private float _size = 0;
 	private float _specular = 0.5f;
 	private bool _shadows = false;
 
@@ -65,6 +66,18 @@ public partial class Light : Dynamic
 		{
 			_brightness = value;
 			LightNode.LightEnergy = value / IntensityConversion;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float Size
+	{
+		get => _size;
+		set
+		{
+			_size = value;
+			LightNode.LightSize = value;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Added size property to lights to allow for softer shadows for selected lights.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->
<img width="711" height="670" alt="image" src="https://github.com/user-attachments/assets/2397288b-2903-4db1-8e6f-34bbe553d733" />
<img width="675" height="614" alt="image" src="https://github.com/user-attachments/assets/e3a6a664-85b7-4d5e-9ed7-4b85455a1b01" />


## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None