### PR TITLE
Draft: Expose Volumetric Fog Options

### DIFF
--- a/Polytoria/scripts/datamodel/Lighting.cs
+++ b/Polytoria/scripts/datamodel/Lighting.cs
@@ -179,6 +179,14 @@ public sealed partial class Lighting : Instance
 	private Color _fogColor;
 	private float _fogStartDistance;
 	private float _fogEndDistance;
+	private bool _volumetricFogEnabled;
+	private float _volumetricFogDensity;
+	private Color _volumetricFogLightColor;
+	private Color _volumetricFogAmbientColor;
+	private float _volumetricFogSkyImpact;
+	private float _volumetricFogDetailLength;
+	private float _volumetricFogLightingImpact;
+	private float _volumetricFogAnisotropy;
 
 	[Editable, ScriptProperty]
 	public AmbientSourceEnum AmbientSource
@@ -250,6 +258,104 @@ public sealed partial class Lighting : Instance
 		{
 			_fogEndDistance = value;
 			environment.FogDepthEnd = value;
+			OnPropertyChanged();
+		}
+	}
+
+	// Does not work on opengl
+	[Editable, ScriptProperty]
+	public bool VolumetricFogEnabled
+	{
+		get => _volumetricFogEnabled;
+		set
+		{
+			_volumetricFogEnabled = value;
+			environment.VolumetricFogEnabled = value;
+
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float VolumetricFogDensity
+	{
+		get => _volumetricFogDensity;
+		set
+		{
+			_volumetricFogDensity = value;
+			environment.VolumetricFogDensity = value;
+
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public Color VolumetricFogLightColor
+	{
+		get => _volumetricFogLightColor;
+		set
+		{
+			_volumetricFogLightColor = value;
+			environment.VolumetricFogAlbedo = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public Color VolumetricFogAmbientColor
+	{
+		get => _volumetricFogAmbientColor;
+		set
+		{
+			_volumetricFogAmbientColor = value;
+			environment.VolumetricFogEmission = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float VolumetricFogSkyImpact
+	{
+		get => _volumetricFogSkyImpact;
+		set
+		{
+			_volumetricFogSkyImpact = value;
+			environment.VolumetricFogSkyAffect = value;
+			OnPropertyChanged();
+		}
+	}
+	[Editable, ScriptProperty]
+	public float VolumetricFogLightingImpact
+	{
+		get => _volumetricFogLightingImpact;
+		set
+		{
+			_volumetricFogLightingImpact = value;
+			environment.VolumetricFogGIInject = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float VolumetricFogDetailLength
+	{
+		get => _volumetricFogDetailLength;
+		set
+		{
+			_volumetricFogDetailLength = value;
+			environment.VolumetricFogLength = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float VolumetricFogAnisotropy
+	{
+		get => _volumetricFogAnisotropy;
+		set
+		{
+			_volumetricFogAnisotropy = value;
+			environment.VolumetricFogAnisotropy = value;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

Exposes Godot's built-in Volumetric Fog (part of WorldEnvioronment) options.

Pros: Volumetric Fog is a great atmospheric option for creators.
Cons: Is expensive compute wise, and only works on Forward rendering. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/) (I'm pretty sure, git's being a pain about it though)

## Screenshots / video
<img width="2072" height="1125" alt="vol-fog-demo" src="https://github.com/user-attachments/assets/910bdf1b-e721-4205-98c3-3f8fd7f0ad1d" />

## AI/LLM use

None