### PR TITLE
properties Fix

### DIFF
--- a/Polytoria/scripts/creator/ui/Explorer.cs
+++ b/Polytoria/scripts/creator/ui/Explorer.cs
@@ -430,6 +430,12 @@ public sealed partial class Explorer : TabContainer
 			return;
 
 		Instance instance = _itemToInstance[item];
+
+		if (selected && !Input.IsKeyPressed(Key.Ctrl))
+		{
+			CurrentRoot?.CreatorContext.Selections.DeselectAll();
+		}
+
 		_isUpdatingSelection = true;
 		try
 		{


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
selecting a searched instance in the explorer breaks the properties menu

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
none