### PR TITLE
Prevent certain special characters in project names

### DIFF
--- a/Polytoria/scripts/creator/ui/wizards/new_project/NewProjectWizard.cs
+++ b/Polytoria/scripts/creator/ui/wizards/new_project/NewProjectWizard.cs
@@ -19,9 +19,6 @@ public partial class NewProjectWizard : Control
 	public const string DefaultProjectName = "MyProject";
 	public bool ReturnToSplash = false;
 
-	private static readonly char[] InvalidProjectNameChars =
-		[.. Path.GetInvalidFileNameChars(), '\\', '/', ':', '*', '?', '"', '<', '>', '|'];
-
 	[Export] private LineEdit _projectNameEdit = null!;
 	[Export] private LineEdit _projectPathEdit = null!;
 	[Export] private Button _pathBrowseBtn = null!;
@@ -56,7 +53,7 @@ public partial class NewProjectWizard : Control
 	{
 		if (_isSanitizing) return;
 
-		string cleansedName = string.Join("_", newText.Split(InvalidProjectNameChars));
+		string cleansedName = newText.SanitizeFileName();
 
 		if (cleansedName != newText)
 		{
@@ -138,7 +135,7 @@ public partial class NewProjectWizard : Control
 				return;
 			}
 
-			if (projName.IndexOfAny(InvalidProjectNameChars) >= 0)
+			if (projName != projName.SanitizeFileName())
 			{
 				CreatorService.Interface.PopupAlert("Project name contains invalid characters");
 				return;

--- a/Polytoria/scripts/creator/ui/wizards/new_project/NewProjectWizard.cs
+++ b/Polytoria/scripts/creator/ui/wizards/new_project/NewProjectWizard.cs
@@ -19,6 +19,9 @@ public partial class NewProjectWizard : Control
 	public const string DefaultProjectName = "MyProject";
 	public bool ReturnToSplash = false;
 
+	private static readonly char[] InvalidProjectNameChars =
+		[..Path.GetInvalidFileNameChars(), '\\', '/', ':', '*', '?', '"', '<', '>', '|'];
+
 	[Export] private LineEdit _projectNameEdit = null!;
 	[Export] private LineEdit _projectPathEdit = null!;
 	[Export] private Button _pathBrowseBtn = null!;
@@ -29,6 +32,7 @@ public partial class NewProjectWizard : Control
 	private ButtonGroup _templateBtnGroup = new();
 	private string _targetTemplatePath = "";
 	private string _oldNameText = "";
+	private bool _isSanitizing = false;
 
 	public static NewProjectWizard Singleton { get; private set; } = null!;
 
@@ -50,12 +54,25 @@ public partial class NewProjectWizard : Control
 
 	private void OnNameEditTextChanged(string newText)
 	{
-		if (_projectPathEdit.Text.EndsWith(_oldNameText))
+		if (_isSanitizing) return;
+
+		string cleansedName = string.Join("_", newText.Split(InvalidProjectNameChars));
+
+		if (cleansedName != newText)
 		{
-			_projectPathEdit.Text = _projectPathEdit.Text.GetBaseDir().PathJoin(newText);
+			_isSanitizing = true;
+			int caret = _projectNameEdit.CaretColumn;
+			_projectNameEdit.Text = cleansedName;
+			_projectNameEdit.CaretColumn = Math.Min(caret, cleansedName.Length);
+			_isSanitizing = false;
 		}
 
-		_oldNameText = newText;
+		if (_projectPathEdit.Text.EndsWith(_oldNameText))
+		{
+			_projectPathEdit.Text = _projectPathEdit.Text.GetBaseDir().PathJoin(cleansedName);
+		}
+
+		_oldNameText = cleansedName;
 	}
 
 	private void OnTemplateBtnPressed(BaseButton button)
@@ -121,6 +138,12 @@ public partial class NewProjectWizard : Control
 				return;
 			}
 
+			if (projName.IndexOfAny(InvalidProjectNameChars) >= 0)
+			{
+				CreatorService.Interface.PopupAlert("Project name contains invalid characters");
+				return;
+			}
+
 			if (string.IsNullOrWhiteSpace(projPath))
 			{
 				CreatorService.Interface.PopupAlert("Please specify a folder to create project on");
@@ -144,9 +167,7 @@ public partial class NewProjectWizard : Control
 				}
 				else
 				{
-
 					await ProjectManager.NewProjectFromTemplate(projPath, _targetTemplatePath, new() { ProjectName = projName });
-
 				}
 			}
 			catch (Exception ex)

--- a/Polytoria/scripts/creator/ui/wizards/new_project/NewProjectWizard.cs
+++ b/Polytoria/scripts/creator/ui/wizards/new_project/NewProjectWizard.cs
@@ -20,7 +20,7 @@ public partial class NewProjectWizard : Control
 	public bool ReturnToSplash = false;
 
 	private static readonly char[] InvalidProjectNameChars =
-		[..Path.GetInvalidFileNameChars(), '\\', '/', ':', '*', '?', '"', '<', '>', '|'];
+		[.. Path.GetInvalidFileNameChars(), '\\', '/', ':', '*', '?', '"', '<', '>', '|'];
 
 	[Export] private LineEdit _projectNameEdit = null!;
 	[Export] private LineEdit _projectPathEdit = null!;

--- a/Polytoria/scripts/utils/Extensions.cs
+++ b/Polytoria/scripts/utils/Extensions.cs
@@ -6,6 +6,7 @@ using Godot;
 using System;
 using System.Globalization;
 using System.Linq;
+using System.IO;
 
 namespace Polytoria.Utils;
 
@@ -227,6 +228,14 @@ public static class StringExtension
 			ns = "";
 		}
 		return ns;
+	}
+
+	public static string SanitizeFileName(this string s)
+	{
+		char[] characters =
+			[.. Path.GetInvalidFileNameChars(), '\\', '/', ':', '*', '?', '"', '<', '>', '|'];
+
+		return string.Join("_", s.Split(characters));
 	}
 
 	public static string TrimExtension(this string s)

--- a/Polytoria/scripts/utils/Extensions.cs
+++ b/Polytoria/scripts/utils/Extensions.cs
@@ -213,6 +213,9 @@ public static class NodeExtension
 
 public static class StringExtension
 {
+	private static readonly char[] characters =
+			[.. Path.GetInvalidFileNameChars(), '\\', '/', ':', '*', '?', '"', '<', '>', '|'];
+			
 	public static string SanitizePath(this string s)
 	{
 		string ns = s.Replace('\\', '/');
@@ -232,9 +235,6 @@ public static class StringExtension
 
 	public static string SanitizeFileName(this string s)
 	{
-		char[] characters =
-			[.. Path.GetInvalidFileNameChars(), '\\', '/', ':', '*', '?', '"', '<', '>', '|'];
-
 		return string.Join("_", s.Split(characters));
 	}
 

--- a/Polytoria/scripts/utils/Extensions.cs
+++ b/Polytoria/scripts/utils/Extensions.cs
@@ -213,9 +213,9 @@ public static class NodeExtension
 
 public static class StringExtension
 {
-	private static readonly char[] characters =
+	private static readonly char[] InvalidFileNameChars =
 			[.. Path.GetInvalidFileNameChars(), '\\', '/', ':', '*', '?', '"', '<', '>', '|'];
-			
+
 	public static string SanitizePath(this string s)
 	{
 		string ns = s.Replace('\\', '/');
@@ -235,7 +235,7 @@ public static class StringExtension
 
 	public static string SanitizeFileName(this string s)
 	{
-		return string.Join("_", s.Split(characters));
+		return string.Join("_", s.Split(InvalidFileNameChars));
 	}
 
 	public static string TrimExtension(this string s)


### PR DESCRIPTION
## Summary

The splash screen new project modal now prevents certain special characters (as defined by the Path package) and ones that aren't included by default, to reduce/eliminate errors when constructing paths later on in the flow of loading/creating a world/project.

## Related issue or discussion

Fixes #199 
Related to #199 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

No visual changes.
N/A

## AI/LLM use

None