### PR TITLE
Fixed flipped values from snap to selected

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -929,6 +929,7 @@ public sealed partial class Camera : Dynamic
 		if (targets.Length == 0)
 			return;
 
+		// Calculate bounding box of all selected instances
 		Aabb combinedBounds = new();
 		bool first = true;
 

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -922,14 +922,13 @@ public sealed partial class Camera : Dynamic
 
 
 #if CREATOR
-	public void MoveToSelected()
+	public async void MoveToSelected()
 	{
 		Instance[] targets = [.. Root.CreatorContext.Selections.SelectedInstances];
 
 		if (targets.Length == 0)
 			return;
 
-		// Calculate bounding box of all selected instances
 		Aabb combinedBounds = new();
 		bool first = true;
 
@@ -962,29 +961,42 @@ public sealed partial class Camera : Dynamic
 		float distance = radius / Mathf.Tan(fovRadians * 0.5f);
 
 		distance *= 1.2f;
-
 		distance = Mathf.Max(distance, radius + 2.0f);
-
-		Vector3 currentDir;
 
 		Vector3 currentPos = GDNode3D.GlobalPosition;
 		Vector3 toCamera = currentPos - center;
 
-		if (toCamera.Length() < 0.1f)
+		Vector3 currentDir =
+			toCamera.Length() < 0.1f
+				? new Vector3(1, 1, 1).Normalized()
+				: toCamera.Normalized();
+
+		Vector3 targetPosition = center + currentDir * distance;
+
+		Transform3D targetTransform =
+			new Transform3D(Basis.Identity, targetPosition)
+				.LookingAt(center, Vector3.Up);
+
+		Quaternion targetRotation =
+			targetTransform.Basis.GetRotationQuaternion();
+
+		for (int i = 0; i < 30; i++)
 		{
-			currentDir = new Vector3(1, 1, 1).Normalized();
+			GDNode3D.GlobalPosition =
+				GDNode3D.GlobalPosition.Lerp(targetPosition, 0.15f);
+
+			Quaternion currentRotation =
+				GDNode3D.GlobalBasis.GetRotationQuaternion();
+
+			GDNode3D.GlobalBasis = new Basis(
+				currentRotation.Slerp(targetRotation, 0.15f)
+			);
+
+			await GDNode3D.ToSignal(
+				GDNode3D.GetTree(),
+				SceneTree.SignalName.ProcessFrame
+			);
 		}
-		else
-		{
-			currentDir = toCamera.Normalized();
-		}
-
-		Vector3 newPosition = center + currentDir * distance;
-
-		GDNode3D.GlobalPosition = newPosition;
-		GDNode3D.LookAt(center, Vector3.Up);
-
-		GDNode3D.RotateObjectLocal(Vector3.Up, Mathf.Pi);
 	}
 
 	public Vector3 GetPlacementPosition(Instance[]? ignoreList = null)

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -28,7 +28,6 @@ public sealed partial class Image3D : Dynamic
 	private bool _castShadows;
 	private bool _shaded;
 	private bool _faceCamera;
-	private bool _doubleSided;
 	private TextureFilterEnum _textureFilter;
 
 	[Editable, ScriptProperty]
@@ -156,18 +155,6 @@ public sealed partial class Image3D : Dynamic
 		{
 			_faceCamera = value;
 			_material.BillboardMode = value ? BaseMaterial3D.BillboardModeEnum.Enabled : BaseMaterial3D.BillboardModeEnum.Disabled;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty, DefaultValue(false)]
-	public bool DoubleSided
-	{
-		get => _doubleSided;
-		set
-		{
-			_doubleSided = value;
-			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -28,6 +28,7 @@ public sealed partial class Image3D : Dynamic
 	private bool _castShadows;
 	private bool _shaded;
 	private bool _faceCamera;
+	private bool _doubleSided;
 	private TextureFilterEnum _textureFilter;
 
 	[Editable, ScriptProperty]
@@ -155,6 +156,18 @@ public sealed partial class Image3D : Dynamic
 		{
 			_faceCamera = value;
 			_material.BillboardMode = value ? BaseMaterial3D.BillboardModeEnum.Enabled : BaseMaterial3D.BillboardModeEnum.Disabled;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(false)]
+	public bool DoubleSided
+	{
+		get => _doubleSided;
+		set
+		{
+			_doubleSided = value;
+			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Fixed and Improved MoveToSelected function to not have flipped rotation values and added a lerp to smooth the motion.

## Related issue or discussion

Fixes #

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
To help figure out how to smooth motion using lerp for Position and Rotation values.