### PR TITLE
Fix TweenService.TweenRotation

### DIFF
--- a/Polytoria/scripts/datamodel/services/TweenService.cs
+++ b/Polytoria/scripts/datamodel/services/TweenService.cs
@@ -480,10 +480,10 @@ public sealed partial class TweenService : Instance
 		[ScriptMethod]
 		public void TweenRotation(Dynamic target, Vector3 destination, float time)
 		{
-			tween.TweenMethod(Callable.From((Quaternion val) =>
+			TweenQuaternion(target.Quaternion, Quaternion.FromEuler(destination.DegToRad()), time, new((q) =>
 			{
-				target.GDNode3D.Quaternion = val;
-			}), target.GDNode3D.Quaternion, Quaternion.FromEuler(destination.FlipEuler()), time);
+				target.Quaternion = (Quaternion)q[0]!;
+			}));
 		}
 
 		[ScriptMethod]


### PR DESCRIPTION
## Summary

Fixed implementation of TweenRotation to not use bad values and follow style of TweenPosition.

## Related issue or discussion

Fixes #306

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [X] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

[AbsBfC9OZ1.webm](https://github.com/user-attachments/assets/eec74eb5-3e10-4d32-b7d8-2035e36a5909)

(See issue for code)

## AI/LLM use

None