### PR TITLE
Fix find and replace UI placement

### DIFF
--- a/Polytoria/scenes/creator/tabs/text_editor/text_editor.tscn
+++ b/Polytoria/scenes/creator/tabs/text_editor/text_editor.tscn
@@ -88,12 +88,6 @@ vertical_alignment = 1
 autowrap_mode = 3
 
 [node name="Finder" parent="." unique_id=495200113 instance=ExtResource("3_ypnaf")]
-layout_mode = 0
-anchors_preset = 0
-anchor_left = 0.0
-anchor_right = 0.0
-offset_left = 0.0
-offset_top = 36.0
-offset_right = 1152.0
-offset_bottom = 36.0
-grow_horizontal = 1
+layout_mode = 1
+offset_left = -102.0
+offset_right = -102.0


### PR DESCRIPTION
## Summary

Fixed anchor of UI so it is anchored to the right side of the screen instead of the left

## Related issue or discussion

Fixes #180

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

## AI/LLM use

None