### PR TITLE
change target zoom logic

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -668,11 +668,11 @@ public sealed partial class Camera : Dynamic
 				switch (btnEvent2.ButtonIndex)
 				{
 					case MouseButton.WheelUp:
-						_targetZoom = _distance - (ScrollSensitivity / 5);
+						_targetZoom -= ScrollSensitivity / 5;
 						break;
 
 					case MouseButton.WheelDown:
-						_targetZoom = _distance + (ScrollSensitivity / 5);
+						_targetZoom += ScrollSensitivity / 5;
 						break;
 				}
 			}


### PR DESCRIPTION
## Summary

made zooming directly add/subtract from camera's target zoom instead of being dependent on the camera's `Distance` (`targetZoom = distance ± (ScrollSensitivity / 5)` => `targetZoom ±= ScrollSensitivity / 5`)

## Related issue or discussion

Related to #136

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

this is kinda hard to demonstrate sorry if this video is weird

https://github.com/user-attachments/assets/1900d444-951b-4882-a6cf-dfecd9cf1d29

## AI/LLM use

None