### PR TITLE
fix _G being readonly + formatter <3

### DIFF
--- a/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
@@ -628,6 +628,9 @@ public partial class LuaState : IDisposable
 			SetReadOnly(-1, true);
 			SetMetaTable(-2);
 
+			PushValue(-1);
+			SetField(-2, "_G");
+
 			Replace(LuaState.LUA_GLOBALSINDEX);
 		}
 	}


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
fixes _G being read only allowing for per script global writes. (hopefully passed all my tests...)

## Related issue or discussion

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
none