### PR TITLE
Revert "Fix Creator zoom flipped (#191)"

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -807,12 +807,12 @@ public sealed partial class Camera : Dynamic
 
 	private void SnapForward()
 	{
-		Position += Forward * -_moveSpeed / 10;
+		Position += Forward * _moveSpeed / 10;
 	}
 
 	private void SnapBackward()
 	{
-		Position += Forward * _moveSpeed / 10;
+		Position += Forward * -_moveSpeed / 10;
 	}
 
 	public void ReceiveDragTouchInput(InputEventScreenDrag dragEvent)


### PR DESCRIPTION
Reverts Polytoria/polytoria-game#191

Reverted due to `Dynamic.Forward` is now flipped correctly (#253)