### PR TITLE
Polish Creator tab bar behavior

### DIFF
--- a/Polytoria/scenes/creator/creator.tscn
+++ b/Polytoria/scenes/creator/creator.tscn
@@ -1067,7 +1067,6 @@ size_flags_horizontal = 3
 theme = ExtResource("16_1f7jh")
 theme_override_constants/icon_max_width = 16
 clip_tabs = false
-close_with_middle_mouse = false
 tab_close_display_policy = 2
 drag_to_rearrange_enabled = true
 

--- a/Polytoria/scripts/creator/ui/Tabs.cs
+++ b/Polytoria/scripts/creator/ui/Tabs.cs
@@ -112,6 +112,7 @@ public sealed partial class Tabs : Control
 		};
 
 		_tabBar.TabClosePressed += async idx => await Remove(_orderedControls[(int)idx]);
+		_tabBar.GuiInput += OnTabBarGUIInput;
 
 		_leftButton.ButtonDown += () => _scrollLeft = true;
 		_leftButton.ButtonUp += () => _scrollLeft = false;
@@ -171,6 +172,10 @@ public sealed partial class Tabs : Control
 
 		_tabBar.AddTab(title ?? other.Title, Globals.LoadIcon(icon));
 		CurrentControl = container;
+
+		UpdateTabBar();
+		_tabBar.Position = new Vector2(_maxScroll, _tabBar.Position.Y);
+
 	}
 
 	private async Task Remove(Control control, bool isBulkOp = false)
@@ -261,6 +266,21 @@ public sealed partial class Tabs : Control
 	{
 		if (_scrollLeft) ScrollTabBar((float)(900 * delta));
 		if (_scrollRight) ScrollTabBar((float)(-900 * delta));
+	}
+
+	private void OnTabBarGUIInput(InputEvent @event)
+	{
+		if (@event is InputEventMouseButton btn)
+		{
+			if (btn.ButtonIndex == MouseButton.WheelUp)
+			{
+				ScrollTabBar((float)(10 * btn.Factor));
+			}
+			else if (btn.ButtonIndex == MouseButton.WheelDown)
+			{
+				ScrollTabBar((float)(10 * -btn.Factor));
+			}
+		}
 	}
 
 	private void ScrollTabBar(float delta)


### PR DESCRIPTION
## Summary
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
The new tab bar had some stuff missing from the previous one, this fixes them.

- Can middle click to close a tab again
- Can scroll the tab bar with mouse wheel again
- Tab bar jumps to end when opening a new tab

## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
<!-- Describe AI use, or write "None" if not applicable -->
None.