### PR TITLE
Set toolbox page to 1 on search

### DIFF
--- a/Polytoria/scripts/creator/ui/docks/toolbox/Toolbox.cs
+++ b/Polytoria/scripts/creator/ui/docks/toolbox/Toolbox.cs
@@ -72,6 +72,7 @@ public sealed partial class Toolbox : Control
 	{
 		if (SearchQuery == _searchEdit.Text) return;
 		SearchQuery = _searchEdit.Text;
+		CurrentPage = 1;
 		Refresh();
 	}
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
This PR sets the toolbox page to 1 when searching. Searching currently causes the page to stay the same which ends up with Page 2 of 1 etc. Simple one line fix.


## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
None
<!-- Describe AI use, or write "None" if not applicable -->