### PR TITLE
Conditional Visibility of Creator Settings

### DIFF
--- a/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
@@ -124,6 +124,12 @@ public static class CreatorSettingsRegistry
 				[
 					new() { Value = IndentationModeEnum.Tabs, Label = "Tabs" },
 					new() { Value = IndentationModeEnum.Spaces, Label = "Spaces" },
+				],
+				Conditions = [
+					new SettingCondition<PreferredEditorEnum>() {
+						Target = CreatorSettingKeys.CodeEditor.PreferredEditor,
+						Predicate = x => x == PreferredEditorEnum.BuiltIn
+					}
 				]
 			});
 
@@ -139,7 +145,13 @@ public static class CreatorSettingsRegistry
 				DefaultValue = 2,
 				MinValue = 1,
 				MaxValue = 8,
-				Step = 1
+				Step = 1,
+				Conditions = [
+					new SettingCondition<PreferredEditorEnum>() {
+						Target = CreatorSettingKeys.CodeEditor.PreferredEditor,
+						Predicate = x => x == PreferredEditorEnum.BuiltIn
+					}
+				]
 			});
 
 		// Popups

--- a/Polytoria/scripts/creator/ui/popups/settings/SettingsPopup.cs
+++ b/Polytoria/scripts/creator/ui/popups/settings/SettingsPopup.cs
@@ -59,7 +59,7 @@ public sealed partial class SettingsPopup : PopupWindowBase
 
 	private void OnItemSelected()
 	{
-		if (!_itemToSectionKey.TryGetValue(_categoryTree.GetSelected(), out string sectionKey))
+		if (!_itemToSectionKey.TryGetValue(_categoryTree.GetSelected(), out var sectionKey))
 			return;
 
 		if (sectionKey == _activeSection)
@@ -91,7 +91,7 @@ public sealed partial class SettingsPopup : PopupWindowBase
 		else
 		{
 			foreach (var ui in cachedUIs)
-				ui.Visible = ui._visible;
+				ui.Visible = ui.PropertyVisible;
 		}
 	}
 }

--- a/Polytoria/scripts/creator/ui/popups/settings/SettingsPopup.cs
+++ b/Polytoria/scripts/creator/ui/popups/settings/SettingsPopup.cs
@@ -91,7 +91,7 @@ public sealed partial class SettingsPopup : PopupWindowBase
 		else
 		{
 			foreach (var ui in cachedUIs)
-				ui.Visible = true;
+				ui.Visible = ui._visible;
 		}
 	}
 }

--- a/Polytoria/scripts/creator/ui/popups/settings/components/SettingsPropertyUI.cs
+++ b/Polytoria/scripts/creator/ui/popups/settings/components/SettingsPropertyUI.cs
@@ -18,7 +18,7 @@ public partial class SettingsPropertyUI : Control
 
 	public SettingDef SettingDef { get; private set; } = null!;
 	public ISettingsContext SettingsContext { get; private set; } = null!;
-	public bool _visible = true;
+	public bool PropertyVisible = true;
 
 	private IProperty _input = null!;
 	private bool _suppressChanged;
@@ -50,7 +50,7 @@ public partial class SettingsPropertyUI : Control
 		((Control)input).SetAnchorsAndOffsetsPreset(Control.LayoutPreset.FullRect);
 
 		if (SettingDef.Conditions != null)
-			Visible = _visible = false;
+			Visible = PropertyVisible = false;
 
 		_input = input;
 		SettingsContext.Changed += OnExternalChanged;
@@ -65,7 +65,7 @@ public partial class SettingsPropertyUI : Control
 				// Visible at start?
 				if (SettingDef.Conditions != null)
 				{
-					Visible = _visible = SettingDef.Conditions.Any((cond) =>
+					Visible = PropertyVisible = SettingDef.Conditions.Any((cond) =>
 					{
 						object? value = SettingsContext.GetUntyped(cond.Target);
 						return cond.UntypedPredicate(value);
@@ -103,7 +103,7 @@ public partial class SettingsPropertyUI : Control
 		{
 			var match = SettingDef.Conditions.Where(c => c.Target == e.Key);
 			if (match.Any())
-				Visible = _visible = match.Any(c => c.UntypedPredicate(e.NewValue));
+				Visible = PropertyVisible = match.Any(c => c.UntypedPredicate(e.NewValue));
 		}
 
 		if (_suppressChanged || e.Key != SettingDef.Key)

--- a/Polytoria/scripts/creator/ui/popups/settings/components/SettingsPropertyUI.cs
+++ b/Polytoria/scripts/creator/ui/popups/settings/components/SettingsPropertyUI.cs
@@ -7,6 +7,7 @@ using Polytoria.Creator.Properties;
 using Polytoria.Shared;
 using Polytoria.Shared.Settings;
 using System;
+using System.Linq;
 
 namespace Polytoria.Creator.UI.Components;
 
@@ -17,6 +18,7 @@ public partial class SettingsPropertyUI : Control
 
 	public SettingDef SettingDef { get; private set; } = null!;
 	public ISettingsContext SettingsContext { get; private set; } = null!;
+	public bool _visible = true;
 
 	private IProperty _input = null!;
 	private bool _suppressChanged;
@@ -47,6 +49,9 @@ public partial class SettingsPropertyUI : Control
 
 		((Control)input).SetAnchorsAndOffsetsPreset(Control.LayoutPreset.FullRect);
 
+		if (SettingDef.Conditions != null)
+			Visible = _visible = false;
+
 		_input = input;
 		SettingsContext.Changed += OnExternalChanged;
 
@@ -57,6 +62,16 @@ public partial class SettingsPropertyUI : Control
 
 			try
 			{
+				// Visible at start?
+				if (SettingDef.Conditions != null)
+				{
+					Visible = _visible = SettingDef.Conditions.Any((cond) =>
+					{
+						object? value = SettingsContext.GetUntyped(cond.Target);
+						return cond.UntypedPredicate(value);
+					});
+				}
+
 				object? currentValue = SettingsContext.GetUntyped(SettingDef.Key);
 				input.SetValue(currentValue);
 
@@ -83,6 +98,14 @@ public partial class SettingsPropertyUI : Control
 
 	private void OnExternalChanged(SettingChangedEvent e)
 	{
+		// Recompute visibility
+		if (SettingDef.Conditions != null)
+		{
+			var match = SettingDef.Conditions.Where(c => c.Target == e.Key);
+			if (match.Any())
+				Visible = _visible = match.Any(c => c.UntypedPredicate(e.NewValue));
+		}
+
 		if (_suppressChanged || e.Key != SettingDef.Key)
 			return;
 

--- a/Polytoria/scripts/shared/settings/SettingDef.cs
+++ b/Polytoria/scripts/shared/settings/SettingDef.cs
@@ -23,6 +23,20 @@ public class SettingOption<T> : ISettingOption
 	public object? UntypedValue => Value;
 }
 
+public interface ISettingCondition
+{
+	string Target { get; }
+	Func<object?, bool> UntypedPredicate { get; }
+}
+
+public class SettingCondition<T> : ISettingCondition
+{
+	private Func<object?, bool>? _cachedUntypedPredicate;
+	public Func<object?, bool> UntypedPredicate => _cachedUntypedPredicate ??= o => Predicate((T)o!);
+	public required string Target { get; init; }
+	public required Func<T, bool> Predicate { get; init; }
+}
+
 public abstract class SettingDef
 {
 	public required string Key { get; init; }
@@ -35,6 +49,7 @@ public abstract class SettingDef
 
 	public bool RequiresRestart { get; init; }
 	public bool IsAdvanced { get; init; }
+	public IReadOnlyList<ISettingCondition>? Conditions { get; init; }
 
 	public abstract object UntypedDefault { get; }
 	public abstract Type ValueType { get; }


### PR DESCRIPTION
## Summary

This adds an ability to define a condition that modifies whether a setting in Creator is visible. I want this feature for a future feature I want to add.

To demonstrate this feature, it has been used on the built-in code editor indentation features.

I'm not super confident on my implementation. I hope it's okay!

## Related issue or discussion

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [X] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

[dvgbgfe5OQ.webm](https://github.com/user-attachments/assets/6fa3d3c4-491f-4864-be11-390e111ec164)

## AI/LLM use

I consulted it for certain bugs and received zero useful information.