### PR TITLE
Make F8 toggle console instead of open

### DIFF
--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -266,7 +266,7 @@ delete={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194312,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
-open_console={
+toggle_console={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194339,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]

--- a/Polytoria/scripts/client/ui/CoreUIRoot.cs
+++ b/Polytoria/scripts/client/ui/CoreUIRoot.cs
@@ -75,9 +75,9 @@ public partial class CoreUIRoot : CanvasLayer
 		{
 			Visible = !Visible;
 		}
-		if (@event.IsActionPressed("open_console"))
+		if (@event.IsActionPressed("toggle_console"))
 		{
-			DevWindow.Popup();
+			DevWindow.Toggle();
 		}
 		base._UnhandledInput(@event);
 	}

--- a/Polytoria/scripts/client/ui/core/console/DevConsoleWindow.cs
+++ b/Polytoria/scripts/client/ui/core/console/DevConsoleWindow.cs
@@ -104,9 +104,9 @@ public partial class DevConsoleWindow : Control
 		base._ExitTree();
 	}
 
-	public void Popup()
+	public void Toggle()
 	{
-		Visible = true;
+		Visible = !Visible;
 	}
 
 	private void OnCloseRequested()


### PR DESCRIPTION
## Summary
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
The debug console is currently only closable with the close button which requires a cursor, very inconvenient. This PR changes F8 to toggle it rather than only open, like it was in 1.0. 

## Related issue or discussion
N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
None.
<!-- Describe AI use, or write "None" if not applicable -->