### PR TITLE
Use external name of enums in properties

### DIFF
--- a/Polytoria/scripts/docsgen/APIReferenceGenerator.cs
+++ b/Polytoria/scripts/docsgen/APIReferenceGenerator.cs
@@ -11,6 +11,7 @@ using Polytoria.Shared;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -489,6 +490,14 @@ public class APIReferenceGenerator
 		if (type == typeof(ValueType))
 		{
 			return null;
+		}
+
+		if (type.IsEnum)
+		{
+			// Find the Enum's external name
+			string name = ScriptService.EnumMap.FirstOrDefault(x => x.Value == type).Key;
+			if (!string.IsNullOrEmpty(name))
+				return name;
 		}
 
 		return type.Name;


### PR DESCRIPTION
## Summary

Changes class property definitions to use the external name of the enum instead of the internal (C#) name.

## Related issue or discussion

Fixes #179

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [X] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [X] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

## AI/LLM use

None