### PR TITLE
Added DoubleSided property to Image3D's.

### DIFF
--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -28,7 +28,6 @@ public sealed partial class Image3D : Dynamic
 	private bool _castShadows;
 	private bool _shaded;
 	private bool _faceCamera;
-	private bool _doubleSided;
 	private TextureFilterEnum _textureFilter;
 
 	[Editable, ScriptProperty]
@@ -156,18 +155,6 @@ public sealed partial class Image3D : Dynamic
 		{
 			_faceCamera = value;
 			_material.BillboardMode = value ? BaseMaterial3D.BillboardModeEnum.Enabled : BaseMaterial3D.BillboardModeEnum.Disabled;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty, DefaultValue(false)]
-	public bool DoubleSided
-	{
-		get => _doubleSided;
-		set
-		{
-			_doubleSided = value;
-			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -161,16 +161,16 @@ public sealed partial class Image3D : Dynamic
 	}
 
 	[Editable, ScriptProperty, DefaultValue(false)]
-    public bool DoubleSided
-    {
-        get => _doubleSided;
-        set
-        {
-            _doubleSided = value;
-            _material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
-            OnPropertyChanged();
-        }
-    }
+	public bool DoubleSided
+	{
+		get => _doubleSided;
+		set
+		{
+			_doubleSided = value;
+			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
+			OnPropertyChanged();
+		}
+	}
 
 	[Editable, ScriptProperty, DefaultValue(TextureFilterEnum.Linear)]
 	public TextureFilterEnum TextureFilter

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -28,6 +28,7 @@ public sealed partial class Image3D : Dynamic
 	private bool _castShadows;
 	private bool _shaded;
 	private bool _faceCamera;
+	private bool _doubleSided;
 	private TextureFilterEnum _textureFilter;
 
 	[Editable, ScriptProperty]
@@ -158,6 +159,18 @@ public sealed partial class Image3D : Dynamic
 			OnPropertyChanged();
 		}
 	}
+
+	[Editable, ScriptProperty, DefaultValue(false)]
+    public bool DoubleSided
+    {
+        get => _doubleSided;
+        set
+        {
+            _doubleSided = value;
+            _material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
+            OnPropertyChanged();
+        }
+    }
 
 	[Editable, ScriptProperty, DefaultValue(TextureFilterEnum.Linear)]
 	public TextureFilterEnum TextureFilter

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -28,6 +28,7 @@ public sealed partial class Image3D : Dynamic
 	private bool _castShadows;
 	private bool _shaded;
 	private bool _faceCamera;
+	private bool _doubleSided;
 	private TextureFilterEnum _textureFilter;
 
 	[Editable, ScriptProperty]
@@ -155,6 +156,18 @@ public sealed partial class Image3D : Dynamic
 		{
 			_faceCamera = value;
 			_material.BillboardMode = value ? BaseMaterial3D.BillboardModeEnum.Enabled : BaseMaterial3D.BillboardModeEnum.Disabled;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(false)]
+	public bool DoubleSided
+	{
+		get => _doubleSided;
+		set
+		{
+			_doubleSided = value;
+			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Added DoubleSided property to Image3D objects to disable backface culling.

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None