### PR TITLE
Added two new methods, implementing gamepad vibration support

### DIFF
--- a/Polytoria/scripts/datamodel/services/InputService.cs
+++ b/Polytoria/scripts/datamodel/services/InputService.cs
@@ -549,6 +549,16 @@ public sealed partial class InputService : Instance
 	}
 
 	[ScriptMethod]
+	public void StartGamepadVibration(float weakMagnitude, float strongMagnitude, float duration){
+		Input.StartJoyVibration(0,weakMagnitude,strongMagnitude,duration);
+	}
+	
+	[ScriptMethod]
+	public void StopGamepadVibration(){
+		Input.StopJoyVibration(0);
+	}
+
+	[ScriptMethod]
 	public Vector3 GetMouseWorldPosition(Instance[]? ignoreList = null)
 	{
 		Viewport viewport = GDNode.GetViewport();


### PR DESCRIPTION
## Summary

Added`Input:StartGamepadVibration` and `Input:StopGamepadVibration` methods to implement controller vibration/haptic support

## Related issue or discussion

Related to #305

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

none