### PR TITLE
Implement Auto rendering device setting

### DIFF
--- a/Polytoria/scripts/client/settings/ClientSettingsService.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingsService.cs
@@ -14,6 +14,7 @@ namespace Polytoria.Client.Settings;
 public sealed partial class ClientSettingsService : SettingsServiceBase
 {
 	private const string SettingsPathConst = "user://settings_client.json";
+	private const string RenderingMethodMigrationPath = "user://rendering_method_migration";
 	public static ClientSettingsService Instance { get; private set; } = null!;
 
 	public ClientEntry Entry { get; init; } = null!;
@@ -30,6 +31,7 @@ public sealed partial class ClientSettingsService : SettingsServiceBase
 	{
 		bool settingsExists = FileAccess.FileExists(SettingsPathConst);
 		Load();
+		MigrateRenderingMethod();
 		ApplyDefaults();
 
 		if (!settingsExists)
@@ -46,10 +48,43 @@ public sealed partial class ClientSettingsService : SettingsServiceBase
 		}
 
 		RenderingMethodOption renderingMethod = Get<RenderingMethodOption>(SharedSettingKeys.Graphics.RenderingMethod);
-		RenderingDeviceSwitcher.Switch(RenderingDeviceSwitcher.FromRenderingMethodOption(renderingMethod));
+		RenderingDeviceSwitcher.Switch(renderingMethod);
 
 		if (!settingsExists)
 			QueueSave();
+	}
+
+	private void MigrateRenderingMethod()
+	{
+		if (FileAccess.FileExists(RenderingMethodMigrationPath))
+		{
+			return;
+		}
+
+		try
+		{
+			if (_values.TryGetValue(SharedSettingKeys.Graphics.RenderingMethod, out object? rawValue))
+			{
+				RenderingMethodOption renderingMethod = (RenderingMethodOption)ClientSettingsRegistry.Definitions[SharedSettingKeys.Graphics.RenderingMethod].ConvertToType(rawValue);
+				PT.Print("Current rendering method: " + renderingMethod);
+				if (renderingMethod == RenderingMethodOption.Standard)
+				{
+					Set(SharedSettingKeys.Graphics.RenderingMethod, RenderingMethodOption.Auto);
+					PT.Print("Migrated rendering method setting to Auto");
+				}
+				else
+				{
+					PT.Print("No migration needed for rendering method");
+				}
+			}
+
+			using var file = FileAccess.Open(RenderingMethodMigrationPath, FileAccess.ModeFlags.Write);
+			file.StoreString(Globals.AppVersion);
+		}
+		catch (Exception e)
+		{
+			PT.PrintErr("Failed to migrate rendering method setting: " + e);
+		}
 	}
 
 	private void SetupBenchmark(GraphicsBenchmarker benchmarker)

--- a/Polytoria/scripts/creator/settings/CreatorSettingsService.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingsService.cs
@@ -15,6 +15,7 @@ namespace Polytoria.Creator.Settings;
 public sealed partial class CreatorSettingsService : SettingsServiceBase
 {
 	private const string SettingsPathConst = "user://creator/creator_settings.json";
+	private const string RenderingMethodMigrationPath = "user://creator/rendering_method_migration";
 	public static CreatorSettingsService Instance { get; private set; } = null!;
 
 	private static readonly Dictionary<string, string> OldToNewKeyMap = new()
@@ -48,13 +49,14 @@ public sealed partial class CreatorSettingsService : SettingsServiceBase
 	{
 		MigrateFromOldFormat();
 		Load();
+		MigrateRenderingMethod();
 		ApplyDefaults();
 
 		if (!FileAccess.FileExists(SettingsPathConst))
 			Set(SharedSettingKeys.Graphics.Preset, GraphicsPreset.Medium);
 
 		RenderingMethodOption renderingMethod = Get<RenderingMethodOption>(SharedSettingKeys.Graphics.RenderingMethod);
-		RenderingDeviceSwitcher.Switch(RenderingDeviceSwitcher.FromRenderingMethodOption(renderingMethod));
+		RenderingDeviceSwitcher.Switch(renderingMethod);
 	}
 
 	[RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Deserialize<TValue>(String, JsonSerializerOptions)")]
@@ -119,6 +121,39 @@ public sealed partial class CreatorSettingsService : SettingsServiceBase
 		catch (Exception e)
 		{
 			PT.PrintErr($"Failed to migrate creator settings: {e}");
+		}
+	}
+
+	private void MigrateRenderingMethod()
+	{
+		if (FileAccess.FileExists(RenderingMethodMigrationPath))
+		{
+			return;
+		}
+
+		try
+		{
+			if (_values.TryGetValue(SharedSettingKeys.Graphics.RenderingMethod, out object? rawValue))
+			{
+				RenderingMethodOption renderingMethod = (RenderingMethodOption)CreatorSettingsRegistry.Definitions[SharedSettingKeys.Graphics.RenderingMethod].ConvertToType(rawValue);
+				PT.Print("Current rendering method: " + renderingMethod);
+				if (renderingMethod == RenderingMethodOption.Standard)
+				{
+					Set(SharedSettingKeys.Graphics.RenderingMethod, RenderingMethodOption.Auto);
+					PT.Print("Migrated rendering method setting to Auto");
+				}
+				else
+				{
+					PT.Print("No migration needed for rendering method");
+				}
+			}
+
+			using var file = FileAccess.Open(RenderingMethodMigrationPath, FileAccess.ModeFlags.Write);
+			file.StoreString(Globals.AppVersion);
+		}
+		catch (Exception e)
+		{
+			PT.PrintErr("Failed to migrate rendering method setting: " + e);
 		}
 	}
 

--- a/Polytoria/scripts/shared/RenderingDeviceSwitcher.cs
+++ b/Polytoria/scripts/shared/RenderingDeviceSwitcher.cs
@@ -5,6 +5,7 @@
 using Godot;
 using Polytoria.Shared.Settings;
 using System;
+using System.Collections.Generic;
 
 namespace Polytoria.Shared;
 
@@ -17,9 +18,21 @@ public static class RenderingDeviceSwitcher
 			RenderingMethodOption.Standard => RenderingDeviceEnum.Forward,
 			RenderingMethodOption.Performance => RenderingDeviceEnum.Mobile,
 			RenderingMethodOption.Compatibility => RenderingDeviceEnum.GLCompatibility,
+			RenderingMethodOption.Auto => throw new ArgumentException("Auto does not map to rendering device"),
 			_ => RenderingDeviceEnum.Forward
 		};
 	}
+
+	public static void Switch(RenderingMethodOption option)
+	{
+		if (option == RenderingMethodOption.Auto)
+		{
+			return;
+		}
+
+		Switch(FromRenderingMethodOption(option));
+	}
+
 	public static void Switch(RenderingDeviceEnum to)
 	{
 		// Mobile are locked to one renderer only, don't change
@@ -42,9 +55,38 @@ public static class RenderingDeviceSwitcher
 		}
 
 		string exePath = OS.GetExecutablePath();
-		OS.CreateProcess(exePath, [.. args, "--rendering-method", renderingName, "-rmswignore"]);
+		OS.CreateProcess(exePath, GetRestartArgs(args, renderingName));
 		Globals.Singleton.Quit(force: true);
 		throw new SwitchingRenderingDeviceException();
+	}
+
+	private static string[] GetRestartArgs(string[] args, string renderingName)
+	{
+		List<string> filtered = new List<string>();
+
+		for (int i = 0; i < args.Length; i++)
+		{
+			string arg = args[i];
+
+			if (arg == "--rendering-method" || arg == "--rendering-driver")
+			{
+				if (i + 1 < args.Length && !args[i + 1].StartsWith('-'))
+					i++;
+
+				continue;
+			}
+
+			if (arg == "-rmswignore" || arg == "--rmswignore")
+				continue;
+
+			filtered.Add(arg);
+		}
+
+		filtered.Add("--rendering-method");
+		filtered.Add(renderingName);
+		filtered.Add("-rmswignore");
+
+		return filtered.ToArray();
 	}
 
 	public static string GetCurrentDriverName()

--- a/Polytoria/scripts/shared/RenderingDeviceSwitcher.cs
+++ b/Polytoria/scripts/shared/RenderingDeviceSwitcher.cs
@@ -55,7 +55,10 @@ public static class RenderingDeviceSwitcher
 		}
 
 		string exePath = OS.GetExecutablePath();
+
+		// rebuild command line arguments, replaces existing rendering method argument with the new one
 		OS.CreateProcess(exePath, GetRestartArgs(args, renderingName));
+		
 		Globals.Singleton.Quit(force: true);
 		throw new SwitchingRenderingDeviceException();
 	}
@@ -68,6 +71,7 @@ public static class RenderingDeviceSwitcher
 		{
 			string arg = args[i];
 
+			// skip existing rendering method arguments
 			if (arg == "--rendering-method" || arg == "--rendering-driver")
 			{
 				if (i + 1 < args.Length && !args[i + 1].StartsWith('-'))

--- a/Polytoria/scripts/shared/RenderingDeviceSwitcher.cs
+++ b/Polytoria/scripts/shared/RenderingDeviceSwitcher.cs
@@ -76,7 +76,7 @@ public static class RenderingDeviceSwitcher
 				continue;
 			}
 
-			if (arg == "-rmswignore" || arg == "--rmswignore")
+			if (arg == "-rmswignore")
 				continue;
 
 			filtered.Add(arg);

--- a/Polytoria/scripts/shared/settings/SharedSettingEnums.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingEnums.cs
@@ -16,9 +16,10 @@ public enum GraphicsPreset
 
 public enum RenderingMethodOption
 {
-	Standard,
-	Performance,
-	Compatibility
+	Auto = -1,
+	Standard = 0,
+	Performance = 1,
+	Compatibility = 2
 }
 
 public enum ShadowQuality

--- a/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
@@ -79,10 +79,11 @@ public static class SharedSettingsRegistry
 					Description = "Rendering method to use. Use compatibility on older hardware.",
 					ValueKind = SettingValueKind.Enum,
 					ControlKind = SettingControlKind.Dropdown,
-					DefaultValue = RenderingMethodOption.Standard,
+					DefaultValue = RenderingMethodOption.Auto,
 					RequiresRestart = true,
 					Options =
 					[
+						new() { Value = RenderingMethodOption.Auto, Label = "Auto" },
 						new() { Value = RenderingMethodOption.Standard, Label = "Standard" },
 						new() { Value = RenderingMethodOption.Performance, Label = "Performance" },
 						new() { Value = RenderingMethodOption.Compatibility, Label = "Compatibility" },


### PR DESCRIPTION
## Summary

Polytoria currently forces Standard (Forward+) as the default rendering method which overrides Godot's automatic fallback. This PR adds the new default RenderingMethodOption.Auto option which doesn't force a specific rendering method and adds migrations for the Standard rendering method. This should fix most issues related to crashes/grey screens on launch.

## Related issue or discussion

Fixes #100 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="1213" height="228" alt="image" src="https://github.com/user-attachments/assets/2b1cb4c7-b2f6-4ba5-a65d-645bac7a73f8" />

## AI/LLM use

Inline auto suggestions by Copilot