### PR TITLE
Fix Ctrl-Lock not restoring after closing built-in menu

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -64,6 +64,7 @@ public sealed partial class Camera : Dynamic
 	private InputHelper _inputHelper = null!;
 
 	internal Camera3D Camera3D = null!;
+	internal bool IsTurning => _turning;
 
 	[Editable, ScriptProperty, DefaultValue(CameraModeEnum.Follow)]
 	public CameraModeEnum Mode
@@ -602,26 +603,19 @@ public sealed partial class Camera : Dynamic
 
 	private void OnGameFocused()
 	{
-		if (IsFirstPerson || AlwaysLocked)
+		if (AlwaysLocked)
 		{
-			if (AlwaysLocked)
-			{
-				CtrlLocked = true;
-			}
-			else
-			{
-				StartTurning();
-			}
+			CtrlLocked = true;
+		}
+
+		if (IsFirstPerson || AlwaysLocked || CtrlLocked)
+		{
+			StartTurning();
 		}
 	}
 
 	private void OnGameUnfocused()
 	{
-		if (CtrlLocked)
-		{
-			CtrlLocked = false;
-			StopTurning();
-		}
 		if (_turning)
 		{
 			StopTurning();

--- a/Polytoria/scripts/datamodel/services/InputService.cs
+++ b/Polytoria/scripts/datamodel/services/InputService.cs
@@ -389,7 +389,12 @@ public sealed partial class InputService : Instance
 			Input.MouseMode = Input.MouseModeEnum.Visible;
 			return;
 		}
-		Input.MouseMode = _cursorLocked ? Input.MouseModeEnum.Captured : (_cursorVisible ? Input.MouseModeEnum.Visible : Input.MouseModeEnum.Hidden);
+		Camera? cam = Root.Environment.CurrentCamera;
+		bool camCapturing = cam?.IsTurning ?? false;
+
+		Input.MouseMode = (_cursorLocked || camCapturing)
+			? Input.MouseModeEnum.Captured
+			: (_cursorVisible ? Input.MouseModeEnum.Visible : Input.MouseModeEnum.Hidden);
 	}
 
 	private bool RecomputeGameFocused()


### PR DESCRIPTION
## Summary

Fixes Ctrl-Lock being reset to disabled when opening then closing the built-in (Esc) menu.
Also adds an internal IsTurning property to Camera.

Fixes #170 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/8b75b826-7e74-4231-b8e5-822dd00c5227

## AI/LLM use

None