### PR TITLE
Add PTSignalConnection to ignored Luau definition gen types

### DIFF
--- a/Polytoria/scripts/docsgen/LuaDefinitionGenerator.cs
+++ b/Polytoria/scripts/docsgen/LuaDefinitionGenerator.cs
@@ -80,8 +80,8 @@ public class LuaDefinitionGenerator
 
 		foreach (ScriptClass item in refer.Classes)
 		{
-			// Ignore PTSignal, already declared
-			if (item.Name == "PTSignal") continue;
+			// Ignore already declared types
+			if (item.Name == "PTSignal" || item.Name == "PTSignalConnection") continue;
 
 			builder.AppendLine(GenerateClass(item));
 		}


### PR DESCRIPTION
## Summary

Adds `PTSignalConnection` to skipped classes when generating `def.d.luau`.

## Related issue or discussion

Fixes #178

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [X] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->

None