### PR TITLE
Added Quaternion and LocalQuaternion to Dynamic.InvokeTransformChanged()

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -735,6 +735,8 @@ public partial class Dynamic : Instance
 		OnPropertyChanged(nameof(LocalPosition), false);
 		OnPropertyChanged(nameof(LocalRotation), false);
 		OnPropertyChanged(nameof(LocalSize), false);
+		OnPropertyChanged(nameof(Quaternion), false);
+		OnPropertyChanged(nameof(LocalQuaternion), false);
 
 		TransformChanged?.Invoke();
 		foreach (Instance item in GetChildren())


### PR DESCRIPTION
## Summary

`<Dynamic>.PropertyChanged:Connect()` now fires for indirect `Quaternion` and `LocalQuaternion` changes, e.g. if `Rotation` is changed it will fire for quaternions.

## Related issue or discussion

Fixes [Bug]: Dynamic.InvokeTransformChanged() Doesn't Include Quaternions #187 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A.

## AI/LLM use

None.