### PR TITLE
Center mouse on CtrlLock

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -635,7 +635,11 @@ public sealed partial class Camera : Dynamic
 	{
 		if (Mode != CameraModeEnum.Follow) return;
 		_turning = true;
+
+		Vector2 screenCenter = GDNode.GetViewport().GetVisibleRect().GetCenter();
 		_turnStartPos = GDNode.GetViewport().GetMousePosition();
+		GDNode.GetViewport().WarpMouse(screenCenter);
+
 		Root.Input.OverrideMousePosTo = Root.Input.MousePosition;
 		Root.Input.OverrideMousePos = true;
 		Input.MouseMode = Input.MouseModeEnum.Captured;


### PR DESCRIPTION
## Summary
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Centers the mouse when ctrllocking, rather than retaining the original mouse position.

## Related issue or discussion

Fixes #284

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

Previous behavior

https://github.com/user-attachments/assets/30417ac0-9d71-4d92-b089-ae048830eac4

New behavior

https://github.com/user-attachments/assets/afee2f13-6c1c-49f0-8886-7638155a8e15





## AI/LLM use
<!-- Describe AI use, or write "None" if not applicable -->
None.