### PR TITLE
Changed canJump to include _jumpEnabled, added JumpEnabled property t…

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -35,6 +35,7 @@ public partial class NPC : Physical
 	private RemoteTransform3D? _toolRemoteTransform;
 	private float _maxHealth = 100;
 	private float _jumpPower = 36;
+	private bool _jumpEnabled = true;
 	private float _walkSpeed = 16;
 	private string _displayName = "";
 	protected RayCast3D FootFwdRaycast = null!;
@@ -252,6 +253,17 @@ public partial class NPC : Physical
 		set
 		{
 			_maxHealth = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool JumpEnabled
+	{
+		get => _jumpEnabled;
+		set
+		{
+			_jumpEnabled = value;
 			OnPropertyChanged();
 		}
 	}
@@ -847,7 +859,7 @@ public partial class NPC : Physical
 	[ScriptMethod]
 	public virtual void Jump()
 	{
-		bool canJump = CharBody3D.IsOnFloor() || (!_coyoteUsed && _timeSinceGrounded <= CoyoteTime);
+		bool canJump = (CharBody3D.IsOnFloor() || (!_coyoteUsed && _timeSinceGrounded <= CoyoteTime)) && _jumpEnabled;
 		bool playJumpSound = false;
 		if (canJump)
 		{

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -938,6 +938,7 @@ public sealed partial class Player : NPC
 		StaminaRegen = Root.PlayerDefaults.StaminaRegen;
 		StaminaBurn = Root.PlayerDefaults.StaminaBurn;
 		JumpPower = Root.PlayerDefaults.JumpPower;
+		JumpEnabled = Root.PlayerDefaults.JumpEnabled;
 		RespawnTime = Root.PlayerDefaults.RespawnTime;
 		UseHeadTurning = Root.PlayerDefaults.UseHeadTurning;
 		UseBubbleChat = Root.PlayerDefaults.UseBubbleChat;

--- a/Polytoria/scripts/datamodel/PlayerDefaults.cs
+++ b/Polytoria/scripts/datamodel/PlayerDefaults.cs
@@ -13,6 +13,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 	private float _maxHealth;
 	private float _walkSpeed;
 	private float _jumpPower;
+	private bool _jumpEnabled;
 	private Color _chatColor;
 	private float _respawnTime;
 	private bool _canMove;
@@ -68,6 +69,17 @@ public sealed partial class PlayerDefaults : HiddenBase
 		set
 		{
 			_jumpPower = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool JumpEnabled
+	{
+		get => _jumpEnabled;
+		set
+		{
+			_jumpEnabled = value;
 			OnPropertyChanged();
 		}
 	}
@@ -242,6 +254,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 		MaxHealth = 100f;
 		WalkSpeed = 16f;
 		JumpPower = 36f;
+		JumpEnabled = true;
 		ChatColor = new Color(1, 1, 1);
 		RespawnTime = 5.0f;
 		CanMove = true;


### PR DESCRIPTION
## Summary

Adds a "JumpEnabled" property to the NPC and PlayerDefaults classes to enable and disable jumping rather than setting jumppower to 0 *(which still calls the NPC.Jump() function regardless, making it a hacky solution)*

## Related issue or discussion

Adds #323 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/d12d51ce-ef79-453a-80e7-ee71fb01044b

## AI/LLM use

None