### PR TITLE
[Bugfix]: Fixing Capture/Screenshot logic (#no-Flips)

### DIFF
--- a/Polytoria/scripts/datamodel/services/CaptureService.cs
+++ b/Polytoria/scripts/datamodel/services/CaptureService.cs
@@ -217,8 +217,8 @@ public sealed partial class CaptureService : Instance
 		}
 
 		pivot.GlobalPosition = pos;
-		pivot.GlobalRotationDegrees = rot.FlipEuler();
-		cam.RotationDegrees = new Vector3(0, 180, 0);
+		pivot.GlobalRotationDegrees = rot;
+		cam.RotationDegrees = new Vector3(0, 0, 0);
 		if (photoSize != null && photoSize != Vector2.Zero && !(photoSize > _photoSizeLimit))
 		{
 			subview.Size = (Vector2I)photoSize;


### PR DESCRIPTION
## Summary

Frees the Screenshot-Logic from the Flips  #no-Flips

1. Change: 180 to 0 for the cam to look at the right direction (Our Cam alr looks in the right dir and we copy that value no need to change that - line could be deleted)
2. Change: Removed .FlipEuler() so the Screenshot also works when the camera is rotated (the angle changes)

## Important Note (Breaks Screenshot in older Worlds):
This change **only** fixes the screenshot inside Worlds that already converted to the new Coordinate System (introduced: 2.0.2). If your World is still on 1.0 or the System before the Coordinate-System Change u can't use Screenshots like before (causes: camera to be inverted). To give Players the best experience Migrate to the new Coordinate System (Can be done automaticly in Tools)

## Related issue or discussion

Fixes #243 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

(I have some extra settings on that seem to apply to the cam that does the screen but not to the clients cam - but thats another issue prob #144)
<img width="1150" height="630" alt="image" src="https://github.com/user-attachments/assets/14f9f6f8-9e72-4d19-b285-72af1f27522e" />


## AI/LLM use

None