### PR TITLE
Fix/settings save aot

### DIFF
--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -29,7 +29,7 @@ warnings/check_invalid_track_paths=false
 [application]
 
 config/name="Polytoria"
-config/version="2.0.2"
+config/version="2.0.3"
 run/main_scene="uid://c2tql65t73ak5"
 config/use_custom_user_dir=true
 config/custom_user_dir_name="PolytoriaClient"

--- a/Polytoria/scripts/shared/settings/SettingsFileUtility.cs
+++ b/Polytoria/scripts/shared/settings/SettingsFileUtility.cs
@@ -5,22 +5,21 @@
 using Godot;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using FileAccess = Godot.FileAccess;
+using System.IO;
+using System.Text;
 
 namespace Polytoria.Shared.Settings;
 
 internal static class SettingsFileUtility
 {
-	[RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
-	[RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
 	internal static bool Save(string path, Dictionary<string, object?> values)
 	{
 		try
 		{
 			// Serialize BEFORE opening the file so a serialization failure doesnt break anything :pray:
-			string json = JsonSerializer.Serialize(values);
+			string json = Serialize(values);
 
 			using var file = FileAccess.Open(path, FileAccess.ModeFlags.Write);
 			if (file == null)
@@ -156,4 +155,58 @@ internal static class SettingsFileUtility
 		};
 	}
 
+	private static string Serialize(Dictionary<string, object?> values)
+	{
+		using var stream = new MemoryStream();
+		using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+		{
+			Indented = true
+		}))
+		{
+			writer.WriteStartObject();
+
+			foreach ((string key, object? value) in values)
+			{
+				writer.WritePropertyName(key);
+				WriteValue(writer, value);
+			}
+
+			writer.WriteEndObject();
+		}
+
+		return Encoding.UTF8.GetString(stream.ToArray());
+	}
+
+	private static void WriteValue(Utf8JsonWriter writer, object? value)
+	{
+		switch (value)
+		{
+			case null:
+				writer.WriteNullValue();
+				break;
+
+			case bool boolValue:
+				writer.WriteBooleanValue(boolValue);
+				break;
+
+			case int intValue:
+				writer.WriteNumberValue(intValue);
+				break;
+
+			case float floatValue:
+				writer.WriteNumberValue(floatValue);
+				break;
+
+			case string stringValue:
+				writer.WriteStringValue(stringValue);
+				break;
+
+			case Enum enumValue:
+				writer.WriteStringValue(enumValue.ToString());
+				break;
+
+			default:
+				throw new InvalidOperationException($"Unsupported setting value type '{value.GetType().FullName}'.");
+		}
+	}
 }

--- a/Polytoria/scripts/shared/settings/SettingsServiceBase.cs
+++ b/Polytoria/scripts/shared/settings/SettingsServiceBase.cs
@@ -6,7 +6,6 @@ using Godot;
 using Polytoria.Shared;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Polytoria.Shared.Settings;
 
@@ -21,8 +20,6 @@ public abstract partial class SettingsServiceBase : Node, ISettingsContext
 
 	public event Action<SettingChangedEvent>? Changed;
 
-	[RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
-	[RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
 	protected SettingsServiceBase()
 	{
 		_headless = DisplayServer.GetName() == "headless";
@@ -30,8 +27,6 @@ public abstract partial class SettingsServiceBase : Node, ISettingsContext
 			Globals.BeforeQuit += Save;
 	}
 
-	[RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
-	[RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
 	public override void _ExitTree()
 	{
 		if (!_headless)
@@ -113,8 +108,6 @@ public abstract partial class SettingsServiceBase : Node, ISettingsContext
 		}).CallDeferred();
 	}
 
-	[RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
-	[RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
 	public void Save()
 	{
 		SettingsFileUtility.Save(SettingsPath, _values);


### PR DESCRIPTION
## Summary

Fixes settings saving in exported NativeAOT builds by replacing reflection based serialization with explicit json writing

## Related issue or discussion

Fixes #246

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [x] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

Accepted inline copilot suggestions