### PR TITLE
[Feature] Framerate controls in settings

### DIFF
--- a/Polytoria/scripts/client/settings/appliers/DisplaySettingsApplier.cs
+++ b/Polytoria/scripts/client/settings/appliers/DisplaySettingsApplier.cs
@@ -32,6 +32,9 @@ public sealed partial class DisplaySettingsApplier : Node
 			case SharedSettingKeys.Display.VSync:
 				ApplyVsync();
 				break;
+			case SharedSettingKeys.Display.FpsCap:
+				ApplyFpsCap();
+				break;
 			case ClientSettingKeys.Display.UiScale:
 				ApplyUiScale();
 				break;
@@ -42,6 +45,7 @@ public sealed partial class DisplaySettingsApplier : Node
 	{
 		ApplyFullscreen();
 		ApplyVsync();
+		ApplyFpsCap();
 		ApplyUiScale();
 	}
 
@@ -60,6 +64,11 @@ public sealed partial class DisplaySettingsApplier : Node
 	{
 		bool vsync = ClientSettingsService.Instance.Get<bool>(SharedSettingKeys.Display.VSync);
 		DisplayServer.WindowSetVsyncMode(vsync ? DisplayServer.VSyncMode.Enabled : DisplayServer.VSyncMode.Disabled);
+	}
+
+	private void ApplyFpsCap()
+	{
+		Engine.MaxFps = ClientSettingsService.Instance.Get<int>(SharedSettingKeys.Display.FpsCap);
 	}
 
 	private void ApplyUiScale()

--- a/Polytoria/scripts/client/settings/appliers/DisplaySettingsApplier.cs
+++ b/Polytoria/scripts/client/settings/appliers/DisplaySettingsApplier.cs
@@ -32,6 +32,9 @@ public sealed partial class DisplaySettingsApplier : Node
 			case SharedSettingKeys.Display.VSync:
 				ApplyVsync();
 				break;
+			case SharedSettingKeys.Display.FpsPreset:
+				ApplyFpsCap();
+				break;
 			case SharedSettingKeys.Display.FpsCap:
 				ApplyFpsCap();
 				break;
@@ -68,7 +71,8 @@ public sealed partial class DisplaySettingsApplier : Node
 
 	private void ApplyFpsCap()
 	{
-		Engine.MaxFps = ClientSettingsService.Instance.Get<int>(SharedSettingKeys.Display.FpsCap);
+		var fpsPreset = ClientSettingsService.Instance.Get<FpsPreset>(SharedSettingKeys.Display.FpsPreset);
+		Engine.MaxFps = fpsPreset != FpsPreset.Custom ? (int)fpsPreset : ClientSettingsService.Instance.Get<int>(SharedSettingKeys.Display.FpsCap);
 	}
 
 	private void ApplyUiScale()

--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -116,6 +116,7 @@ public partial class CreatorInterface : Control, IScriptObject
 		ApplyUIScale();
 		ApplyFullscreen();
 		ApplyVSync();
+		ApplyFpsCap();
 
 		base._Ready();
 	}
@@ -138,6 +139,9 @@ public partial class CreatorInterface : Control, IScriptObject
 				break;
 			case SharedSettingKeys.Display.VSync:
 				ApplyVSync();
+				break;
+			case SharedSettingKeys.Display.FpsCap:
+				ApplyFpsCap();
 				break;
 		}
 	}
@@ -177,6 +181,11 @@ public partial class CreatorInterface : Control, IScriptObject
 		bool useVSync = CreatorSettingsService.Instance.Get<bool>(SharedSettingKeys.Display.VSync);
 		DisplayServer.WindowSetVsyncMode(useVSync ? DisplayServer.VSyncMode.Enabled : DisplayServer.VSyncMode.Disabled);
 		OS.LowProcessorUsageMode = useVSync;
+	}
+
+	private static void ApplyFpsCap()
+	{
+		Engine.MaxFps = CreatorSettingsService.Instance.Get<int>(SharedSettingKeys.Display.FpsCap);
 	}
 
 	public static void CreateNewWorld()

--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -140,6 +140,9 @@ public partial class CreatorInterface : Control, IScriptObject
 			case SharedSettingKeys.Display.VSync:
 				ApplyVSync();
 				break;
+			case SharedSettingKeys.Display.FpsPreset:
+				ApplyFpsCap();
+				break;
 			case SharedSettingKeys.Display.FpsCap:
 				ApplyFpsCap();
 				break;
@@ -185,7 +188,8 @@ public partial class CreatorInterface : Control, IScriptObject
 
 	private static void ApplyFpsCap()
 	{
-		Engine.MaxFps = CreatorSettingsService.Instance.Get<int>(SharedSettingKeys.Display.FpsCap);
+		var fpsPreset = CreatorSettingsService.Instance.Get<FpsPreset>(SharedSettingKeys.Display.FpsPreset);
+		Engine.MaxFps = fpsPreset != FpsPreset.Custom ? (int)fpsPreset : CreatorSettingsService.Instance.Get<int>(SharedSettingKeys.Display.FpsCap);
 	}
 
 	public static void CreateNewWorld()

--- a/Polytoria/scripts/shared/settings/SharedSettingEnums.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingEnums.cs
@@ -4,6 +4,15 @@
 
 namespace Polytoria.Shared.Settings;
 
+public enum FpsPreset
+{
+	Custom = 9999,
+	Limitless = 0,
+	Reduced = 30,
+	Standard = 60,
+	Extended = 120
+}
+
 public enum GraphicsPreset
 {
 	Low,

--- a/Polytoria/scripts/shared/settings/SharedSettingEnums.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingEnums.cs
@@ -10,7 +10,10 @@ public enum FpsPreset
 	Limitless = 0,
 	Reduced = 30,
 	Standard = 60,
-	Extended = 120
+	Extended = 90,
+	Smooth = 120,
+	Slick = 144,
+	Fluid = 240
 }
 
 public enum GraphicsPreset

--- a/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
@@ -10,6 +10,7 @@ public static class SharedSettingKeys
 	{
 		public const string Fullscreen = "display.fullscreen";
 		public const string VSync = "display.vsync";
+		public const string FpsCap = "display.fps_cap";
 	}
 
 	public static class Graphics

--- a/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
@@ -10,6 +10,7 @@ public static class SharedSettingKeys
 	{
 		public const string Fullscreen = "display.fullscreen";
 		public const string VSync = "display.vsync";
+		public const string FpsPreset = "display.fps_preset";
 		public const string FpsCap = "display.fps_cap";
 	}
 

--- a/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
@@ -48,6 +48,22 @@ public static class SharedSettingsRegistry
 				}
 			},
 			{
+				SharedSettingKeys.Display.FpsCap,
+				new SettingDef<int>
+				{
+					Key = SharedSettingKeys.Display.FpsCap,
+					SectionKey = "display",
+					Label = "FPS Cap",
+					Description = "Limit the maximum number of frames per second.",
+					ValueKind = SettingValueKind.Int,
+					ControlKind = SettingControlKind.Slider,
+					DefaultValue = 0,
+					MinValue = 0,
+					MaxValue = 300,
+					Step = 6
+				}
+			},
+			{
 				SharedSettingKeys.Graphics.Preset,
 				new SettingDef<GraphicsPreset>
 				{

--- a/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
@@ -54,7 +54,7 @@ public static class SharedSettingsRegistry
 					Key = SharedSettingKeys.Display.FpsPreset,
 					SectionKey = "display",
 					Label = "FPS Preset",
-					Description = "Fps preset.",
+					Description = "Set the FPS preset to use.\nIf V-Sync is enabled, framerate won't surpass the display refresh rate.",
 					ValueKind = SettingValueKind.Enum,
 					ControlKind = SettingControlKind.Dropdown,
 					DefaultValue = FpsPreset.Custom,
@@ -63,7 +63,10 @@ public static class SharedSettingsRegistry
 						new() { Value = FpsPreset.Custom, Label = "Custom" },
 						new() { Value = FpsPreset.Reduced, Label = "Reduced (30)" },
 						new() { Value = FpsPreset.Standard, Label = "Standard (60)" },
-						new() { Value = FpsPreset.Extended, Label = "Extended (120)" },
+						new() { Value = FpsPreset.Extended, Label = "Extended (90)" },
+						new() { Value = FpsPreset.Smooth, Label = "Smooth (120)" },
+						new() { Value = FpsPreset.Slick, Label = "Slick (144)" },
+						new() { Value = FpsPreset.Fluid, Label = "Fluid (240)" },
 						new() { Value = FpsPreset.Limitless, Label = "Limitless" },
 					]
 				}
@@ -75,12 +78,12 @@ public static class SharedSettingsRegistry
 					Key = SharedSettingKeys.Display.FpsCap,
 					SectionKey = "display",
 					Label = "FPS Cap",
-					Description = "Set the maximum number of frames per second.\nIf V-Sync is enabled, it won't surpass the refresh rate.",
+					Description = "Limit the number of frames per second.",
 					ValueKind = SettingValueKind.Int,
 					ControlKind = SettingControlKind.Slider,
 					DefaultValue = 0,
 					MinValue = 0,
-					MaxValue = 300,
+					MaxValue = 360,
 					Step = 6,
 					Conditions = [
 						new SettingCondition<FpsPreset>() {

--- a/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
@@ -48,19 +48,46 @@ public static class SharedSettingsRegistry
 				}
 			},
 			{
+				SharedSettingKeys.Display.FpsPreset,
+				new SettingDef<FpsPreset>
+				{
+					Key = SharedSettingKeys.Display.FpsPreset,
+					SectionKey = "display",
+					Label = "FPS Preset",
+					Description = "Fps preset.",
+					ValueKind = SettingValueKind.Enum,
+					ControlKind = SettingControlKind.Dropdown,
+					DefaultValue = FpsPreset.Custom,
+					Options =
+					[
+						new() { Value = FpsPreset.Custom, Label = "Custom" },
+						new() { Value = FpsPreset.Reduced, Label = "Reduced (30)" },
+						new() { Value = FpsPreset.Standard, Label = "Standard (60)" },
+						new() { Value = FpsPreset.Extended, Label = "Extended (120)" },
+						new() { Value = FpsPreset.Limitless, Label = "Limitless" },
+					]
+				}
+			},
+			{
 				SharedSettingKeys.Display.FpsCap,
 				new SettingDef<int>
 				{
 					Key = SharedSettingKeys.Display.FpsCap,
 					SectionKey = "display",
 					Label = "FPS Cap",
-					Description = "Limit the maximum number of frames per second.",
+					Description = "Set the maximum number of frames per second.\nIf V-Sync is enabled, it won't surpass the refresh rate.",
 					ValueKind = SettingValueKind.Int,
 					ControlKind = SettingControlKind.Slider,
 					DefaultValue = 0,
 					MinValue = 0,
 					MaxValue = 300,
-					Step = 6
+					Step = 6,
+					Conditions = [
+						new SettingCondition<FpsPreset>() {
+							Target = SharedSettingKeys.Display.FpsPreset,
+							Predicate = x => x == FpsPreset.Custom
+						}
+					]
 				}
 			},
 			{


### PR DESCRIPTION
## Summary
This PR adds extensive options for limiting the number of frames per second rendered within the creator and client. This feature has been requested by many people, because the only option currently available is to disable/enable V-Sync. This is not enough, especially for people with high refresh rate screens, laptops or other devices, where there needs to be less power consumption and load on the system.

FPS Presets are meant to be quick to select. There are 8 presets available:
- "Reduced" => 30 fps
- "Standard" => 60 fps
- "Extended" => 90 fps
- "Smooth" => 120 fps
- "Slick" => 144 fps
- "Fluid" => 240 fps
- "Limitless" => disables the framerate cap
- "Custom" => enables selecting a custom limit with a slider. The slider accepts values from 0 (i.e. no limit) to 360 and snaps to integers divisible by 6.

When V-Sync is enabled, the framerate is never allowed to surpass the display refresh rate. It can be used in cases where a common refresh rate is not available through the custom cap slider (like 75 or 160).

## Related issue or discussion

Related to #295 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Creator interface
<img width="880" height="608" alt="image" src="https://github.com/user-attachments/assets/ea5936ef-749b-4832-9057-6e69152c11f3" />
<img width="179" height="241" alt="image" src="https://github.com/user-attachments/assets/a021d02e-bba8-4033-b0b9-ca79a689afcf" />

Client interface
<img width="962" height="524" alt="image" src="https://github.com/user-attachments/assets/252bee7c-d296-4fda-9353-ae962d0c2220" />
<img width="962" height="524" alt="image" src="https://github.com/user-attachments/assets/65039109-d480-46f1-ad64-e461a66272cb" />


(outdated video only showing the slider)
[polytoria_fpsCap.mp4](https://github.com/user-attachments/assets/b81a2d73-b088-4f2d-a5d5-30f0299a03b1)

## AI/LLM use

None