### PR TITLE
Add Camera.Near & Camera.Far

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -42,6 +42,9 @@ public sealed partial class Camera : Dynamic
 	private bool _ctrlLocked = false;
 	private bool _alwaysLocked = false;
 
+	private float _nearPlaneZ;
+	private float _farPlaneZ;
+
 	private float _moveSpeed = 8f;
 	private readonly float _rotateSpeed = 0.005f;
 	private Dynamic? _target = null!;
@@ -182,6 +185,28 @@ public sealed partial class Camera : Dynamic
 		{
 			_orthographicSize = value;
 			Camera3D.Size = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(0.05f)]
+	public float NearPlaneZ
+	{
+		get => _nearPlaneZ;
+		set
+		{
+			_nearPlaneZ = Camera3D.Near = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(4000f)]
+	public float FarPlaneZ
+	{
+		get => _farPlaneZ;
+		set
+		{
+			_farPlaneZ = Camera3D.Far = value;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -42,8 +42,8 @@ public sealed partial class Camera : Dynamic
 	private bool _ctrlLocked = false;
 	private bool _alwaysLocked = false;
 
-	private float _nearPlaneZ;
-	private float _farPlaneZ;
+	private float _near;
+	private float _far;
 
 	private float _moveSpeed = 8f;
 	private readonly float _rotateSpeed = 0.005f;
@@ -190,23 +190,23 @@ public sealed partial class Camera : Dynamic
 	}
 
 	[Editable, ScriptProperty, DefaultValue(0.05f)]
-	public float NearPlaneZ
+	public float Near
 	{
-		get => _nearPlaneZ;
+		get => _near;
 		set
 		{
-			_nearPlaneZ = Camera3D.Near = value;
+			_near = Camera3D.Near = value;
 			OnPropertyChanged();
 		}
 	}
 
 	[Editable, ScriptProperty, DefaultValue(4000f)]
-	public float FarPlaneZ
+	public float Far
 	{
-		get => _farPlaneZ;
+		get => _far;
 		set
 		{
-			_farPlaneZ = Camera3D.Far = value;
+			_far = Camera3D.Far = value;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

adds `Camera.Near` and `Camera.Far`, which expose `Camera3D.Near` and `Camera.Far` respectively. rendering can be a little bit finicky with some specific values, but I think these are probably fine staying unclamped

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img src=https://github.com/user-attachments/assets/fbc57b16-1625-44f2-9be5-13a8c640f91d>

## AI/LLM use

None