### PR TITLE
Gamepad sprint toggle fix

### DIFF
--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -33,17 +33,18 @@ public class DefaultMovement : IPlayerMovement
 			moveDirection.Z = backwardStrength - forwardStrength;
 			moveDirection = moveDirection.Rotated(Vector3.Up, facingRot.Y).LimitLength(1);
 
+			bool initialSprintOverride = Target.SprintOverride;
 			jump = Input.IsActionPressed("jump");
-			sprint = Input.IsActionPressed("sprint") || Target.SprintOverride;
+			sprint = Input.IsActionPressed("sprint") || initialSprintOverride;
 
 			if (Target.SprintHoldAgain)
 			{
 				sprint = false;
-			}
-
-			if (Input.IsActionJustReleased("sprint"))
-			{
-				Target.SprintHoldAgain = false;
+				Target.SprintOverride = false;
+				if (Input.IsActionJustReleased("sprint") || initialSprintOverride)
+				{
+					Target.SprintHoldAgain = false;
+				}
 			}
 
 			camLocked = cam.IsFirstPerson || cam.CtrlLocked;

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -39,8 +39,7 @@ public class DefaultMovement : IPlayerMovement
 
 			if (Target.SprintHoldAgain)
 			{
-				sprint = false;
-				Target.SprintOverride = false;
+				sprint = Target.SprintOverride = false;
 				if (Input.IsActionJustReleased("sprint") || initialSprintOverride)
 				{
 					Target.SprintHoldAgain = false;


### PR DESCRIPTION
## Summary

changed sprinting logic a little. `Player.SprintHoldAgain` is set to false when `Player.SprintOverride` is true (or the sprint key was just released), and `Player.SprintOverride` is set to false when `Player.SprintHoldAgain` is true

## Related issue or discussion

Fixes #210

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None