### PR TITLE
Creator: Better tabs bar interface

### DIFF
--- a/Polytoria/resources/themes/creator/tabs.tres
+++ b/Polytoria/resources/themes/creator/tabs.tres
@@ -2,7 +2,25 @@
 
 [ext_resource type="Texture2D" uid="uid://eh73dq328feq" path="res://assets/textures/creator/close.svg" id="1_030fu"]
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_qg106"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_030fu"]
+draw_center = false
+border_width_left = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.12941177, 0.5882353, 0.9529412, 1)
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+expand_margin_left = 1.0
+expand_margin_right = 1.0
+expand_margin_bottom = 1.0
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_suxfw"]
+content_margin_left = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 2.0
+bg_color = Color(0.11764706, 0.11764706, 0.11764706, 1)
+border_width_top = 2
+border_color = Color(0.129412, 0.588235, 0.952941, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_57nwh"]
 bg_color = Color(0.0862745, 0.0862745, 0.0862745, 1)
@@ -16,23 +34,15 @@ content_margin_right = 6.0
 content_margin_bottom = 6.0
 bg_color = Color(0.14902, 0.14902, 0.14902, 1)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_suxfw"]
-content_margin_left = 6.0
-content_margin_top = 6.0
-content_margin_right = 6.0
-content_margin_bottom = 6.0
-bg_color = Color(0.14902, 0.14902, 0.14902, 1)
-border_width_top = 2
-border_color = Color(0.129412, 0.588235, 0.952941, 1)
-
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_po7xu"]
 bg_color = Color(0.0862745, 0.0862745, 0.0862745, 1)
 
 [resource]
 resource_name = "TabsTheme"
+default_font_size = 0
 TabBar/icons/close = ExtResource("1_030fu")
-TabBar/styles/button_highlight = SubResource("StyleBoxEmpty_qg106")
-TabBar/styles/button_pressed = SubResource("StyleBoxEmpty_qg106")
+TabBar/styles/tab_focus = SubResource("StyleBoxFlat_030fu")
+TabBar/styles/tab_selected = SubResource("StyleBoxFlat_suxfw")
 TabContainer/constants/icon_max_width = 18
 TabContainer/constants/icon_separation = 6
 TabContainer/constants/side_margin = 0

--- a/Polytoria/scenes/creator/creator.tscn
+++ b/Polytoria/scenes/creator/creator.tscn
@@ -1049,14 +1049,6 @@ custom_minimum_size = Vector2(0, 28)
 layout_mode = 2
 mouse_filter = 2
 
-[node name="LeftButton" type="Button" parent="GUI/Splitter/Center/Tabs/Bar" unique_id=1141546916]
-custom_minimum_size = Vector2(24, 0)
-layout_mode = 2
-action_mode = 0
-icon = ExtResource("25_bc04q")
-icon_alignment = 1
-expand_icon = true
-
 [node name="TabsClip" type="Control" parent="GUI/Splitter/Center/Tabs/Bar" unique_id=1532866770]
 clip_contents = true
 layout_mode = 2
@@ -1064,8 +1056,13 @@ size_flags_horizontal = 3
 mouse_filter = 2
 
 [node name="TabBar" type="TabBar" parent="GUI/Splitter/Center/Tabs/Bar/TabsClip" unique_id=130268270]
-layout_mode = 0
-offset_bottom = 24.0
+layout_mode = 1
+anchors_preset = -1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_bottom = -1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 3
 theme = ExtResource("16_1f7jh")
 theme_override_constants/icon_max_width = 16
@@ -1074,9 +1071,32 @@ close_with_middle_mouse = false
 tab_close_display_policy = 2
 drag_to_rearrange_enabled = true
 
-[node name="RightButton" type="Button" parent="GUI/Splitter/Center/Tabs/Bar" unique_id=1096239978]
+[node name="LeftButton" type="Button" parent="GUI/Splitter/Center/Tabs/Bar/TabsClip" unique_id=1141546916]
 custom_minimum_size = Vector2(24, 0)
-layout_mode = 2
+layout_mode = 1
+anchors_preset = -1
+anchor_bottom = 1.0
+offset_left = 2.0
+offset_top = 2.0
+offset_bottom = -2.0
+grow_vertical = 2
+action_mode = 0
+icon = ExtResource("25_bc04q")
+icon_alignment = 1
+expand_icon = true
+
+[node name="RightButton" type="Button" parent="GUI/Splitter/Center/Tabs/Bar/TabsClip" unique_id=1096239978]
+custom_minimum_size = Vector2(24, 8)
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 2.0
+offset_right = -2.0
+offset_bottom = -2.0
+grow_horizontal = 0
+grow_vertical = 2
 action_mode = 0
 icon = ExtResource("26_4n5gq")
 icon_alignment = 1

--- a/Polytoria/scenes/creator/creator.tscn
+++ b/Polytoria/scenes/creator/creator.tscn
@@ -1045,7 +1045,7 @@ mouse_filter = 2
 script = ExtResource("16_smqtq")
 
 [node name="Bar" type="HBoxContainer" parent="GUI/Splitter/Center/Tabs" unique_id=1220724128]
-custom_minimum_size = Vector2(0, 24)
+custom_minimum_size = Vector2(0, 28)
 layout_mode = 2
 mouse_filter = 2
 

--- a/Polytoria/scenes/creator/creator.tscn
+++ b/Polytoria/scenes/creator/creator.tscn
@@ -27,6 +27,8 @@
 [ext_resource type="FontFile" uid="uid://clwbylh8y2lf2" path="res://assets/fonts/creator/JetBrainsMono-Regular.ttf" id="21_je108"]
 [ext_resource type="Texture2D" uid="uid://bstnds573cu1e" path="res://assets/textures/ui-icons/trash.svg" id="22_i1txp"]
 [ext_resource type="PackedScene" uid="uid://ba2m71tw3g6mf" path="res://scenes/creator/load_overlay.tscn" id="25_b5k6b"]
+[ext_resource type="Texture2D" uid="uid://c60spvojllrt4" path="res://assets/textures/ui-icons/chevron-left.svg" id="25_bc04q"]
+[ext_resource type="Texture2D" uid="uid://yd5kv6j4l3hp" path="res://assets/textures/ui-icons/chevron-right.svg" id="26_4n5gq"]
 [ext_resource type="Texture2D" uid="uid://dk3ggy6lhcnbu" path="res://assets/textures/ui-icons/empty.png" id="26_bc04q"]
 [ext_resource type="PackedScene" uid="uid://bfh6n2s5op0nu" path="res://scenes/creator/docks/toolbox/toolbox.tscn" id="26_dfqoe"]
 [ext_resource type="Script" uid="uid://dsmyuj4u8d0kx" path="res://scripts/creator/ui/StatusBar.cs" id="26_xdd36"]
@@ -1033,8 +1035,42 @@ size_flags_vertical = 3
 theme_override_constants/separation = 0
 theme_override_icons/touch_dragger = SubResource("PlaceholderTexture2D_0tvsp")
 theme_override_icons/grabber = SubResource("PlaceholderTexture2D_0tvsp")
+split_offsets = PackedInt32Array(30, -34)
+split_offset = 30
 
-[node name="Tabs" type="TabContainer" parent="GUI/Splitter/Center" unique_id=705803924]
+[node name="TopTabs" type="HBoxContainer" parent="GUI/Splitter/Center" unique_id=1220724128]
+layout_mode = 2
+script = ExtResource("16_smqtq")
+
+[node name="LeftButton" type="Button" parent="GUI/Splitter/Center/TopTabs" unique_id=1141546916]
+custom_minimum_size = Vector2(30, 30)
+layout_mode = 2
+icon = ExtResource("25_bc04q")
+icon_alignment = 1
+expand_icon = true
+
+[node name="TabControl" type="Control" parent="GUI/Splitter/Center/TopTabs" unique_id=1532866770]
+clip_contents = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="TabBar" type="TabBar" parent="GUI/Splitter/Center/TopTabs/TabControl" unique_id=130268270]
+layout_mode = 0
+offset_left = 4.0
+offset_right = 486.0
+offset_bottom = 16.0
+size_flags_horizontal = 3
+clip_tabs = false
+close_with_middle_mouse = false
+
+[node name="RightButton" type="Button" parent="GUI/Splitter/Center/TopTabs" unique_id=1096239978]
+custom_minimum_size = Vector2(30, 30)
+layout_mode = 2
+icon = ExtResource("26_4n5gq")
+icon_alignment = 1
+expand_icon = true
+
+[node name="TabsOld" type="TabContainer" parent="GUI/Splitter/Center" unique_id=705803924]
 layout_mode = 2
 size_flags_vertical = 3
 mouse_filter = 2

--- a/Polytoria/scenes/creator/creator.tscn
+++ b/Polytoria/scenes/creator/creator.tscn
@@ -1035,48 +1035,56 @@ size_flags_vertical = 3
 theme_override_constants/separation = 0
 theme_override_icons/touch_dragger = SubResource("PlaceholderTexture2D_0tvsp")
 theme_override_icons/grabber = SubResource("PlaceholderTexture2D_0tvsp")
-split_offsets = PackedInt32Array(30, -34)
+split_offsets = PackedInt32Array(30)
 split_offset = 30
 
-[node name="TopTabs" type="HBoxContainer" parent="GUI/Splitter/Center" unique_id=1220724128]
+[node name="Tabs" type="VBoxContainer" parent="GUI/Splitter/Center" unique_id=31203848]
 layout_mode = 2
+size_flags_vertical = 3
+mouse_filter = 2
 script = ExtResource("16_smqtq")
 
-[node name="LeftButton" type="Button" parent="GUI/Splitter/Center/TopTabs" unique_id=1141546916]
-custom_minimum_size = Vector2(30, 30)
+[node name="Bar" type="HBoxContainer" parent="GUI/Splitter/Center/Tabs" unique_id=1220724128]
+custom_minimum_size = Vector2(0, 24)
 layout_mode = 2
+mouse_filter = 2
+
+[node name="LeftButton" type="Button" parent="GUI/Splitter/Center/Tabs/Bar" unique_id=1141546916]
+custom_minimum_size = Vector2(24, 0)
+layout_mode = 2
+action_mode = 0
 icon = ExtResource("25_bc04q")
 icon_alignment = 1
 expand_icon = true
 
-[node name="TabControl" type="Control" parent="GUI/Splitter/Center/TopTabs" unique_id=1532866770]
+[node name="TabsClip" type="Control" parent="GUI/Splitter/Center/Tabs/Bar" unique_id=1532866770]
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
+mouse_filter = 2
 
-[node name="TabBar" type="TabBar" parent="GUI/Splitter/Center/TopTabs/TabControl" unique_id=130268270]
+[node name="TabBar" type="TabBar" parent="GUI/Splitter/Center/Tabs/Bar/TabsClip" unique_id=130268270]
 layout_mode = 0
-offset_left = 4.0
-offset_right = 486.0
-offset_bottom = 16.0
+offset_bottom = 24.0
 size_flags_horizontal = 3
+theme = ExtResource("16_1f7jh")
+theme_override_constants/icon_max_width = 16
 clip_tabs = false
 close_with_middle_mouse = false
+tab_close_display_policy = 2
+drag_to_rearrange_enabled = true
 
-[node name="RightButton" type="Button" parent="GUI/Splitter/Center/TopTabs" unique_id=1096239978]
-custom_minimum_size = Vector2(30, 30)
+[node name="RightButton" type="Button" parent="GUI/Splitter/Center/Tabs/Bar" unique_id=1096239978]
+custom_minimum_size = Vector2(24, 0)
 layout_mode = 2
+action_mode = 0
 icon = ExtResource("26_4n5gq")
 icon_alignment = 1
 expand_icon = true
 
-[node name="TabsOld" type="TabContainer" parent="GUI/Splitter/Center" unique_id=705803924]
+[node name="Container" type="PanelContainer" parent="GUI/Splitter/Center/Tabs" unique_id=1955047821]
 layout_mode = 2
 size_flags_vertical = 3
-mouse_filter = 2
-theme = ExtResource("16_1f7jh")
-drag_to_rearrange_enabled = true
-script = ExtResource("16_smqtq")
 
 [node name="BottomTabs" type="PanelContainer" parent="GUI/Splitter/Center" unique_id=198117763]
 layout_mode = 2

--- a/Polytoria/scripts/creator/CreatorSession.cs
+++ b/Polytoria/scripts/creator/CreatorSession.cs
@@ -31,15 +31,15 @@ namespace Polytoria.Creator;
 public partial class CreatorSession : Node, IDisposable
 {
 	private const string LuauRCContent = @"{
-    ""languageMode"": ""nocheck""
+	""languageMode"": ""nocheck""
 }";
 	private const string VSCodeSetupContent = @"{
-    ""luau-lsp.platform.type"": ""standard"",
-    ""luau-lsp.types.definitionFiles"": {
-        ""@poly"": ""./.poly/luau/def.d.luau"",
+	""luau-lsp.platform.type"": ""standard"",
+	""luau-lsp.types.definitionFiles"": {
+		""@poly"": ""./.poly/luau/def.d.luau"",
     },
 	""files.exclude"": {
-        ""**/*.meta"": true
+		""**/*.meta"": true
     }
 }";
 

--- a/Polytoria/scripts/creator/ui/Tabs.cs
+++ b/Polytoria/scripts/creator/ui/Tabs.cs
@@ -3,11 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using Godot;
-<<<<<<< HEAD
 using Polytoria.Creator.Settings;
-=======
-//using Polytoria.Creator.Settings;
->>>>>>> a4efa7a (Replace UI with new interface)
 using Polytoria.Creator.UI.TextEditor;
 using Polytoria.Datamodel;
 using Polytoria.Datamodel.Creator;
@@ -88,11 +84,7 @@ public sealed partial class Tabs : Control
 			{
 				if (!(control is TextEditorContainer txt && txt.EditorRoot.Saved))
 				{
-<<<<<<< HEAD
 					if (!await CreatorService.Interface.PromptConfirmation("Are you sure you want to close this tab? Any unsaved changes will be lost.", dismissKey: CreatorSettingKeys.Popups.CloseTabWarning)) return;
-=======
-					//if (!await CreatorService.Interface.PromptConfirmation("Are you sure you want to close this tab? Any unsaved changes will be lost.", dismissKey: CreatorSettingKeys.Popups.CloseTabWarning)) return;
->>>>>>> a4efa7a (Replace UI with new interface)
 				}
 			}
 

--- a/Polytoria/scripts/creator/ui/Tabs.cs
+++ b/Polytoria/scripts/creator/ui/Tabs.cs
@@ -86,8 +86,8 @@ public sealed partial class Tabs : Control
 		_tabBar = GetNode<TabBar>("Bar/TabsClip/TabBar");
 		_tabsContainer = GetNode<PanelContainer>("Container");
 
-		_leftButton = GetNode<Button>("Bar/LeftButton");
-		_rightButton = GetNode<Button>("Bar/RightButton");
+		_leftButton = GetNode<Button>("Bar/TabsClip/LeftButton");
+		_rightButton = GetNode<Button>("Bar/TabsClip/RightButton");
 
 		_tabBar.TabCloseDisplayPolicy = TabBar.CloseButtonDisplayPolicy.ShowAlways;
 
@@ -293,16 +293,16 @@ public sealed partial class Tabs : Control
 	{
 		if (_tabBar.Position.X == _maxScroll)
 		{
-			_rightButton.Disabled = true;
+			_rightButton.Visible = false;
 			_scrollRight = false;
 		}
-		else if (_rightButton.Disabled) _rightButton.Disabled = false;
+		else if (!_rightButton.Visible) _rightButton.Visible = true;
 
 		if (_tabBar.Position.X == _scrollSidePadding)
 		{
-			_leftButton.Disabled = true;
+			_leftButton.Visible = false;
 			_scrollLeft = false;
 		}
-		else if (_leftButton.Disabled) _leftButton.Disabled = false;
+		else if (!_leftButton.Visible) _leftButton.Visible = true;
 	}
 }

--- a/Polytoria/scripts/creator/ui/Tabs.cs
+++ b/Polytoria/scripts/creator/ui/Tabs.cs
@@ -3,7 +3,11 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using Godot;
+<<<<<<< HEAD
 using Polytoria.Creator.Settings;
+=======
+//using Polytoria.Creator.Settings;
+>>>>>>> a4efa7a (Replace UI with new interface)
 using Polytoria.Creator.UI.TextEditor;
 using Polytoria.Datamodel;
 using Polytoria.Datamodel.Creator;
@@ -13,29 +17,82 @@ using System.Collections.Generic;
 
 namespace Polytoria.Creator.UI;
 
-public sealed partial class Tabs : TabContainer
+public sealed partial class Tabs : Control
 {
+	private int _currentIdx, _selectedIdx;
+	
+	private readonly List<Control> _orderedControls = [];
+	private readonly Dictionary<Control, int> _controlToIdx = [];
+	private readonly Dictionary<int, Control> _idxToControl = [];
+	
 	private readonly Dictionary<string, TextEditorContainer> _openedScripts = [];
-
+		
+	private TabBar _tabBar = null!;
+	
+	private PanelContainer _tabsContainer = null!;
+	
+	private Button _leftButton = null!, _rightButton = null!;
+	private bool _scrollLeft, _scrollRight;
+	
 	public static Tabs Singleton { get; private set; } = null!;
 	public Tabs()
 	{
 		Singleton = this;
 	}
-
+	
 	public override void _Ready()
 	{
-		TabBar bar = GetTabBar();
-		bar.TabCloseDisplayPolicy = TabBar.CloseButtonDisplayPolicy.ShowAlways;
-		bar.TabClosePressed += async idx =>
+		_tabBar = GetNode<TabBar>("Bar/TabsClip/TabBar");
+		_tabsContainer = GetNode<PanelContainer>("Container");
+		
+		_leftButton = GetNode<Button>("Bar/LeftButton");
+		_rightButton = GetNode<Button>("Bar/RightButton");
+		
+		_tabBar.TabCloseDisplayPolicy = TabBar.CloseButtonDisplayPolicy.ShowAlways;
+		_tabBar.TabSelected += idx => _selectedIdx = (int)idx;
+		_tabBar.TabChanged += idx =>
 		{
-			Control control = GetTabControl((int)idx);
+			SetCurrentTab((int)idx);
+			World? game = null;
 
+			if (idx != -1)
+			{
+				Control control = _idxToControl[(int)idx];
+
+				if (control is WorldContainer gameContainer)
+				{
+					game = gameContainer.World;
+				}
+				if (control is TextEditorContainer textedit)
+				{
+					game = World.Current;
+				}
+			}
+			
+			World.Current = game;
+		};
+		
+		_tabBar.ActiveTabRearranged += newIdx =>
+		{
+			var control = _orderedControls[(int)_selectedIdx];
+			_orderedControls.RemoveAt((int)_selectedIdx);
+			_orderedControls.Insert((int)newIdx, control);
+			RebuildLookups();
+			_selectedIdx = -1;
+		};
+		
+		_tabBar.TabClosePressed += async idx =>
+		{
+			var control = _orderedControls[(int)idx];
 			if (control is WorldContainer || control is TextEditorContainer)
 			{
 				if (!(control is TextEditorContainer txt && txt.EditorRoot.Saved))
 				{
+<<<<<<< HEAD
 					if (!await CreatorService.Interface.PromptConfirmation("Are you sure you want to close this tab? Any unsaved changes will be lost.", dismissKey: CreatorSettingKeys.Popups.CloseTabWarning)) return;
+=======
+					//if (!await CreatorService.Interface.PromptConfirmation("Are you sure you want to close this tab? Any unsaved changes will be lost.", dismissKey: CreatorSettingKeys.Popups.CloseTabWarning)) return;
+>>>>>>> a4efa7a (Replace UI with new interface)
 				}
 			}
 
@@ -47,31 +104,39 @@ public sealed partial class Tabs : TabContainer
 			{
 				_openedScripts.Remove(tec.TargetFilePathAbsolute);
 			}
+			Remove((int)idx);
 			control.QueueFree();
 		};
-
-		TabChanged += idx =>
-		{
-			World? game = null;
-
-			if (idx != -1)
-			{
-				Control control = GetTabControl((int)idx);
-
-				if (control is WorldContainer gameContainer)
-				{
-					game = gameContainer.World;
-				}
-				if (control is TextEditorContainer textedit)
-				{
-					game = World.Current;
-				}
-			}
-
-			World.Current = game;
-		};
+		
+		_leftButton.ButtonDown += () => _scrollLeft = true;
+		_leftButton.ButtonUp += () => _scrollLeft = false;
+		_rightButton.ButtonDown += () => _scrollRight = true;
+		_rightButton.ButtonUp += () => _scrollRight = false;
 	}
-
+	
+	private void Remove(int idx)
+	{
+		_orderedControls.RemoveAt((int)idx);
+		_tabBar.RemoveTab((int)idx);
+		RebuildLookups();
+		
+		_tabBar.Size = new Vector2(0, _tabBar.Size.Y);
+		_tabBar.Position = new Vector2(Mathf.Clamp(_tabBar.Position.X, -Mathf.Max(_tabBar.Size.X - this.Size.X + 96, 0), 0), _tabBar.Position.Y);
+		SetCurrentTab(_tabBar.CurrentTab);
+	}
+	
+	private void RebuildLookups()
+	{
+		_controlToIdx.Clear();
+		_idxToControl.Clear();
+		for (int i = 0; i < _tabBar.TabCount; i++)
+		{
+			var c = _orderedControls[i];
+			_idxToControl[i] = c;
+			_controlToIdx[c] = i;
+		}
+	}
+	
 	public void CloseTabsOfSession(CreatorSession session)
 	{
 		foreach ((string k, TextEditorContainer c) in _openedScripts)
@@ -83,15 +148,24 @@ public sealed partial class Tabs : TabContainer
 			}
 		}
 	}
-
+	
+	public void SetCurrentTab(int idx)
+	{
+		_idxToControl[_currentIdx].Visible = false;
+		
+		_currentIdx = idx;
+		_tabBar.CurrentTab = idx;
+		_idxToControl[_currentIdx].Visible = true;
+	}
+	
 	public void SetTabTitle(Control c, string to)
 	{
-		SetTabTitle(GetTabIdxFromControl(c), to);
+		_tabBar.SetTabTitle(_controlToIdx[c], to);
 	}
-
+	
 	public void Insert(TabData other, string? title = null)
 	{
-		Node container;
+		Control container;
 		string icon;
 
 		if (other is GameTab gt)
@@ -113,27 +187,26 @@ public sealed partial class Tabs : TabContainer
 			string fullPath = txt.Session.GlobalizePath(txt.TargetPath);
 			if (_openedScripts.TryGetValue(fullPath, out TextEditorContainer? existingTec))
 			{
-				CurrentTab = GetTabIdxFromControl(existingTec);
+				SetCurrentTab(_controlToIdx[existingTec]);
 				return;
 			}
-			ScriptTypeEnum st = CreatorService.GetScriptTypeFromPath(txt.TargetPath);
 			TextEditorContainer tec = new(txt.TargetPath, fullPath, txt.Session) { OriginTabName = txt.Title ?? "" };
 			container = tec;
-			if (st == ScriptTypeEnum.Module)
+			ScriptTypeEnum st = CreatorService.GetScriptTypeFromPath(txt.TargetPath);
+			switch (st)
 			{
-				icon = "ModuleScript";
-			}
-			else if (st == ScriptTypeEnum.Server)
-			{
-				icon = "ServerScript";
-			}
-			else if (st == ScriptTypeEnum.Client)
-			{
-				icon = "ClientScript";
-			}
-			else
-			{
-				icon = "Script";
+				case (ScriptTypeEnum.Module):
+					icon = "ModuleScript";
+					break;
+				case (ScriptTypeEnum.Server):
+					icon = "ServerScript";
+					break;
+				case (ScriptTypeEnum.Client):
+					icon = "ClientScript";
+					break;
+				default:
+					icon = "Script";
+					break;
 			}
 			_openedScripts[fullPath] = tec;
 		}
@@ -141,16 +214,16 @@ public sealed partial class Tabs : TabContainer
 		{
 			throw new NotImplementedException();
 		}
+		int idx = _tabBar.TabCount;
+		_orderedControls.Add(container);
+		_idxToControl[idx] = container;
+		_controlToIdx[container] = idx;
 
-		AddChild(container, true);
-		int idx = GetTabCount() - 1;
-
-		SetTabTitle(idx, title ?? other.Title);
-		SetTabIcon(idx, Globals.LoadIcon(icon));
-
-		CurrentTab = idx;
+		_tabsContainer.AddChild(container, true);
+		_tabBar.AddTab(title ?? other.Title, Globals.LoadIcon(icon));
+		SetCurrentTab(idx);
 	}
-
+	
 	public class TextEditorTab : TabData
 	{
 		public string TargetPath = null!;
@@ -165,5 +238,18 @@ public sealed partial class Tabs : TabContainer
 	public class TabData
 	{
 		public string Title = "Tab";
+	}
+	
+	public override void _Process(double delta)
+	{
+		if (_scrollLeft) SlideBar((float)(640 * delta));
+		if (_scrollRight) SlideBar((float)(-640 * delta));
+	}
+	
+	private void SlideBar(float delta)
+	{
+		var pos = _tabBar.Position;
+		pos.X = Mathf.Clamp(pos.X + delta, -Mathf.Max(_tabBar.Size.X - this.Size.X + 96, 0), 0);
+		_tabBar.Position = pos;
 	}
 }

--- a/Polytoria/scripts/creator/ui/Tabs.cs
+++ b/Polytoria/scripts/creator/ui/Tabs.cs
@@ -10,151 +10,120 @@ using Polytoria.Datamodel.Creator;
 using Polytoria.Shared;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Polytoria.Creator.UI;
 
 public sealed partial class Tabs : Control
 {
-	private int _currentIdx, _selectedIdx;
-	
+	private Control? _currentControl;
+
+	[Export]
+	public Control? CurrentControl
+	{
+		get => _currentControl;
+		private set
+		{
+			if (_currentControl == value) return;
+			if (_currentControl != null) _currentControl.Visible = false;
+
+			_currentControl = value;
+			if (value == null) return;
+
+			if (!_controlToIdx.TryGetValue(value, out var idx))
+			{
+				_tabsContainer.AddChild(value, true);
+
+				idx = _tabBar.TabCount - 1;
+				_orderedControls.Add(value);
+				_controlToIdx[value] = idx;
+			}
+			value.Visible = true;
+			_surpressTabChanged = true;
+			_tabBar.CurrentTab = idx;
+			_surpressTabChanged = false;
+			UpdateTabBar();
+
+			if (value is WorldContainer gameContainer)
+			{
+				World.Current = gameContainer.World;
+			}
+			if (value is TextEditorContainer tec && World.Current.LinkedSession != tec.TargetSession)
+			{
+				World.Current = tec.TargetSession.OpenedWorlds[0];
+			}
+		}
+	}
+
+	private bool _surpressTabChanged;
+
+	private int _selectedIdx;
+
 	private readonly List<Control> _orderedControls = [];
 	private readonly Dictionary<Control, int> _controlToIdx = [];
-	private readonly Dictionary<int, Control> _idxToControl = [];
-	
-	private readonly Dictionary<string, TextEditorContainer> _openedScripts = [];
-		
+	private readonly Dictionary<string, Control> _openedFiles = [];
+
+	private Control _tabsClip = null!;
 	private TabBar _tabBar = null!;
-	
 	private PanelContainer _tabsContainer = null!;
-	
+
 	private Button _leftButton = null!, _rightButton = null!;
 	private bool _scrollLeft, _scrollRight;
+	private int _maxScroll;
 	
+	private const int _scrollSidePadding = 2;
+
 	public static Tabs Singleton { get; private set; } = null!;
 	public Tabs()
 	{
 		Singleton = this;
 	}
-	
+
 	public override void _Ready()
 	{
+		_tabsClip = GetNode<Control>("Bar/TabsClip");
 		_tabBar = GetNode<TabBar>("Bar/TabsClip/TabBar");
 		_tabsContainer = GetNode<PanelContainer>("Container");
-		
+
 		_leftButton = GetNode<Button>("Bar/LeftButton");
 		_rightButton = GetNode<Button>("Bar/RightButton");
-		
+
 		_tabBar.TabCloseDisplayPolicy = TabBar.CloseButtonDisplayPolicy.ShowAlways;
-		_tabBar.TabSelected += idx => _selectedIdx = (int)idx;
+
+		_tabsClip.Resized += () => UpdateTabBar();
+
 		_tabBar.TabChanged += idx =>
 		{
-			SetCurrentTab((int)idx);
-			World? game = null;
-
-			if (idx != -1)
-			{
-				Control control = _idxToControl[(int)idx];
-
-				if (control is WorldContainer gameContainer)
-				{
-					game = gameContainer.World;
-				}
-				if (control is TextEditorContainer textedit)
-				{
-					game = World.Current;
-				}
-			}
-			
-			World.Current = game;
+			if (_surpressTabChanged) return;
+			if ((int)idx < 0 || (int)idx >= _orderedControls.Count) return;
+			CurrentControl = _orderedControls[(int)idx];
 		};
-		
+
+		_tabBar.TabSelected += idx => _selectedIdx = (int)idx;
+
 		_tabBar.ActiveTabRearranged += newIdx =>
 		{
 			var control = _orderedControls[(int)_selectedIdx];
 			_orderedControls.RemoveAt((int)_selectedIdx);
 			_orderedControls.Insert((int)newIdx, control);
-			RebuildLookups();
+			RebuildLookup();
 			_selectedIdx = -1;
 		};
-		
-		_tabBar.TabClosePressed += async idx =>
-		{
-			var control = _orderedControls[(int)idx];
-			if (control is WorldContainer || control is TextEditorContainer)
-			{
-				if (!(control is TextEditorContainer txt && txt.EditorRoot.Saved))
-				{
-					if (!await CreatorService.Interface.PromptConfirmation("Are you sure you want to close this tab? Any unsaved changes will be lost.", dismissKey: CreatorSettingKeys.Popups.CloseTabWarning)) return;
-				}
-			}
 
-			if (control is WorldContainer g)
-			{
-				g.World.ForceDelete();
-			}
-			else if (control is TextEditorContainer tec)
-			{
-				_openedScripts.Remove(tec.TargetFilePathAbsolute);
-			}
-			Remove((int)idx);
-			control.QueueFree();
-		};
-		
+		_tabBar.TabClosePressed += async idx => await Remove(_orderedControls[(int)idx]);
+
 		_leftButton.ButtonDown += () => _scrollLeft = true;
 		_leftButton.ButtonUp += () => _scrollLeft = false;
 		_rightButton.ButtonDown += () => _scrollRight = true;
 		_rightButton.ButtonUp += () => _scrollRight = false;
 	}
-	
-	private void Remove(int idx)
-	{
-		_orderedControls.RemoveAt((int)idx);
-		_tabBar.RemoveTab((int)idx);
-		RebuildLookups();
-		
-		_tabBar.Size = new Vector2(0, _tabBar.Size.Y);
-		_tabBar.Position = new Vector2(Mathf.Clamp(_tabBar.Position.X, -Mathf.Max(_tabBar.Size.X - this.Size.X + 96, 0), 0), _tabBar.Position.Y);
-		SetCurrentTab(_tabBar.CurrentTab);
-	}
-	
-	private void RebuildLookups()
-	{
-		_controlToIdx.Clear();
-		_idxToControl.Clear();
-		for (int i = 0; i < _tabBar.TabCount; i++)
-		{
-			var c = _orderedControls[i];
-			_idxToControl[i] = c;
-			_controlToIdx[c] = i;
-		}
-	}
-	
-	public void CloseTabsOfSession(CreatorSession session)
-	{
-		foreach ((string k, TextEditorContainer c) in _openedScripts)
-		{
-			if (c.TargetSession == session)
-			{
-				_openedScripts.Remove(k);
-				c.QueueFree();
-			}
-		}
-	}
-	
-	public void SetCurrentTab(int idx)
-	{
-		_idxToControl[_currentIdx].Visible = false;
-		
-		_currentIdx = idx;
-		_tabBar.CurrentTab = idx;
-		_idxToControl[_currentIdx].Visible = true;
-	}
-	
+
 	public void SetTabTitle(Control c, string to)
 	{
 		_tabBar.SetTabTitle(_controlToIdx[c], to);
 	}
-	
+
 	public void Insert(TabData other, string? title = null)
 	{
 		Control container;
@@ -169,17 +138,18 @@ public sealed partial class Tabs : Control
 			{
 				gt.World.Deleted -= deleted;
 				if (IsInstanceValid(container))
+				{
 					container.QueueFree();
+				}
 			}
-
 			gt.World.Deleted += deleted;
 		}
 		else if (other is TextEditorTab txt)
 		{
 			string fullPath = txt.Session.GlobalizePath(txt.TargetPath);
-			if (_openedScripts.TryGetValue(fullPath, out TextEditorContainer? existingTec))
+			if (_openedFiles.TryGetValue(fullPath, out Control? existing))
 			{
-				SetCurrentTab(_controlToIdx[existingTec]);
+				CurrentControl = existing;
 				return;
 			}
 			TextEditorContainer tec = new(txt.TargetPath, fullPath, txt.Session) { OriginTabName = txt.Title ?? "" };
@@ -200,22 +170,85 @@ public sealed partial class Tabs : Control
 					icon = "Script";
 					break;
 			}
-			_openedScripts[fullPath] = tec;
+			_openedFiles[fullPath] = tec;
 		}
 		else
 		{
 			throw new NotImplementedException();
 		}
-		int idx = _tabBar.TabCount;
-		_orderedControls.Add(container);
-		_idxToControl[idx] = container;
-		_controlToIdx[container] = idx;
 
-		_tabsContainer.AddChild(container, true);
 		_tabBar.AddTab(title ?? other.Title, Globals.LoadIcon(icon));
-		SetCurrentTab(idx);
+		CurrentControl = container;
 	}
-	
+
+	private async Task Remove(Control control, bool isBulkOp = false)
+	{
+		if (control is WorldContainer || control is TextEditorContainer)
+		{
+			if (!(control is TextEditorContainer txt && txt.EditorRoot.Saved))
+			{
+				if (!await CreatorService.Interface.PromptConfirmation("Are you sure you want to close this tab? Any unsaved changes will be lost.", dismissKey: CreatorSettingKeys.Popups.CloseTabWarning)) return;
+			}
+
+			if (control is WorldContainer g)
+			{
+				g.World.ForceDelete();
+			}
+			if (control is TextEditorContainer tec)
+			{
+				_openedFiles.Remove(tec.TargetFilePathAbsolute);
+			}
+		}
+
+		int idx = _controlToIdx[control];
+		_orderedControls.RemoveAt((int)idx);
+		_tabBar.RemoveTab((int)idx);
+
+		if (!isBulkOp)
+		{
+			RebuildLookup();
+			if (_tabBar.TabCount > 0 && control == CurrentControl)
+				CurrentControl = _orderedControls[Mathf.Clamp(idx, 0, _tabBar.TabCount - 1)];
+		}
+
+		control.QueueFree();
+		if (_tabBar.TabCount == 0)
+		{
+			_currentControl = null;
+			World.Current = null;
+		}
+		UpdateTabBar();
+	}
+
+	private void RebuildLookup()
+	{
+		_controlToIdx.Clear();
+		for (int i = 0; i < _tabBar.TabCount; i++)
+			_controlToIdx[_orderedControls[i]] = i;
+	}
+
+	public void CloseTabsOfSession(CreatorSession session)
+	{
+		var sessionTabs = _orderedControls
+			.Where(c => c is TextEditorContainer tec && tec.TargetSession == session)
+			.Select(c => _controlToIdx[c])
+			.OrderByDescending(i => i)
+			.ToList();
+
+		foreach (int idx in sessionTabs)
+			Remove(_orderedControls[idx], isBulkOp: true);
+
+		if (_tabBar.TabCount > 0)
+		{
+			RebuildLookup();
+			if (CurrentControl == null)
+			{
+				var lowestClosed = sessionTabs[sessionTabs.Count - 1];
+				CurrentControl = _orderedControls[Mathf.Clamp(lowestClosed, 0, _tabBar.TabCount - 1)];
+			}
+		}
+	}
+
 	public class TextEditorTab : TabData
 	{
 		public string TargetPath = null!;
@@ -231,17 +264,53 @@ public sealed partial class Tabs : Control
 	{
 		public string Title = "Tab";
 	}
-	
+
 	public override void _Process(double delta)
 	{
-		if (_scrollLeft) SlideBar((float)(640 * delta));
-		if (_scrollRight) SlideBar((float)(-640 * delta));
+		if (_scrollLeft) ScrollTabBar((float)(900 * delta));
+		if (_scrollRight) ScrollTabBar((float)(-900 * delta));
 	}
-	
-	private void SlideBar(float delta)
+
+	private void ScrollTabBar(float delta)
+	{
+		_tabBar.Position = new Vector2(_tabBar.Position.X + delta, _tabBar.Position.Y);
+		ClampBarScroll();
+	}
+
+	private int GetMaxScroll()
+	{
+		_tabBar.Size = new Vector2(0, _tabBar.Size.Y);
+		return (int)-Mathf.Max(_tabBar.Size.X - _tabsClip.Size.X + _scrollSidePadding, -_scrollSidePadding);
+	}
+
+	private void UpdateTabBar()
+	{
+		_maxScroll = GetMaxScroll();
+		ClampBarScroll();
+	}
+
+	private void ClampBarScroll()
 	{
 		var pos = _tabBar.Position;
-		pos.X = Mathf.Clamp(pos.X + delta, -Mathf.Max(_tabBar.Size.X - this.Size.X + 96, 0), 0);
+		pos.X = Mathf.Clamp(pos.X, _maxScroll, _scrollSidePadding);
 		_tabBar.Position = pos;
+		UpdateScrollButtons();
+	}
+
+	private void UpdateScrollButtons()
+	{
+		if (_tabBar.Position.X == _maxScroll)
+		{
+			_rightButton.Disabled = true;
+			_scrollRight = false;
+		}
+		else if (_rightButton.Disabled) _rightButton.Disabled = false;
+
+		if (_tabBar.Position.X == _scrollSidePadding)
+		{
+			_leftButton.Disabled = true;
+			_scrollLeft = false;
+		}
+		else if (_leftButton.Disabled) _leftButton.Disabled = false;
 	}
 }

--- a/Polytoria/scripts/creator/ui/Tabs.cs
+++ b/Polytoria/scripts/creator/ui/Tabs.cs
@@ -26,7 +26,7 @@ public sealed partial class Tabs : Control
 		private set
 		{
 			if (_currentControl == value) return;
-			if (_currentControl != null) _currentControl.Visible = false;
+			_currentControl?.Visible = false;
 
 			_currentControl = value;
 			if (value == null) return;
@@ -49,7 +49,7 @@ public sealed partial class Tabs : Control
 			{
 				World.Current = gameContainer.World;
 			}
-			if (value is TextEditorContainer tec && World.Current.LinkedSession != tec.TargetSession)
+			if (value is TextEditorContainer tec && World.Current != null && World.Current.LinkedSession != tec.TargetSession)
 			{
 				World.Current = tec.TargetSession.OpenedWorlds[0];
 			}
@@ -71,7 +71,7 @@ public sealed partial class Tabs : Control
 	private Button _leftButton = null!, _rightButton = null!;
 	private bool _scrollLeft, _scrollRight;
 	private int _maxScroll;
-	
+
 	private const int _scrollSidePadding = 2;
 
 	public static Tabs Singleton { get; private set; } = null!;
@@ -91,7 +91,7 @@ public sealed partial class Tabs : Control
 
 		_tabBar.TabCloseDisplayPolicy = TabBar.CloseButtonDisplayPolicy.ShowAlways;
 
-		_tabsClip.Resized += () => UpdateTabBar();
+		_tabsClip.Resized += UpdateTabBar;
 
 		_tabBar.TabChanged += idx =>
 		{
@@ -104,8 +104,8 @@ public sealed partial class Tabs : Control
 
 		_tabBar.ActiveTabRearranged += newIdx =>
 		{
-			var control = _orderedControls[(int)_selectedIdx];
-			_orderedControls.RemoveAt((int)_selectedIdx);
+			var control = _orderedControls[_selectedIdx];
+			_orderedControls.RemoveAt(_selectedIdx);
 			_orderedControls.Insert((int)newIdx, control);
 			RebuildLookup();
 			_selectedIdx = -1;
@@ -155,21 +155,13 @@ public sealed partial class Tabs : Control
 			TextEditorContainer tec = new(txt.TargetPath, fullPath, txt.Session) { OriginTabName = txt.Title ?? "" };
 			container = tec;
 			ScriptTypeEnum st = CreatorService.GetScriptTypeFromPath(txt.TargetPath);
-			switch (st)
+			icon = st switch
 			{
-				case (ScriptTypeEnum.Module):
-					icon = "ModuleScript";
-					break;
-				case (ScriptTypeEnum.Server):
-					icon = "ServerScript";
-					break;
-				case (ScriptTypeEnum.Client):
-					icon = "ClientScript";
-					break;
-				default:
-					icon = "Script";
-					break;
-			}
+				ScriptTypeEnum.Module => "ModuleScript",
+				ScriptTypeEnum.Server => "ServerScript",
+				ScriptTypeEnum.Client => "ClientScript",
+				_ => "Script",
+			};
 			_openedFiles[fullPath] = tec;
 		}
 		else
@@ -201,8 +193,8 @@ public sealed partial class Tabs : Control
 		}
 
 		int idx = _controlToIdx[control];
-		_orderedControls.RemoveAt((int)idx);
-		_tabBar.RemoveTab((int)idx);
+		_orderedControls.RemoveAt(idx);
+		_tabBar.RemoveTab(idx);
 
 		if (!isBulkOp)
 		{
@@ -236,14 +228,14 @@ public sealed partial class Tabs : Control
 			.ToList();
 
 		foreach (int idx in sessionTabs)
-			Remove(_orderedControls[idx], isBulkOp: true);
+			_ = Remove(_orderedControls[idx], isBulkOp: true);
 
 		if (_tabBar.TabCount > 0)
 		{
 			RebuildLookup();
 			if (CurrentControl == null)
 			{
-				var lowestClosed = sessionTabs[sessionTabs.Count - 1];
+				var lowestClosed = sessionTabs[^1];
 				CurrentControl = _orderedControls[Mathf.Clamp(lowestClosed, 0, _tabBar.TabCount - 1)];
 			}
 		}


### PR DESCRIPTION
## Summary
This PR replaces the `TabContainer`-based tab interface of the creator with a smooth scrolling tab strip using `TabBar`. I decided to rewrite the whole interface because I found that working with many tabs wasn't great, due to the snap scrolling and aggressive tab cutoff from the `TabContainer` that would complicate navigation.
Because `TabBar` does not manage the linkage of tabs and `Containers` by itself, the behaviour had to be rewritten from the ground up. Instead of hiding tabs that can't be fully displayed within the bounds of the bar, a `Control` node is used to clip the contents of the `TabBar`. When the bar is scrolled, its position relative to the clipping area is changed linearly to the left or right. The scroll buttons have also been enlarged and repositioned to be on separate sides of the bar, making them somewhat easier to click and hold.
This new layout also enables the addition of buttons or other controls next to the tab bar, which would've been complicated to pull off with `TabContainer`'s rigidity.

If there's anything I've missed, please let me know.

## Related issue or discussion

None

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Screenshot of the tab bar, at maximized and reduced window size:
<img width="1457" height="354" alt="Screenshot_20260513_195449" src="https://github.com/user-attachments/assets/d40fbaad-8fbb-42d7-beb0-d27368dfe194" />

<img width="917" height="287" alt="Screenshot_20260513_195644" src="https://github.com/user-attachments/assets/ae50eea2-b600-4ad5-9b7f-debca993f2b8" />

Video showing the new UI layout:
https://github.com/user-attachments/assets/f2e676b3-51fa-4708-b37a-40ff6fae4afe

## AI/LLM use

Minimal usage for debugging.