### PR TITLE
Added UIImage UV Offset and Scale Properties

### DIFF
--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -28,7 +28,6 @@ public sealed partial class Image3D : Dynamic
 	private bool _castShadows;
 	private bool _shaded;
 	private bool _faceCamera;
-	private bool _doubleSided;
 	private TextureFilterEnum _textureFilter;
 
 	[Editable, ScriptProperty]
@@ -156,18 +155,6 @@ public sealed partial class Image3D : Dynamic
 		{
 			_faceCamera = value;
 			_material.BillboardMode = value ? BaseMaterial3D.BillboardModeEnum.Enabled : BaseMaterial3D.BillboardModeEnum.Disabled;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty, DefaultValue(false)]
-	public bool DoubleSided
-	{
-		get => _doubleSided;
-		set
-		{
-			_doubleSided = value;
-			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -28,6 +28,7 @@ public sealed partial class Image3D : Dynamic
 	private bool _castShadows;
 	private bool _shaded;
 	private bool _faceCamera;
+	private bool _doubleSided;
 	private TextureFilterEnum _textureFilter;
 
 	[Editable, ScriptProperty]
@@ -155,6 +156,18 @@ public sealed partial class Image3D : Dynamic
 		{
 			_faceCamera = value;
 			_material.BillboardMode = value ? BaseMaterial3D.BillboardModeEnum.Enabled : BaseMaterial3D.BillboardModeEnum.Disabled;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(false)]
+	public bool DoubleSided
+	{
+		get => _doubleSided;
+		set
+		{
+			_doubleSided = value;
+			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/UIImage.cs
+++ b/Polytoria/scripts/datamodel/UIImage.cs
@@ -19,10 +19,25 @@ public partial class UIImage : UIField
 	private string _imageID = "";
 	private ImageTypeEnum _imageType;
 	private TextureFilterEnum _textureFilter;
+	private Vector2 _textureScale = Vector2.One;
+	private Vector2 _textureOffset = Vector2.Zero;
 	private Color _color = new(1, 1, 1, 1);
 	private ImageStretchModeEnum _stretchMode = ImageStretchModeEnum.Stretch;
 	private bool _flipH = false;
 	private bool _flipV = false;
+	private Texture2D? _loadedTexture;
+	private ShaderMaterial? _shaderMaterial;
+
+	private const string UV_SHADER = """
+    shader_type canvas_item;
+    uniform vec2 texture_scale = vec2(1.0, 1.0);
+    uniform vec2 texture_offset = vec2(0.0, 0.0);
+
+    void fragment() {
+        vec2 uv = (UV * texture_scale) - texture_offset;
+        COLOR = texture(TEXTURE, uv);
+    }
+    """;
 
 	[Editable, ScriptProperty, Export]
 	public ImageAsset? Image
@@ -79,6 +94,30 @@ public partial class UIImage : UIField
 			CreatePTImageAsset();
 		}
 	}
+
+	[Editable, ScriptProperty]
+    public Vector2 TextureScale
+    {
+        get => _textureScale;
+        set
+		{
+			_textureScale = value;
+			ApplyTexture();
+			OnPropertyChanged();
+		}
+    }
+
+    [Editable, ScriptProperty]
+    public Vector2 TextureOffset
+    {
+        get => _textureOffset;
+        set 
+		{
+			_textureOffset = value;
+			ApplyTexture();
+			OnPropertyChanged();
+		}
+    }
 
 	[Editable, ScriptProperty]
 	public Color Color
@@ -188,14 +227,42 @@ public partial class UIImage : UIField
 		StretchMode = ImageStretchModeEnum.Stretch;
 	}
 
+	private void ApplyTexture()
+	{
+		if (_loadedTexture == null) return;
+
+		if (_textureScale == Vector2.One && _textureOffset == Vector2.Zero)
+		{
+			GDTextureRect.Material = null;
+			GDTextureRect.Texture = _loadedTexture;
+			return;
+		}
+
+		if (_shaderMaterial == null)
+		{
+			Shader shader = new();
+			shader.Code = UV_SHADER;
+			_shaderMaterial = new ShaderMaterial();
+			_shaderMaterial.Shader = shader;
+		}
+
+		_shaderMaterial.SetShaderParameter("texture_scale", _textureScale);
+		_shaderMaterial.SetShaderParameter("texture_offset", _textureOffset);
+		GDTextureRect.Texture = _loadedTexture;
+		GDTextureRect.TextureRepeat = CanvasItem.TextureRepeatEnum.Enabled;
+		GDTextureRect.Material = _shaderMaterial;
+	}
+
 	private void SetToDefaultImage()
 	{
-		GDTextureRect.Texture = GD.Load<Texture2D>("res://assets/textures/client/ui/DefaultImage.png");
+		_loadedTexture = GD.Load<Texture2D>("res://assets/textures/client/ui/DefaultImage.png");
+		ApplyTexture();
 	}
 
 	private void OnResourceLoaded(Resource tex)
 	{
-		GDTextureRect.Texture = (Texture2D)tex;
+		_loadedTexture = (Texture2D)tex;
+		ApplyTexture();
 		Loading = false;
 	}
 

--- a/Polytoria/scripts/datamodel/UIImage.cs
+++ b/Polytoria/scripts/datamodel/UIImage.cs
@@ -96,28 +96,28 @@ public partial class UIImage : UIField
 	}
 
 	[Editable, ScriptProperty]
-    public Vector2 TextureScale
-    {
-        get => _textureScale;
-        set
+	public Vector2 TextureScale
+	{
+		get => _textureScale;
+		set
 		{
 			_textureScale = value;
 			ApplyTexture();
 			OnPropertyChanged();
 		}
-    }
+	}
 
-    [Editable, ScriptProperty]
-    public Vector2 TextureOffset
-    {
-        get => _textureOffset;
-        set 
+	[Editable, ScriptProperty]
+	public Vector2 TextureOffset
+	{
+		get => _textureOffset;
+		set
 		{
 			_textureOffset = value;
 			ApplyTexture();
 			OnPropertyChanged();
 		}
-    }
+	}
 
 	[Editable, ScriptProperty]
 	public Color Color

--- a/Polytoria/scripts/datamodel/UIImage.cs
+++ b/Polytoria/scripts/datamodel/UIImage.cs
@@ -32,10 +32,11 @@ public partial class UIImage : UIField
     shader_type canvas_item;
     uniform vec2 texture_scale = vec2(1.0, 1.0);
     uniform vec2 texture_offset = vec2(0.0, 0.0);
+    uniform vec4 modulate_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);
 
     void fragment() {
         vec2 uv = (UV * texture_scale) - texture_offset;
-        COLOR = texture(TEXTURE, uv);
+        COLOR = texture(TEXTURE, uv) * modulate_color;
     }
     """;
 
@@ -126,7 +127,7 @@ public partial class UIImage : UIField
 		set
 		{
 			_color = value;
-			NodeControl.SelfModulate = value;
+			ApplyTexture();
 			OnPropertyChanged();
 		}
 	}
@@ -235,6 +236,7 @@ public partial class UIImage : UIField
 		{
 			GDTextureRect.Material = null;
 			GDTextureRect.Texture = _loadedTexture;
+			GDTextureRect.SelfModulate = _color;
 			return;
 		}
 
@@ -248,6 +250,8 @@ public partial class UIImage : UIField
 
 		_shaderMaterial.SetShaderParameter("texture_scale", _textureScale);
 		_shaderMaterial.SetShaderParameter("texture_offset", _textureOffset);
+		_shaderMaterial.SetShaderParameter("modulate_color", _color);
+		GDTextureRect.SelfModulate = new Color(1, 1, 1, 1);
 		GDTextureRect.Texture = _loadedTexture;
 		GDTextureRect.TextureRepeat = CanvasItem.TextureRepeatEnum.Enabled;
 		GDTextureRect.Material = _shaderMaterial;

--- a/Polytoria/scripts/datamodel/UIImage.cs
+++ b/Polytoria/scripts/datamodel/UIImage.cs
@@ -35,7 +35,7 @@ public partial class UIImage : UIField
     uniform vec4 modulate_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);
 
     void fragment() {
-        vec2 uv = (UV * texture_scale) - texture_offset;
+        vec2 uv = (UV * texture_scale) + texture_offset;
         COLOR = texture(TEXTURE, uv) * modulate_color;
     }
     """;


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Added Offset and Scale properties to UIImage to match Image3Ds.

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
Research into how Materials and Shaders work within Godot.