### PR TITLE
Added two new methods, implementing gamepad vibration support

### DIFF
--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -695,9 +695,9 @@ public sealed partial class Gizmos : Node
 		Vector3 rayNormal = rayOrigin + _camera.ProjectRayNormal(mousePos) * 1000;
 
 		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayOrigin, rayNormal);
-        query.CollideWithBodies = true;
-        query.CollideWithAreas = true;
-        query.CollisionMask = (1 << 0) | (1 << 1) | (1 << 3);
+		query.CollideWithBodies = true;
+		query.CollideWithAreas = true;
+		query.CollisionMask = (1 << 0) | (1 << 1) | (1 << 3);
 
 		Godot.Collections.Array<Rid> excludeArray = [];
 

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -695,14 +695,14 @@ public partial class Dynamic : Instance
 		if (to && this is not IGroup and not Camera && this is not Physical)
 		{
 			if (this is Physical p && p.CanCollide)
-            {
-                _boundArea3D.CollisionLayer = (1 << 3);
-            }
-            else
-            {
-                _boundArea3D.CollisionLayer = (1 << 2);
-            }
-            _boundArea3D.CollisionLayer = (1 << 2);
+			{
+				_boundArea3D.CollisionLayer = (1 << 3);
+			}
+			else
+			{
+				_boundArea3D.CollisionLayer = (1 << 2);
+			}
+			_boundArea3D.CollisionLayer = (1 << 2);
 		}
 		else
 		{

--- a/Polytoria/scripts/datamodel/services/InputService.cs
+++ b/Polytoria/scripts/datamodel/services/InputService.cs
@@ -552,14 +552,16 @@ public sealed partial class InputService : Instance
 		}
 		return null;
 	}
-	
+
 	[ScriptMethod]
-	public void StartGamepadVibration(float weakMagnitude, float strongMagnitude, float duration){
-		Input.StartJoyVibration(0,weakMagnitude,strongMagnitude,duration);
+	public void StartGamepadVibration(float weakMagnitude, float strongMagnitude, float duration)
+	{
+		Input.StartJoyVibration(0, weakMagnitude, strongMagnitude, duration);
 	}
-	
+
 	[ScriptMethod]
-	public void StopGamepadVibration(){
+	public void StopGamepadVibration()
+	{
 		Input.StopJoyVibration(0);
 	}
 

--- a/Polytoria/scripts/datamodel/services/InputService.cs
+++ b/Polytoria/scripts/datamodel/services/InputService.cs
@@ -552,6 +552,16 @@ public sealed partial class InputService : Instance
 		}
 		return null;
 	}
+	
+	[ScriptMethod]
+	public void StartGamepadVibration(float weakMagnitude, float strongMagnitude, float duration){
+		Input.StartJoyVibration(0,weakMagnitude,strongMagnitude,duration);
+	}
+	
+	[ScriptMethod]
+	public void StopGamepadVibration(){
+		Input.StopJoyVibration(0);
+	}
 
 	[ScriptMethod]
 	public Vector3 GetMouseWorldPosition(Instance[]? ignoreList = null)


### PR DESCRIPTION
## Summary

(This was created to help @juicewrlddpolytoria-bit, it's essentially their PR #308)

AddedInput:StartGamepadVibration and Input:StopGamepadVibration methods to implement controller vibration/haptic support

## Related issue or discussion

Related to #305 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Not a visual change, no screenshot required.

## AI/LLM use

None