### PR TITLE
Quaternion bugfixes

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -187,6 +187,10 @@ public partial class Dynamic : Instance
 		{
 			Quaternion q = value.Flip();
 			GDNode3D.GlobalBasis = new(q);
+			if (AutoUpdateNetTransform)
+			{
+				UpdateNetTransformReliable();
+			}
 			OnPropertyChanged();
 		}
 	}
@@ -199,6 +203,10 @@ public partial class Dynamic : Instance
 		{
 			Quaternion q = value.Flip();
 			GDNode3D.Basis = new(q);
+			if (AutoUpdateNetTransform)
+			{
+				UpdateNetTransformReliable();
+			}
 			OnPropertyChanged();
 		}
 	}
@@ -739,6 +747,8 @@ public partial class Dynamic : Instance
 		OnPropertyChanged(nameof(LocalPosition), false);
 		OnPropertyChanged(nameof(LocalRotation), false);
 		OnPropertyChanged(nameof(LocalSize), false);
+		OnPropertyChanged(nameof(Quaternion), false);
+		OnPropertyChanged(nameof(LocalQuaternion), false);
 
 		TransformChanged?.Invoke();
 		foreach (Instance item in GetChildren())

--- a/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
@@ -97,7 +97,7 @@ public class PTQuaternion : IScriptGDObject
 	[ScriptMethod]
 	public static PTQuaternion AngleAxis(float angle, Vector3 axis)
 	{
-		return FromGDClass(new Quaternion(axis, angle));
+		return FromGDClass(new Quaternion(axis.FlipEuler(), Mathf.DegToRad(angle)).Flip());
 	}
 
 	[ScriptMethod(ConvertParamsToGD = false)]
@@ -109,27 +109,27 @@ public class PTQuaternion : IScriptGDObject
 	[ScriptMethod]
 	public static PTQuaternion Euler(float x, float y, float z)
 	{
-		return FromGDClass(Quaternion.FromEuler(new(x, y, z)));
+		return FromGDClass(Quaternion.FromEuler(MathUtils.Vector3DegToRad(new Vector3(x, y, z).FlipEuler())).Flip());
 	}
 
 	[ScriptMethod]
 	public static PTQuaternion Euler(Vector3 euler)
 	{
-		return FromGDClass(Quaternion.FromEuler(euler));
+		return FromGDClass(Quaternion.FromEuler(MathUtils.Vector3DegToRad(euler.FlipEuler())).Flip());
 	}
 
 
 	[ScriptMethod(ConvertParamsToGD = false)]
 	public static Vector3 ToEuler(PTQuaternion euler)
 	{
-		return MathUtils.Vector3RadToDeg(euler.quat.GetEuler()).FlipEuler();
+		return MathUtils.Vector3RadToDeg(euler.quat.Flip().GetEuler()).FlipEuler();
 	}
 
 	[ScriptMethod]
 	public static PTQuaternion FromToRotation(Vector3 fromDirection, Vector3 toDirection)
 	{
-		Vector3 from = fromDirection.Normalized();
-		Vector3 to = toDirection.Normalized();
+		Vector3 from = fromDirection.Normalized().FlipEuler();
+		Vector3 to = toDirection.Normalized().FlipEuler();
 
 		float dot = from.Dot(to);
 
@@ -143,12 +143,12 @@ public class PTQuaternion : IScriptGDObject
 			Vector3 perpendicular = from.Cross(Vector3.Up);
 			if (perpendicular.LengthSquared() < 1e-6f)
 				perpendicular = from.Cross(Vector3.Right);
-			return FromGDClass(new Quaternion(perpendicular.Normalized(), Mathf.Pi));
+			return FromGDClass(new Quaternion(perpendicular.Normalized().Flip(), Mathf.Pi));
 		}
 
 		Vector3 axis = from.Cross(to).Normalized();
 		float angle = Mathf.Acos(Mathf.Clamp(dot, -1.0f, 1.0f));
-		return FromGDClass(new Quaternion(axis, angle));
+		return FromGDClass(new Quaternion(axis, angle).Flip());
 	}
 
 	[ScriptMethod(ConvertParamsToGD = false)]
@@ -191,13 +191,13 @@ public class PTQuaternion : IScriptGDObject
 	[ScriptMethod]
 	public static PTQuaternion LookRotation(Vector3 forward, Vector3 upwards)
 	{
-		forward = forward.Normalized();
+		forward = forward.Normalized().Flip();
 
-		Vector3 right = upwards.Cross(forward).Normalized();
+		Vector3 right = upwards.Normalized().Flip().Cross(forward);
 		Vector3 up = forward.Cross(right);
 
 		Basis basis = new(right, up, forward);
-		return FromGDClass(basis.GetRotationQuaternion());
+		return FromGDClass(basis.GetRotationQuaternion().Flip());
 	}
 
 	[ScriptMethod(ConvertParamsToGD = false)]


### PR DESCRIPTION
## Summary

Bugfixes:

Multiple functions in `scripts/scripting/datatypes/PTQuaternion.cs` don't correctly flip when converting to and from rotations, resulting in unexpected behavior.

Multiple functions in `scripts/scripting/datatypes/PTQuaternion.cs` don't correctly convert from degrees to radians, resulting in unexpected behavior.

`scripts/datamodel/Dynamic.cs` doesn't notify transform change to Quaternion and LocalQuaternion, resulting in the position and rotation of children instances to not update when the parent is updated.

`scripts/datamodel/Dynamic.cs` doesn't broadcast changes to Quaternion and LocalQuaternion, resulting in the changes to position and rotation remaining local.

## Related issue or discussion

- [Bug]: Quaternions bugged #26 
- [Bug]: ToEuler is broken #39 
- [Bug]: Quaternion.LookRotation doesn't work as expected #50 
- [Bug]: More Quaternion Bugs #138 

- [Bugfix]: Quaternions/Euler Angles Bugs fixed + QoL Improvements #96 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [x] Server
- [x] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

None used.