### PR TITLE
Fixed SnapForward and SnapBackwards for the creator zoom in and out b…

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -805,12 +805,12 @@ public sealed partial class Camera : Dynamic
 
 	private void SnapForward()
 	{
-		Position += Forward * _moveSpeed / 10;
+		Position += Forward * -_moveSpeed / 10;
 	}
 
 	private void SnapBackward()
 	{
-		Position += Forward * -_moveSpeed / 10;
+		Position += Forward * _moveSpeed / 10;
 	}
 
 	public void ReceiveDragTouchInput(InputEventScreenDrag dragEvent)


### PR DESCRIPTION
…eing flipped.

## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Fixed SnapForward and SnapBackwards functions within the camera.cs being flipped.
You would zoom in when you scrolled down and zoom out when you scrolled in.

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Describe AI use, or write "None" if not applicable -->
None