### PR TITLE
Add dotnet-format check

### DIFF
--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -1,0 +1,20 @@
+name: Dotnet Format checks
+on: pull_request
+
+jobs:
+  dotnet-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Add dotnet-format problem matcher
+        uses: xt0rted/dotnet-format-problem-matcher@v1
+
+      - name: Restore dotnet tools
+        uses: xt0rted/dotnet-tool-restore@v1
+
+      - name: Run dotnet format
+        uses: xt0rted/dotnet-format@v1
+        with:
+          only-changed-files: "true"


### PR DESCRIPTION
## Summary

This PR adds [`dotnet-format`](https://github.com/xt0rted/dotnet-format) check to the repository, pull requests made after will check if dotnet-format has been run.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [x] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [x] Other

## AI/LLM use

None

P.S. you when not running dotnet format

<img height="400" alt="image" src="https://github.com/user-attachments/assets/85c61407-3b6e-4dc5-b43e-313639be2116" />
