### PR TITLE
Creator: Removed extra Fs from find-replace dialogue

### DIFF
--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -195,10 +195,12 @@ public partial class TextEditorRoot : Node
 		}
 		else if (@event.IsActionPressed("textedit_find") || @event.IsActionPressed("textedit_replace"))
 		{
+			CodeEditor.AcceptEvent();
 			_finder.Open(CodeEditor.GetSelectedText());
 		}
 		else if (@event.IsActionPressed("ui_cancel"))
 		{
+			CodeEditor.AcceptEvent();
 			_finder.Close();
 		}
 		else


### PR DESCRIPTION
## Summary

Fixed a bug with the find/replace dialogue where it will insert 'f' at the beginning of the input every time you open. I did this by literally inserting two lines...

Now I can say:
**"ALL YOU HAD TO DO WAS INSERT THE DARN LINE, CJ!"**

## Related issue or discussion

Fixes #164

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video


https://github.com/user-attachments/assets/e1626ab4-21a4-470d-aba0-6dcec3730ca7


## AI/LLM use

No AI was used. It's just a few darn lines...