### PR TITLE
Add AutoSize property to UILabel

### DIFF
--- a/Polytoria/scripts/datamodel/UILabel.cs
+++ b/Polytoria/scripts/datamodel/UILabel.cs
@@ -40,6 +40,7 @@ public partial class UILabel : UIView
 			_text = value;
 			_richLabel.Text = _text;
 			_label.Text = _text;
+			if (_autoSize) UpdateAutosize();
 			OnPropertyChanged();
 		}
 	}
@@ -259,17 +260,17 @@ public partial class UILabel : UIView
 			OnPropertyChanged();
 		}
 	}
-	
+
 	private void UpdateAutosize()
 	{
 		Font font = _label.GetThemeFont("font");
 		Vector2 bounds = NodeControl.Size;
 		int lo = 1, hi = 512, result = 0;
-		
+
 		while (lo <= hi)
 		{
 			int mid = (lo + hi) / 2;
-			int scaled = (int)(mid*FontScaleConversion);
+			int scaled = (int)(mid * FontScaleConversion);
 			Vector2 textBounds = font.GetStringSize(_text, _label.HorizontalAlignment, -1, scaled);
 			if (textBounds.X <= bounds.X && textBounds.Y <= bounds.Y)
 			{
@@ -278,10 +279,10 @@ public partial class UILabel : UIView
 			}
 			else hi = mid - 1;
 		}
-		
+
 		SetTextSize(result);
 	}
-	
+
 	private void SetTextSize(float size)
 	{
 		int setto = (int)(size * FontScaleConversion);

--- a/Polytoria/scripts/datamodel/UILabel.cs
+++ b/Polytoria/scripts/datamodel/UILabel.cs
@@ -18,6 +18,7 @@ public partial class UILabel : UIView
 	private string _text = "";
 	private Color _textColor;
 	private float _fontSize;
+	private bool _autoSize;
 	private bool _useRichText;
 	private TextHorizontalAlignmentEnum _justify;
 	private TextVerticalAlignmentEnum _verticalAlign;
@@ -142,17 +143,31 @@ public partial class UILabel : UIView
 		set
 		{
 			_fontSize = value;
-			int setto = (int)(_fontSize * FontScaleConversion);
-			_label.AddThemeFontSizeOverride("font_size", setto);
-			_richLabel.AddThemeFontSizeOverride("normal_font_size", setto);
-			_richLabel.AddThemeFontSizeOverride("bold_font_size", setto);
-			_richLabel.AddThemeFontSizeOverride("bold_italics_font_size", setto);
-			_richLabel.AddThemeFontSizeOverride("italics_font_size", setto);
-			_richLabel.AddThemeFontSizeOverride("mono_font_size", setto);
+			if (!_autoSize) SetTextSize(_fontSize);
 			OnPropertyChanged();
 		}
 	}
 
+	[Editable, ScriptProperty]
+	public bool AutoSize
+	{
+		get => _autoSize;
+		set
+		{
+			_autoSize = value;
+			if (_autoSize)
+			{
+				NodeControl.Resized += UpdateAutosize;
+				UpdateAutosize();
+			}
+			else
+			{
+				NodeControl.Resized -= UpdateAutosize;
+				SetTextSize(_fontSize);
+			}
+			OnPropertyChanged();
+		}
+	}
 
 	[Editable, ScriptProperty]
 	public bool UseRichText
@@ -244,6 +259,39 @@ public partial class UILabel : UIView
 			OnPropertyChanged();
 		}
 	}
+	
+	private void UpdateAutosize()
+	{
+		Font font = _label.GetThemeFont("font");
+		Vector2 bounds = NodeControl.Size;
+		int lo = 1, hi = 512, result = 0;
+		
+		while (lo <= hi)
+		{
+			int mid = (lo + hi) / 2;
+			int scaled = (int)(mid*FontScaleConversion);
+			Vector2 textBounds = font.GetStringSize(_text, _label.HorizontalAlignment, -1, scaled);
+			if (textBounds.X <= bounds.X && textBounds.Y <= bounds.Y)
+			{
+				result = mid;
+				lo = mid + 1;
+			}
+			else hi = mid - 1;
+		}
+		
+		SetTextSize(result);
+	}
+	
+	private void SetTextSize(float size)
+	{
+		int setto = (int)(size * FontScaleConversion);
+		_label.AddThemeFontSizeOverride("font_size", setto);
+		_richLabel.AddThemeFontSizeOverride("normal_font_size", setto);
+		_richLabel.AddThemeFontSizeOverride("bold_font_size", setto);
+		_richLabel.AddThemeFontSizeOverride("bold_italics_font_size", setto);
+		_richLabel.AddThemeFontSizeOverride("italics_font_size", setto);
+		_richLabel.AddThemeFontSizeOverride("mono_font_size", setto);
+	}
 
 	private void OnFontLoaded(Resource resource)
 	{
@@ -253,6 +301,7 @@ public partial class UILabel : UIView
 		_richLabel.AddThemeFontOverride("bold_italics_font", (Font)resource);
 		_richLabel.AddThemeFontOverride("italics_font", (Font)resource);
 		_richLabel.AddThemeFontOverride("mono_font", (Font)resource);
+		if (_autoSize) UpdateAutosize();
 	}
 
 	public override void Init()


### PR DESCRIPTION
## Summary

This PR adds an `AutoSize` property to the `UILabel` class. When enabled, text is automatically resized to fit within the bounds of the `UILabel`.

## Related issue or discussion

None, but was suggested in the main discord server.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video


[polytoria_autoSize.mp4](https://github.com/user-attachments/assets/a7b86687-15f4-455e-8c57-ecf6b231ab6c)

## AI/LLM use

None