### PR TITLE
add Thumbs.db and desktop.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ TestResults/
 ers
 
 .DS_Store
+Thumbs.db
+desktop.ini


### PR DESCRIPTION
## Summary

I noticed that Thumbs.db and desktop.ini were missing from ".gitignore", so I decided to add them

## Related issue or discussion

Fixes Thumbs.db and desktop.ini not being in .gitignore
Related to .gitignore

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [x] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [x] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Not required, not a visual change.

## AI/LLM use

None