### PR TITLE
Pause chat scroll if not at bottom

### DIFF
--- a/Polytoria/scripts/client/ui/chat/UIChat.cs
+++ b/Polytoria/scripts/client/ui/chat/UIChat.cs
@@ -189,11 +189,17 @@ public partial class UIChat : Control
 		}
 		_chatLayout.AddChild(chatLabel);
 		_chatMessages.Add(chatLabel);
+
+		// Scroll to the bottom only if the chat is at the bottom
+		VScrollBar vScrollBar = _chatScroll.GetVScrollBar();
+		bool atBottom = vScrollBar.Value + 5 >= (vScrollBar.MaxValue - vScrollBar.Page);
 		Callable.From(() =>
 		{
-			// TODO: Come back and check if user has scrolled or not, before updating the vertical
-			int scrollVal = (int)_chatScroll.GetVScrollBar().MaxValue + 1000;
-			_chatScroll.SetDeferred(ScrollContainer.PropertyName.ScrollVertical, scrollVal);
+			if (atBottom)
+			{
+				int scrollVal = (int)vScrollBar.MaxValue + 1000;
+				_chatScroll.SetDeferred(ScrollContainer.PropertyName.ScrollVertical, scrollVal);
+			}
 		}).CallDeferred();
 
 		// Clean up old chat logs

--- a/Polytoria/scripts/client/ui/chat/UIChat.cs
+++ b/Polytoria/scripts/client/ui/chat/UIChat.cs
@@ -193,14 +193,14 @@ public partial class UIChat : Control
 		// Scroll to the bottom only if the chat is at the bottom
 		VScrollBar vScrollBar = _chatScroll.GetVScrollBar();
 		bool atBottom = vScrollBar.Value + 5 >= (vScrollBar.MaxValue - vScrollBar.Page);
-		Callable.From(() =>
+		if (atBottom)
 		{
-			if (atBottom)
+			PT.CallDeferred(() =>
 			{
 				int scrollVal = (int)vScrollBar.MaxValue + 1000;
 				_chatScroll.SetDeferred(ScrollContainer.PropertyName.ScrollVertical, scrollVal);
-			}
-		}).CallDeferred();
+			});
+		}
 
 		// Clean up old chat logs
 		if (_chatMessages.Count > MaxMessages)


### PR DESCRIPTION
## Summary
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

Chat currently always scrolls to the bottom when a new message appears regardless of whether or not the user has scrolled up. This PR pauses chat scroll if it is not at the bottom, with a bit of lenience. This is my first time working with C#/Godot so it might not be the best way possible lol.

## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/4a72a573-7dc3-4000-801e-3aff3a2a0579

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
<!-- Describe AI use, or write "None" if not applicable -->

Used to understand how the scrolling part of UIChat.cs worked. All code is handwritten.