### PR TITLE
Fix player head jittering and camera shaking on low framerates

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -459,7 +459,7 @@ public sealed partial class Camera : Dynamic
 				}
 			}
 
-			_currentZoom = (float)Mathf.Lerp(_currentZoom, _targetZoom, delta * ScrollLerpSpeed);
+			_currentZoom = (float)Mathf.Lerp(_currentZoom, _targetZoom, Mathf.Clamp(delta * ScrollLerpSpeed, 0, 1));
 			float finalizedZoom = _currentZoom;
 
 			_turnY2.Position = new Vector3(0, 0, _currentZoom);

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -14,7 +14,6 @@ using Polytoria.Utils;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using ZstdSharp.Unsafe;
 
 namespace Polytoria.Datamodel;
 

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -14,6 +14,7 @@ using Polytoria.Utils;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using ZstdSharp.Unsafe;
 
 namespace Polytoria.Datamodel;
 
@@ -431,6 +432,16 @@ public sealed partial class PolytorianModel : CharacterModel
 				targetBlendSpeed = LookBlendSpeed;
 
 				newValue = Mathf.Lerp(current, target, (float)delta * targetBlendSpeed);
+
+				//To fix the turn overshooting the target on low framerates
+				if (target > 0)
+				{
+					newValue = Mathf.Clamp(newValue, 0f, target);
+				}
+				else
+				{
+					newValue = Mathf.Clamp(newValue, target, 0f);
+				}
 			}
 			else
 			{

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -424,7 +424,7 @@ public sealed partial class PolytorianModel : CharacterModel
 			float current = (float)AnimTree.Get(propName);
 
 			float targetBlendSpeed = BlendSpeed;
-			float newValue, interpT;
+			float newValue;
 
 			if (propName.Contains("Look"))
 			{

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -424,23 +424,14 @@ public sealed partial class PolytorianModel : CharacterModel
 			float current = (float)AnimTree.Get(propName);
 
 			float targetBlendSpeed = BlendSpeed;
-			float newValue;
+			float newValue, interpT;
 
 			if (propName.Contains("Look"))
 			{
 				targetBlendSpeed = LookBlendSpeed;
 
-				newValue = Mathf.Lerp(current, target, (float)delta * targetBlendSpeed);
-
-				//To fix the turn overshooting the target on low framerates
-				if (target > 0)
-				{
-					newValue = Mathf.Clamp(newValue, 0f, target);
-				}
-				else
-				{
-					newValue = Mathf.Clamp(newValue, target, 0f);
-				}
+				float lerpT = Mathf.Clamp((float)delta * targetBlendSpeed, 0, 1);
+				newValue = Mathf.Lerp(current, target, lerpT);
 			}
 			else
 			{


### PR DESCRIPTION
Signed-off-by: AllyLightweight <webmaster@pigeonland.uk>

## Summary

As @Bucketcom pointed out in #92, low framerates cause the player's head to overshoot its target angle when trying to follow the camera, making it jitter from side to side.
This PR clamps the head position so it won't go any further than its target in either direction.

## Related issue or discussion

Fixes #92

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

This video demonstrates the issue and fix, with the game capped at 5fps to trigger the bug
[HeadBugDemo.webm](https://github.com/user-attachments/assets/9c0142e4-3a21-4e98-b494-dad4f5123631)


## AI/LLM use

None
