### PR TITLE
Fix Pick Instance Cancellation

### DIFF
--- a/Polytoria/scripts/creator/properties/InstanceProperty.cs
+++ b/Polytoria/scripts/creator/properties/InstanceProperty.cs
@@ -4,6 +4,7 @@
 
 using Godot;
 using Polytoria.Datamodel;
+using Polytoria.Datamodel.Creator;
 using System;
 using System.Threading.Tasks;
 
@@ -45,6 +46,10 @@ public sealed partial class InstanceProperty : Button, IProperty<Instance?>
 			ValueChanged?.Invoke(i);
 		}
 		catch (TaskCanceledException) { }
+		catch (Exception ex)
+		{
+			CreatorService.Interface.PopupAlert(ex.Message, "Assignment error");
+		}
 		base._Pressed();
 	}
 

--- a/Polytoria/scripts/datamodel/creator/CreatorSelections.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorSelections.cs
@@ -51,8 +51,7 @@ public sealed partial class CreatorSelections : Instance
 	{
 		if (@event.IsActionPressed("ui_cancel"))
 		{
-			_pickTcs?.SetException(new TaskCanceledException());
-			CreatorService.Interface.StopFollowCursorLabel();
+			CancelPickInstance();
 		}
 	}
 
@@ -82,7 +81,7 @@ public sealed partial class CreatorSelections : Instance
 
 		if (_pickTcs != null)
 		{
-			_pickTcs.SetResult(instance);
+			_pickTcs.TrySetResult(instance);
 			_pickTcs = null;
 			CreatorService.Interface.StopFollowCursorLabel();
 		}
@@ -357,5 +356,12 @@ public sealed partial class CreatorSelections : Instance
 		CreatorService.Interface.StartFollowCursorLabel("Click to pick an instance, or press Esc to cancel.");
 		_pickTcs = new();
 		return _pickTcs.Task;
+	}
+
+	public void CancelPickInstance()
+	{
+		_pickTcs?.TrySetException(new TaskCanceledException());
+		_pickTcs = null;
+		CreatorService.Interface.StopFollowCursorLabel();
 	}
 }


### PR DESCRIPTION
## Summary

Fix Pick instance cancellation, previously it wasn't being cleared correctly, causing unexpected behaviour on `CreatorSelections`

## Related issue or discussion

Fixes #324

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None