### PR TITLE
Fix oneshot animation filter logic

### DIFF
--- a/Polytoria/scripts/datamodel/Animator.cs
+++ b/Polytoria/scripts/datamodel/Animator.cs
@@ -414,19 +414,12 @@ public partial class Animator : Instance
 		Godot.Animation anim = AnimationTree.GetAnimation(animationName);
 		animationOneShot.FilterEnabled = true;
 
-		// Filter out one-frame keys
+		// Filter only nodes that have at least one track with more than 1 key
 		for (int i = 0; i < anim.GetTrackCount(); i++)
 		{
-			NodePath trackPath = anim.TrackGetPath(i);
-			int keyCount = anim.TrackGetKeyCount(i);
-
-			if (keyCount <= 1)
+			if (anim.TrackGetKeyCount(i) > 1)
 			{
-				animationOneShot.SetFilterPath(trackPath, false);
-			}
-			else
-			{
-				animationOneShot.SetFilterPath(trackPath, true);
+				animationOneShot.SetFilterPath(anim.TrackGetPath(i), true);
 			}
 		}
 


### PR DESCRIPTION
## Summary

nodes now filter if at least one of their tracks have more than 1 key. fixes the `Wave` animation

## Related issue or discussion

Fixes #321

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img src=https://github.com/user-attachments/assets/aee6039f-9109-42b8-9f71-5fe160cb43d4>

## AI/LLM use

None