### PR TITLE
Add next() support to shared tables + ScriptTupleReturn Attribute Pro…

### DIFF
--- a/Polytoria/scripts/attributes/ScriptingAttributes.cs
+++ b/Polytoria/scripts/attributes/ScriptingAttributes.cs
@@ -55,6 +55,10 @@ public class ScriptMethodAttribute(string? methodName = null) : Attribute, IScri
 	/// </summary>
 	public bool GetParamsAsFunction { get; set; } = false;
 	public ScriptPermissionFlags Permissions { get; set; } = ScriptPermissionFlags.None;
+	/// <summary>
+	/// Should returning an object?[] array automatically unwrap into a lua tuple
+	/// </summary>
+	public bool ScriptTupleReturn { get; set; } = false;
 }
 
 [AttributeUsage(AttributeTargets.Parameter)]

--- a/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
@@ -62,7 +62,6 @@ public class LuaMetatable : LuaObject
 				tcs.SetResult(0);
 				return;
 			}
-
 			// --------------- HANDLE TASK --------------- 
 			if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
 			{
@@ -110,11 +109,18 @@ public class LuaMetatable : LuaObject
 					}
 					else if (task is Task<object?[]> objectArrayTask)
 					{
-						foreach (object? r in objectArrayTask.Result)
+						if (targetMethod.GetCustomAttribute<ScriptMethodAttribute>()?.ScriptTupleReturn == true)
 						{
-							LangProvider.PushValueToLua(state, r);
+							foreach (object? r in objectArrayTask.Result)
+							{
+								LangProvider.PushValueToLua(state, r);
+							}
+							tcs.SetResult(objectArrayTask.Result.Length);
 						}
-						tcs.SetResult(objectArrayTask.Result.Length);
+						else
+						{
+							LangProvider.PushValueToLua(state, objectArrayTask.Result);
+						}
 						return;
 					}
 					else
@@ -139,7 +145,6 @@ public class LuaMetatable : LuaObject
 	{
 		LuaState state = LuaState.FromIntPtr(L);
 		Script script = LuauProvider.GetScriptInstance(state);
-
 		object? targetObject = LangProvider.LuaToObject(state, 1, false);
 
 		if (IsThisInvalid(targetObject))
@@ -258,7 +263,6 @@ public class LuaMetatable : LuaObject
 			}
 		}
 
-		PropertyInfo? prop = ScriptService.GetScriptPropertyOfName(TargetType, key, script.Compatibility);
 		MethodInfo? method = ScriptService.ResolveMethod(script.Compatibility, key, TargetType);
 
 		if (method != null)
@@ -270,6 +274,7 @@ public class LuaMetatable : LuaObject
 				return (int)method.Invoke(targetObject, [state])!;
 			}
 		}
+		PropertyInfo? prop = ScriptService.GetScriptPropertyOfName(TargetType, key, script.Compatibility);
 
 		if (prop != null)
 		{
@@ -902,8 +907,14 @@ public class LuaMetatable : LuaObject
 		}
 		else
 		{
-			object? result = targetMethod.Invoke(targetObject, invokeArgs);
-			LangProvider.PushValueToLua(state, result);
+			object? @return = targetMethod.Invoke(targetObject, invokeArgs);
+			if (methodAttribute?.ScriptTupleReturn == true && @return is object?[] array)
+			{
+				foreach (object? r in array)
+					LangProvider.PushValueToLua(state, r);
+				return array.Length;
+			}
+			LangProvider.PushValueToLua(state, @return);
 			return 1;
 		}
 	}

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -13,6 +13,7 @@ using Polytoria.DatamodelTest;
 using Polytoria.Enums;
 using Polytoria.Scripting.Extensions;
 using Polytoria.Scripting.Libraries;
+using ScriptSharedTable = Polytoria.Scripting.ScriptSharedTable;
 using Polytoria.Shared;
 using System;
 using System.Collections;
@@ -114,6 +115,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		state.PushCFunction(LuaCoroutineResume, "coroutine.resume");
 		state.SetField(-2, "resume");
 
+		// Register custom coroutine.wrap
 		state.PushCFunction(LuaCoroutineWrap, "coroutine.wrap");
 		state.SetField(-2, "wrap");
 
@@ -198,6 +200,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		state.Register("time", LuaTime);
 		state.Register("require", LuaRequire);
 		state.Register("pcall", LuaPCall);
+		state.Register("next", LuaNext);
 
 #if DEBUG
 		// Test special function
@@ -397,6 +400,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 
 	private void RegisterLuaExtensions(LuaState state)
 	{
+
 		Script s = GetScriptInstance(state);
 		foreach ((string libName, Type type) in LuaExtensions)
 		{
@@ -411,6 +415,8 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 					if (attr == null)
 						continue;
 					HandlesLuaStateAttribute? handleLua = method.GetCustomAttribute<HandlesLuaStateAttribute>();
+
+					bool tupleReturn = attr.ScriptTupleReturn;
 
 					string methodName = attr.MethodName ?? method.Name;
 
@@ -436,6 +442,12 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 						try
 						{
 							object? val = method.Invoke(null, args);
+							if (tupleReturn && val is object?[] array)
+							{
+								foreach (object? r in array)
+									PushValueToLua(innerState, r);
+								return array.Length;
+							}
 							PushValueToLua(innerState, val);
 							return 1;
 						}
@@ -840,6 +852,28 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		return 0;
 	}
 
+	public int LuaNext(IntPtr L)
+	{
+		LuaState state = LuaState.FromIntPtr(L);
+		if (state.IsTable(1))
+		{
+			if (state.Next(1))
+				return 2;
+			return 0;
+		}
+		else if (LuaToObject(state, 1) is ScriptSharedTable shared)
+		{
+			(object? key, object? value) = shared.Next(LuaToObject(state, 2));
+			PushValueToLua(state, key);
+			PushValueToLua(state, value);
+			return 2;
+		}
+		else
+		{
+			state.TypeError(1, "table");
+			return 0;
+		}
+	}
 
 	public int LuaPCall(IntPtr L)
 	{
@@ -1028,7 +1062,6 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 
 		return task;
 	}
-
 	public void PushValueToLua(LuaState state, object? value)
 	{
 		Type? valType = value?.GetType();

--- a/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
@@ -610,6 +610,7 @@ public partial class LuaState : IDisposable
 		}
 	}
 
+	// Unused...
 	public void Sandbox()
 	{
 		lock (_lock)
@@ -673,7 +674,11 @@ public partial class LuaState : IDisposable
 		lock (_lock)
 			return NativeBindings.luaL_errorL(_state, message);
 	}
-
+	public int TypeError(int narg, string tname)
+	{
+		lock (_lock)
+			return NativeBindings.luaL_typeerrorL(_state, narg, tname);
+	}
 	public void PushLightUserdataTagged(IntPtr p, int tag = 0)
 	{
 		lock (_lock)

--- a/Polytoria/scripts/scripting/languages/luau/native/NativeBindings.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/NativeBindings.cs
@@ -255,6 +255,10 @@ internal partial class NativeBindings
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	internal static partial int lua_error(IntPtr luaState);
 
+	[LibraryImport(LuaLibraryName, StringMarshalling = StringMarshalling.Utf8)]
+	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+	internal static partial int luaL_typeerrorL(IntPtr luaState, int narg, string tname);
+
 	[LibraryImport(LuaLibraryName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	internal static partial IntPtr lua_newuserdatauv(IntPtr luaState, UIntPtr size, int nuvalue);

--- a/Polytoria/scripts/scripting/misc/ScriptSharedTable.cs
+++ b/Polytoria/scripts/scripting/misc/ScriptSharedTable.cs
@@ -4,33 +4,51 @@
 
 using Polytoria.Attributes;
 using System.Collections.Generic;
+using Polytoria.Shared;
+using System;
+using Polytoria.Scripting;
 
 namespace Polytoria.Scripting;
 
 public partial class ScriptSharedTable : IScriptObject
 {
-	internal Dictionary<object, object> SharedDict = [];
+	internal record class Entry
+	{
+		public object Key { get; set; }
+		public object Value { get; set; }
+		public Entry(object Key, object Value)
+		{
+			this.Key = Key;
+			this.Value = Value;
+		}
+	}
+	internal Dictionary<object, LinkedListNode<Entry>> NodeDict = [];
+	internal LinkedList<Entry> KeyLinkedList = new();
 
 	[ScriptMethod]
 	public void Clear()
 	{
-		SharedDict.Clear();
+		NodeDict.Clear();
+		KeyLinkedList.Clear();
 	}
-
 	[ScriptMethod]
 	public void Remove(string key)
 	{
-		SharedDict.Remove(key);
+		if (NodeDict.Remove(key, out LinkedListNode<Entry> node))
+		{
+			KeyLinkedList.Remove(node);
+		}
 	}
 
 	[ScriptMethod]
 	public void ClearPrefix(string prefix)
 	{
-		foreach ((object key, _) in SharedDict)
+		foreach ((object key, LinkedListNode<Entry> node) in NodeDict)
 		{
 			if (key is string strk && strk.StartsWith(prefix))
 			{
-				SharedDict.Remove(key);
+				NodeDict.Remove(key);
+				KeyLinkedList.Remove(node);
 			}
 		}
 	}
@@ -38,41 +56,72 @@ public partial class ScriptSharedTable : IScriptObject
 	[ScriptMethod]
 	public void ClearSuffix(string suffix)
 	{
-		foreach ((object key, _) in SharedDict)
+		foreach ((object key, LinkedListNode<Entry> node) in NodeDict)
 		{
 			if (key is string strk && strk.EndsWith(suffix))
 			{
-				SharedDict.Remove(key);
+				NodeDict.Remove(key);
+				KeyLinkedList.Remove(node);
 			}
+		}
+	}
+	public (object?, object?) Next(object? index)
+	{
+		if (index != null)
+		{
+			if (NodeDict.TryGetValue(index, out LinkedListNode<Entry> node))
+			{
+				return node.Next?.Value is { } pair ? (pair.Key, pair.Value) : (null, null);
+			}
+			else
+			{
+				throw new Exception("invalid key to 'next'");
+			}
+		}
+		else
+		{
+			return (KeyLinkedList.First?.Value is { } pair) ? (pair.Key, pair.Value) : (null, null);
 		}
 	}
 
 	[ScriptMetamethod(ScriptObjectMetamethod.Index)]
 	public object? Index(object index)
 	{
-		if (SharedDict.TryGetValue(index, out object? value))
+		if (NodeDict.TryGetValue(index, out LinkedListNode<Entry> node))
 		{
-			return value;
+			return node.Value;
 		}
 		return null;
 	}
 
 	[ScriptMetamethod(ScriptObjectMetamethod.NewIndex)]
-	public void NewIndex(object index, object val)
+	public void NewIndex(object index, object? val)
 	{
-		SharedDict[index] = val;
-		if (val == null)
+		if (NodeDict.TryGetValue(index, out LinkedListNode<Entry> node))
 		{
-			SharedDict.Remove(index);
+			if (val != null)
+			{
+
+				node.Value.Value = val;
+			}
+			else
+			{
+				NodeDict.Remove(index);
+				KeyLinkedList.Remove(node);
+			}
+		}
+		else if (val != null)
+		{
+			NodeDict.Add(index, KeyLinkedList.AddLast(new Entry(index, val)));
 		}
 	}
 
 	[ScriptMetamethod(ScriptObjectMetamethod.Iter)]
 	public static IEnumerable<(object, object)> Iter(ScriptSharedTable sTable)
 	{
-		foreach ((var key, var value) in sTable.SharedDict)
+		foreach (Entry kvp in sTable.KeyLinkedList)
 		{
-			yield return (key, value);
+			yield return (kvp.Key, kvp.Value);
 		}
 	}
 }


### PR DESCRIPTION

## Summary

Adds support for using next() on Shared tables. This is done by monkeypatching lua's next function and refactoring the internals of Shared. This doesn't result in any scripting API changes.

This also adds a ScriptTupleReturn property to the ScriptMethod Attribute. If this is present on a ScriptMethod, any object?[] array returned from that method will be automatically passed to lua as a tuple. This does not affect other types of return values. This makes it so you can return more than one value from a ScriptMethod, since it seems like this was previously impossible. In fact, the scripting api seems to have no methods that return more than one value. This functionality seemed to already be present, but only for [async functions](https://github.com/Polytoria/polytoria-game/blob/667b74bde7dd4517ce1e3e640b91f7d6dae6bf71/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs#L111-L119), so this just extends that to synchronous functions, and although it does make breaking changes for those async functions, it seems like nothing is really affected.

This was my first PR, lmk about any action needed.

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion

Fixes # 
Related to #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [X] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [X] Scripting API
- [X] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
For research/debugging, however, no code was written by AI/LLM.

<!-- Describe AI use, or write "None" if not applicable -->