### PR TITLE
add horizontal and vertical flip to UIImage datamodel

### DIFF
--- a/Polytoria/scripts/datamodel/UIImage.cs
+++ b/Polytoria/scripts/datamodel/UIImage.cs
@@ -21,6 +21,8 @@ public partial class UIImage : UIField
 	private TextureFilterEnum _textureFilter;
 	private Color _color = new(1, 1, 1, 1);
 	private ImageStretchModeEnum _stretchMode = ImageStretchModeEnum.Stretch;
+	private bool _flipH = false;
+	private bool _flipV = false;
 
 	[Editable, ScriptProperty, Export]
 	public ImageAsset? Image
@@ -121,6 +123,30 @@ public partial class UIImage : UIField
 				TextureFilterEnum.Linear => CanvasItem.TextureFilterEnum.Linear,
 				_ => throw new IndexOutOfRangeException("Texture filter mode out of range"),
 			};
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool FlipHorizontal
+	{
+		get => _flipH;
+		set
+		{
+			_flipH = value;
+			GDTextureRect.FlipH = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool FlipVertical
+	{
+		get => _flipV;
+		set
+		{
+			_flipV = value;
+			GDTextureRect.FlipV = value;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

adds `FlipHorizontal` and `FlipVertical` (equivalent to `TextureRect`'s `FlipH` and `FlipV`) as properties in UIImages

## Related issue or discussion

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/ea3aea28-c591-4cbb-964d-c53e23df0d6f

## AI/LLM use

None