### PR TITLE
atlas textures (custom regions of one texture) under new asset type PTAtlasImageAsset

### DIFF
--- a/Polytoria/scripts/datamodel/resources/PTAtlasImageAsset.cs
+++ b/Polytoria/scripts/datamodel/resources/PTAtlasImageAsset.cs
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Godot;
+using Polytoria.Attributes;
+using Polytoria.Scripting.Datatypes;
+using Polytoria.Shared.AssetLoaders;
+using System;
+
+namespace Polytoria.Datamodel.Resources;
+
+[Instantiable]
+public partial class PTAtlasImageAsset : PTImageAsset
+{
+	private Vector2 _regionPosition = Vector2.Zero;
+	private Vector2 _regionSize = Vector2.Zero;
+	private AtlasTexture _atlasTexture = null!;
+
+	[Editable, ScriptProperty]
+	public Vector2 RegionPosition
+	{
+		get => _regionPosition;
+		set
+		{
+			_regionPosition = value;
+			UpdateTextureSize();
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public Vector2 RegionSize
+	{
+		get => _regionSize;
+		set
+		{
+			_regionSize = value;
+			UpdateTextureSize();
+			OnPropertyChanged();
+		}
+	}
+
+	internal string? DirectImageURL { get; private set; }
+
+	public new static void RegisterAsset()
+	{
+		RegisterType<PTAtlasImageAsset>();
+	}
+
+	private Rect2 MakeRect()
+	{
+		return new Rect2
+		{
+			Position = _regionPosition,
+			Size = _regionSize
+		};
+	}
+
+	private void UpdateTextureSize()
+	{
+		if (_atlasTexture != null) _atlasTexture.Region = MakeRect();
+	}
+
+	public override void LoadResource()
+	{
+		if (ImageID == 0) { return; }
+		ResourceType resourceType = ImageType switch
+		{
+			ImageTypeEnum.Asset => ResourceType.Decal,
+			ImageTypeEnum.AssetThumbnail => ResourceType.AssetThumbnail,
+			ImageTypeEnum.WorldThumbnail => ResourceType.PlaceThumbnail,
+			ImageTypeEnum.UserAvatar => ResourceType.UserThumbnail,
+			ImageTypeEnum.UserAvatarHeadshot => ResourceType.UserHeadshot,
+			ImageTypeEnum.GuildIcon => ResourceType.GuildThumbnail,
+			ImageTypeEnum.GuildBanner => ResourceType.GuildBanner,
+			ImageTypeEnum.PlaceIcon => ResourceType.PlaceIcon,
+			_ => throw new NotImplementedException()
+		};
+
+		AssetLoader.Singleton.GetRawCache(
+			new() { Type = resourceType, ID = ImageID },
+			OnResourceLoaded
+		);
+	}
+
+	private void OnResourceLoaded(CacheItem cacheItem)
+	{
+		DirectImageURL = cacheItem.DirectURL;
+		_atlasTexture = new AtlasTexture
+		{
+			Atlas = (Texture2D)cacheItem.Resource,
+			Region = MakeRect()
+		};
+
+		InvokeResourceLoaded(_atlasTexture);
+	}
+}

--- a/Polytoria/scripts/datamodel/resources/PTAtlasImageAsset.cs.uid
+++ b/Polytoria/scripts/datamodel/resources/PTAtlasImageAsset.cs.uid
@@ -1,0 +1,1 @@
+uid://dfu33akobgxrq

--- a/Polytoria/scripts/shared/Globals.cs
+++ b/Polytoria/scripts/shared/Globals.cs
@@ -139,6 +139,7 @@ public sealed partial class Globals : Node
 		FileLinkAsset.RegisterAsset();
 		GradientImageAsset.RegisterAsset();
 		PTMeshAnimationAsset.RegisterAsset();
+		PTAtlasImageAsset.RegisterAsset();
 	}
 
 	public override void _EnterTree()


### PR DESCRIPTION
## Summary

adds a new asset type `PTAtlasImageAsset`, using godot's `AtlasTexture`.

heads up, this MIGHT not have been implemented in the best way possible? i don't exactly understand how asset types work in this codebase since it's a little disorganized imho, i managed to make it work but i don't know if it's up to standard

## Related issue or discussion

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

in creator demonstration:

https://github.com/user-attachments/assets/3ab5fd3c-7392-44f2-b5ba-d36c75c2c1bc



in player demonstration (animated via script):

https://github.com/user-attachments/assets/15157187-c5e8-4ecd-9e89-bc75c9bb202a



## AI/LLM use

None