### PR TITLE
Gamepad camera sensitivity fix

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -20,6 +20,8 @@ public sealed partial class Camera : Dynamic
 	public const float ClipSafeMargin = 2.0f;
 	public const float DefaultZoomDistance = 10.0f;
 	public const float DefaultScrollSensitivity = 15.0f;
+	public const float GamepadSensitivity = 400.0f;
+
 	private CameraModeEnum _mode;
 	private float _fov;
 	private bool _clipThroughWalls;
@@ -421,7 +423,7 @@ public sealed partial class Camera : Dynamic
 				float xAxis = Input.GetAxis("cam_rightward", "cam_leftward");
 				float yAxis = Input.GetAxis("cam_downward", "cam_upward");
 
-				_targetRotation += new Vector3(yAxis, xAxis, 0) * Sensitivity;
+				_targetRotation += new Vector3(yAxis * 0.75f, xAxis, 0) * (Sensitivity * GamepadSensitivity * (float)delta);
 				LimitRotation();
 			}
 

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -422,7 +422,7 @@ public sealed partial class Camera : Dynamic
 				float xAxis = Input.GetAxis("cam_rightward", "cam_leftward");
 				float yAxis = Input.GetAxis("cam_downward", "cam_upward");
 
-				_targetRotation += new Vector3(yAxis * 270f, xAxis * 400f, 0) * (Sensitivity * (float)delta);
+				_targetRotation += new Vector3(yAxis * VerticalSpeed * 2, xAxis * HorizontalSpeed * 3, 0) * (Sensitivity * (float)delta);
 				LimitRotation();
 			}
 

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -20,7 +20,6 @@ public sealed partial class Camera : Dynamic
 	public const float ClipSafeMargin = 2.0f;
 	public const float DefaultZoomDistance = 10.0f;
 	public const float DefaultScrollSensitivity = 15.0f;
-	public const float GamepadSensitivity = 400.0f;
 
 	private CameraModeEnum _mode;
 	private float _fov;
@@ -423,7 +422,7 @@ public sealed partial class Camera : Dynamic
 				float xAxis = Input.GetAxis("cam_rightward", "cam_leftward");
 				float yAxis = Input.GetAxis("cam_downward", "cam_upward");
 
-				_targetRotation += new Vector3(yAxis * 0.75f, xAxis, 0) * (Sensitivity * GamepadSensitivity * (float)delta);
+				_targetRotation += new Vector3(yAxis * 270f, xAxis * 400f, 0) * (Sensitivity * (float)delta);
 				LimitRotation();
 			}
 

--- a/Polytoria/scripts/shared/RenderingDeviceSwitcher.cs
+++ b/Polytoria/scripts/shared/RenderingDeviceSwitcher.cs
@@ -58,7 +58,7 @@ public static class RenderingDeviceSwitcher
 
 		// rebuild command line arguments, replaces existing rendering method argument with the new one
 		OS.CreateProcess(exePath, GetRestartArgs(args, renderingName));
-		
+
 		Globals.Singleton.Quit(force: true);
 		throw new SwitchingRenderingDeviceException();
 	}


### PR DESCRIPTION
## Summary

makes gamepad sensitivity framerate independent + based on `Camera.HorizontalSpeed` and `Camera.VerticalSpeed`

## Related issue or discussion

Fixes #226

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img src=https://github.com/user-attachments/assets/1a838720-d14f-42c2-a6ce-140cf2ccd9d4>

## AI/LLM use

None