### PR TITLE
Add LinearNoMipmaps and NearestNoMipmaps to TextureFilterEnum

### DIFF
--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -169,6 +169,7 @@ public sealed partial class Image3D : Dynamic
 			_material.TextureFilter = value switch
 			{
 				TextureFilterEnum.Nearest => BaseMaterial3D.TextureFilterEnum.NearestWithMipmaps,
+				TextureFilterEnum.NearestNoMipmaps => BaseMaterial3D.TextureFilterEnum.Nearest,
 				TextureFilterEnum.Linear => BaseMaterial3D.TextureFilterEnum.LinearWithMipmaps,
 				TextureFilterEnum.LinearNoMipmaps => BaseMaterial3D.TextureFilterEnum.Linear,
 				_ => throw new IndexOutOfRangeException("Texture filter mode out of range"),

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -170,6 +170,7 @@ public sealed partial class Image3D : Dynamic
 			{
 				TextureFilterEnum.Nearest => BaseMaterial3D.TextureFilterEnum.NearestWithMipmaps,
 				TextureFilterEnum.Linear => BaseMaterial3D.TextureFilterEnum.LinearWithMipmaps,
+				TextureFilterEnum.LinearNoMipmaps => BaseMaterial3D.TextureFilterEnum.Linear,
 				_ => throw new IndexOutOfRangeException("Texture filter mode out of range"),
 			};
 			OnPropertyChanged();

--- a/Polytoria/scripts/datamodel/Particles.cs
+++ b/Polytoria/scripts/datamodel/Particles.cs
@@ -98,6 +98,7 @@ public sealed partial class Particles : Dynamic
 			_material.TextureFilter = value switch
 			{
 				TextureFilterEnum.Nearest => BaseMaterial3D.TextureFilterEnum.NearestWithMipmaps,
+				TextureFilterEnum.NearestNoMipmaps => BaseMaterial3D.TextureFilterEnum.Nearest,
 				TextureFilterEnum.Linear => BaseMaterial3D.TextureFilterEnum.LinearWithMipmaps,
 				TextureFilterEnum.LinearNoMipmaps => BaseMaterial3D.TextureFilterEnum.Linear,
 				_ => throw new IndexOutOfRangeException("Texture filter mode out of range"),

--- a/Polytoria/scripts/datamodel/Particles.cs
+++ b/Polytoria/scripts/datamodel/Particles.cs
@@ -99,6 +99,7 @@ public sealed partial class Particles : Dynamic
 			{
 				TextureFilterEnum.Nearest => BaseMaterial3D.TextureFilterEnum.NearestWithMipmaps,
 				TextureFilterEnum.Linear => BaseMaterial3D.TextureFilterEnum.LinearWithMipmaps,
+				TextureFilterEnum.LinearNoMipmaps => BaseMaterial3D.TextureFilterEnum.Linear,
 				_ => throw new IndexOutOfRangeException("Texture filter mode out of range"),
 			};
 			OnPropertyChanged();

--- a/Polytoria/scripts/datamodel/UIImage.cs
+++ b/Polytoria/scripts/datamodel/UIImage.cs
@@ -118,6 +118,7 @@ public partial class UIImage : UIField
 			GDTextureRect.TextureFilter = value switch
 			{
 				TextureFilterEnum.Nearest => CanvasItem.TextureFilterEnum.Nearest,
+				TextureFilterEnum.NearestNoMipmaps => CanvasItem.TextureFilterEnum.Nearest,
 				TextureFilterEnum.Linear => CanvasItem.TextureFilterEnum.Linear,
 				TextureFilterEnum.LinearNoMipmaps => CanvasItem.TextureFilterEnum.Linear,
 				_ => throw new IndexOutOfRangeException("Texture filter mode out of range"),

--- a/Polytoria/scripts/datamodel/UIImage.cs
+++ b/Polytoria/scripts/datamodel/UIImage.cs
@@ -119,6 +119,7 @@ public partial class UIImage : UIField
 			{
 				TextureFilterEnum.Nearest => CanvasItem.TextureFilterEnum.Nearest,
 				TextureFilterEnum.Linear => CanvasItem.TextureFilterEnum.Linear,
+				TextureFilterEnum.LinearNoMipmaps => CanvasItem.TextureFilterEnum.Linear,
 				_ => throw new IndexOutOfRangeException("Texture filter mode out of range"),
 			};
 			OnPropertyChanged();

--- a/Polytoria/scripts/enums/TextureFilter.cs
+++ b/Polytoria/scripts/enums/TextureFilter.cs
@@ -3,5 +3,6 @@ namespace Polytoria.Enums;
 public enum TextureFilterEnum
 {
 	Nearest,
-	Linear
+	Linear,
+	LinearNoMipmaps
 }

--- a/Polytoria/scripts/enums/TextureFilter.cs
+++ b/Polytoria/scripts/enums/TextureFilter.cs
@@ -3,6 +3,7 @@ namespace Polytoria.Enums;
 public enum TextureFilterEnum
 {
 	Nearest,
+	NearestNoMipmaps,
 	Linear,
 	LinearNoMipmaps
 }


### PR DESCRIPTION
## Summary

Adds the LinearNoMipmaps and NearestNoMipmaps options to TextureFilterEnum

## Related issue or discussion

Related to #203 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="2665" height="1578" alt="image" src="https://github.com/user-attachments/assets/c7e9c224-3935-45f3-8edf-36acb02d1fed" />
<img width="2676" height="1579" alt="image" src="https://github.com/user-attachments/assets/0e4f5c8d-1afa-4902-b094-5063f4569f8f" />


## AI/LLM use

None