### PR TITLE
Add CanCollide check when building navmesh

### DIFF
--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -457,7 +457,7 @@ public sealed partial class Environment : Instance
 		// Build navigation mesh
 		foreach (Instance i in GetDescendants())
 		{
-			if (i is Part part)
+			if (i is Part part && part.CanCollide is true)
 			{
 				StaticBody3D staticBody = new();
 				_navRegion.AddChild(staticBody);
@@ -469,8 +469,9 @@ public sealed partial class Environment : Instance
 				};
 				staticBody.AddChild(collisionShape);
 				collisionShape.GlobalTransform = part.GetGlobalTransform();
+
 			}
-			else if (i is Mesh m)
+			else if (i is Mesh m && m.CanCollide is true)
 			{
 				Node3D md = (Node3D)m.GDNode.Duplicate();
 				_navRegion.AddChild(md);


### PR DESCRIPTION
## Summary
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Navmesh building now checks if parts/meshes are collidable, which previously caused pathfinding to be stuck on non-collidable objects.

## Related issue or discussion

Fixes #297

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

https://github.com/user-attachments/assets/3d705a45-4224-4b06-9aa8-373b69040c87

## AI/LLM use
None.
<!-- Describe AI use, or write "None" if not applicable -->