### PR TITLE
Reorganized Insert popup

### DIFF
--- a/Polytoria/scripts/creator/ui/ctxmenus/InsertMenuPopup.cs
+++ b/Polytoria/scripts/creator/ui/ctxmenus/InsertMenuPopup.cs
@@ -39,31 +39,17 @@ public partial class InsertMenuPopup : PopupPanel
 			"Truss",
 			"Mesh",
 			"Seat",
-		},
-		[new() { Title = "Lights" }] = new()
-		{
-			"PointLight",
-			"SpotLight"
-		},
-		[new() { Title = "Elements" }] = new()
-		{
+			"Model",
+			"Folder",
 			"Text3D",
 			"Image3D",
 			"Decal",
-			"Sound",
-			"Particles",
-			"NPC",
-			"GUI3D",
-			"Folder",
-			"Model",
-			"Tool",
-			"Marker3D",
 			"Camera",
 		},
-		[new() { Title = "Character", RecommendOn = [typeof(CharacterModel)] }] = new()
+		[new() { Title = "Lighting" }] = new()
 		{
-			"Accessory",
-			"Clothing",
+			"PointLight",
+			"SpotLight"
 		},
 		[new() { Title = "Scripting", RecommendOn = [typeof(ScriptService), typeof(Folder)] }] = new()
 		{
@@ -81,17 +67,20 @@ public partial class InsertMenuPopup : PopupPanel
 			"ColorValue",
 			"InstanceValue"
 		},
-		[new() { Title = "Skies", RecommendOn = [typeof(Lighting)] }] = new()
+		[new() { Title = "Effects" }] = new()
 		{
-			"ImageSky",
-			"GradientSky",
-			"ProceduralSky"
+			"Particles",
 		},
-		[new() { Title = "Physics" }] = new()
+		[new() { Title = "Audio" }] = new()
 		{
-			"RigidBody",
-			"BodyPosition",
-			"Grabbable",
+			"Sound",
+		},
+		[new() { Title = "Characters", RecommendOn = [typeof(CharacterModel)] }] = new()
+		{
+			"Accessory",
+			"Clothing",
+			"NPC",
+			"Tool",
 		},
 		/*
 		["Vehicles"] = new()
@@ -105,9 +94,10 @@ public partial class InsertMenuPopup : PopupPanel
 		{
 			"ColorAdjustModifier",
 		},
-		[new() { Title = "UIs", RecommendOn = [typeof(UIField), typeof(GUI), typeof(GUI3D), typeof(PlayerGUI)] }] = new()
+		[new() { Title = "UI", RecommendOn = [typeof(UIField), typeof(GUI), typeof(GUI3D), typeof(PlayerGUI)] }] = new()
 		{
 			"GUI",
+			"GUI3D",
 			"UIView",
 			"UILabel",
 			"UIButton",
@@ -121,13 +111,29 @@ public partial class InsertMenuPopup : PopupPanel
 			"UIScrollView",
 			"UIViewport",
 		},
+		[new() { Title = "Teams", RecommendOn = [typeof(Teams)] }] = new()
+		{
+			"Team",
+		},
 		[new() { Title = "Stats", RecommendOn = [typeof(Stats)] }] = new()
 		{
 			"Stat",
 		},
-		[new() { Title = "Teams", RecommendOn = [typeof(Teams)] }] = new()
+		[new() { Title = "Skies", RecommendOn = [typeof(Lighting)] }] = new()
 		{
-			"Team",
+			"ImageSky",
+			"GradientSky",
+			"ProceduralSky"
+		},
+		[new() { Title = "Physics" }] = new()
+		{
+			"RigidBody",
+			"BodyPosition",
+			"Grabbable",
+		},
+		[new() { Title = "Gizmos" }] = new()
+		{
+			"Marker3D",
 		},
 	};
 


### PR DESCRIPTION
Reorganized the Insert popup menu into clearer more descriptive categories with improved ordering.

## Summary
I reordered and split categories in the insert popup menu as well as renamed a few categories for better consistency. Each cattegory is now more specific and now there is no longer a "everything" cattegory (aka Elements). I am not too familiar with Polytorias engine, so I ordered the categories based on what felt right, I do not expect this PR to get accepted immediatly, there are likely problems with it. 

This started from me being annoyed that the "UI" cattegory was called "UIs", but then I realized the inconsistancy in the categories.
## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
https://github.com/user-attachments/assets/1207f8ff-1511-4c3d-bf69-1c33d950f762

## AI/LLM use

None