### PR TITLE
Fix Clothing layer rebuild causing high VRAM

### DIFF
--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -467,7 +467,7 @@ public sealed partial class PolytorianModel : CharacterModel
 		StandardMaterial3D? DuplicateWithColor(StandardMaterial3D? source, StandardMaterial3D? previous)
 		{
 			if (source == null) return null;
-			var dup = (StandardMaterial3D)source.Duplicate(true);
+			var dup = (StandardMaterial3D)source.Duplicate();
 			if (previous != null) dup.AlbedoColor = previous.AlbedoColor;
 			return dup;
 		}


### PR DESCRIPTION
## Summary

Previously, during clothing layer rebuild, it would duplicate the clothing material. This is to ensure the color is separated. Though the deep parameter is causing clothing textures to be duplicated and unused in VRAM, it is not required. This builds up quickly in places with multiple players playing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Before
<img width="247" height="78" alt="image" src="https://github.com/user-attachments/assets/66fb76b5-4c2e-4a3d-acf1-8b98ce69bb39" />

After
<img width="233" height="81" alt="image" src="https://github.com/user-attachments/assets/7d964539-9704-43cb-bb31-0b937fb6e54d" />

*tested with 3 players*

## AI/LLM use

None