### PR TITLE
Fix very odd player disappearing / camera stuck bug

### DIFF
--- a/Polytoria/scripts/utils/dto/Transform3D.cs
+++ b/Polytoria/scripts/utils/dto/Transform3D.cs
@@ -11,45 +11,36 @@ namespace Polytoria.Utils.DTOs;
 [MemoryPackable]
 public partial class Transform3DDto
 {
-	// MemoryPack no like nested classes for some reason, so we gonna string it
-	public string BasisX { get; set; } = null!;
-	public string BasisY { get; set; } = null!;
-	public string BasisZ { get; set; } = null!;
-	public string Origin { get; set; } = null!;
+	public float[] Value { get; set; } = null!;
 
 	[MemoryPackConstructor, JsonConstructor]
 	public Transform3DDto() { }
 
 	public Transform3DDto(Transform3D transform)
 	{
-		BasisX = Vector3Dto.ToString(transform.Basis.X);
-		BasisY = Vector3Dto.ToString(transform.Basis.Y);
-		BasisZ = Vector3Dto.ToString(transform.Basis.Z);
-		Origin = Vector3Dto.ToString(transform.Origin);
+		Value = ToFloatArray(transform);
 	}
 
 	public Transform3D ToTransform3D()
 	{
-		Basis basis = new(
-			Vector3Dto.FromString(BasisX),
-			Vector3Dto.FromString(BasisY),
-			Vector3Dto.FromString(BasisZ)
-		);
+		if (Value == null || Value.Length != 12)
+		{
+			throw new System.InvalidOperationException($"Invalid Transform3DDto value length: {Value?.Length ?? 0}");
+		}
 
-		return new Transform3D(basis, Vector3Dto.FromString(Origin));
+		return FromFloatArray(Value);
 	}
 
-	// String helpers because memory pack don't like nested objects
 	public static Transform3DDto FromString(string str)
 	{
 		var parts = str.Split('|');
-		return new Transform3DDto
-		{
-			BasisX = parts[0],
-			BasisY = parts[1],
-			BasisZ = parts[2],
-			Origin = parts[3]
-		};
+		Basis basis = new(
+			Vector3Dto.FromString(parts[0]),
+			Vector3Dto.FromString(parts[1]),
+			Vector3Dto.FromString(parts[2])
+		);
+
+		return new Transform3DDto(new Transform3D(basis, Vector3Dto.FromString(parts[3])));
 	}
 
 	public static string ToString(Transform3D transform)

--- a/Polytoria/scripts/utils/dto/Vector3.cs
+++ b/Polytoria/scripts/utils/dto/Vector3.cs
@@ -5,6 +5,7 @@
 using Godot;
 using MemoryPack;
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -25,13 +26,21 @@ public partial class Vector3Dto
 	public static string ToString(Vector3 src)
 	{
 		// Limit to 4 decimals
-		return $"{src.X:0.####},{src.Y:0.####},{src.Z:0.####}";
+		return string.Join(",",
+			src.X.ToString("0.####", CultureInfo.InvariantCulture),
+			src.Y.ToString("0.####", CultureInfo.InvariantCulture),
+			src.Z.ToString("0.####", CultureInfo.InvariantCulture)
+		);
 	}
 
 	public static Vector3 FromString(string src)
 	{
 		string[] parts = src.Split(',');
-		return new Vector3(float.Parse(parts[0]), float.Parse(parts[1]), float.Parse(parts[2]));
+		return new Vector3(
+			float.Parse(parts[0], CultureInfo.InvariantCulture),
+			float.Parse(parts[1], CultureInfo.InvariantCulture),
+			float.Parse(parts[2], CultureInfo.InvariantCulture)
+		);
 	}
 }
 


### PR DESCRIPTION

## Summary

As mentioned in #253 and discussed heavily on the beta server, there was a weird bug in my case that suddenly happened - when I tried testing run lil bro when running the creator through Godot itself, the moment the player got teleported everything broke apart - the camera got stuck, the player went invisible and resetting also broke.

I tried to figure out the cause of this by first narrowing down at which commit it started at, but no matter how far back I went it kept happening so it wasnt a recently introduced bug.

After a ton of weird trial and error, I noticed a weird error in the logs:
```
ERROR: Condition "det == 0" is true.
at: invert (core/math/basis.cpp:47) 
```

after consulting glorious ChatGPT, I found out that this is most likely based on a zero-scale transform. My first fix was to add a guard preventing the network sync layer to accept any zero-scale transforms, but that didn't really get to the root of the issue and I suspected it might cause desync. 

So since I had no idea (and honestly not the time) to figure out where the hell a zero transform comes from, I tasked Codex with finding the root cause. It kinda failed at that first, but when I also gave it the snippet of the Lua code it happens at, it quickly found it.

Wanna know the root cause
**Transform3Ds are packed as strings and localization fucks it over**
I love u mawji but what the hell???? 😭😭😭😭😭😭😭

They are packed as
"basisX|basisY|basisZ|origin" and each of those parts is a Vector3, with the components being seperated by a comma. and well, the components apparently werent stringified invariantly from the culture, debug logs i added temporarily showed me that it very much used the comma as decimal seperate due to my locale doing that

WELL ANYWAYS, it syncs as a float array now (and there already were helpers for that????)
also just in case the Vector3Dto.ToString/FromString are still used for some reason, i didnt check, they force invariant culture now

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [x] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

described above already. played a very big role in finding the bug.