### PR TITLE
Add .lscache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ ers
 
 .DS_Store
 Thumbs.db
+
+# C# Dev Kit language server cache files
+*.lscache


### PR DESCRIPTION
## Summary

New C# dev kit for vscode update adds .lscache files which get added to the source tree, this ignores them

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [x] Other

## Checklist

- [ ] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [ ] Ran `dotnet restore`
- [ ] Ran `dotnet format`
- [ ] Ran `dotnet build`
- [ ] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [ ] Tested the changes in a local environment
- [ ] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->