### PR TITLE
Fix graphics settings not applying on first launch

### DIFF
--- a/Polytoria/scripts/client/settings/ClientSettingsService.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingsService.cs
@@ -44,7 +44,8 @@ public sealed partial class ClientSettingsService : SettingsServiceBase
 
 			PT.Print("Graphics auto-detection selected preset: " + autoPreset);
 			Entry?.NetworkEssentialsReady += () => SetupBenchmark(benchmarker);
-		} else
+		}
+		else
 		{
 			GraphicsPresetManager.ApplyCurrentPreset(this);
 		}

--- a/Polytoria/scripts/client/settings/ClientSettingsService.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingsService.cs
@@ -44,6 +44,9 @@ public sealed partial class ClientSettingsService : SettingsServiceBase
 
 			PT.Print("Graphics auto-detection selected preset: " + autoPreset);
 			Entry?.NetworkEssentialsReady += () => SetupBenchmark(benchmarker);
+		} else
+		{
+			GraphicsPresetManager.ApplyCurrentPreset(this);
 		}
 
 		RenderingMethodOption renderingMethod = Get<RenderingMethodOption>(SharedSettingKeys.Graphics.RenderingMethod);

--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -695,9 +695,9 @@ public sealed partial class Gizmos : Node
 		Vector3 rayNormal = rayOrigin + _camera.ProjectRayNormal(mousePos) * 1000;
 
 		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayOrigin, rayNormal);
-        query.CollideWithBodies = true;
-        query.CollideWithAreas = true;
-        query.CollisionMask = (1 << 0) | (1 << 1) | (1 << 3);
+		query.CollideWithBodies = true;
+		query.CollideWithAreas = true;
+		query.CollisionMask = (1 << 0) | (1 << 1) | (1 << 3);
 
 		Godot.Collections.Array<Rid> excludeArray = [];
 

--- a/Polytoria/scripts/creator/settings/CreatorSettingsService.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingsService.cs
@@ -52,7 +52,7 @@ public sealed partial class CreatorSettingsService : SettingsServiceBase
 		ApplyDefaults();
 
 		if (!FileAccess.FileExists(SettingsPathConst))
-			Set(SharedSettingKeys.Graphics.Preset, GraphicsPreset.Medium);
+			GraphicsPresetManager.SelectPreset(this, GraphicsPreset.Medium);
 
 		RenderingMethodOption renderingMethod = Get<RenderingMethodOption>(SharedSettingKeys.Graphics.RenderingMethod);
 		RenderingDeviceSwitcher.Switch(renderingMethod);

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -695,14 +695,14 @@ public partial class Dynamic : Instance
 		if (to && this is not IGroup and not Camera && this is not Physical)
 		{
 			if (this is Physical p && p.CanCollide)
-            {
-                _boundArea3D.CollisionLayer = (1 << 3);
-            }
-            else
-            {
-                _boundArea3D.CollisionLayer = (1 << 2);
-            }
-            _boundArea3D.CollisionLayer = (1 << 2);
+			{
+				_boundArea3D.CollisionLayer = (1 << 3);
+			}
+			else
+			{
+				_boundArea3D.CollisionLayer = (1 << 2);
+			}
+			_boundArea3D.CollisionLayer = (1 << 2);
 		}
 		else
 		{

--- a/Polytoria/scripts/shared/settings/GraphicsPresetManager.cs
+++ b/Polytoria/scripts/shared/settings/GraphicsPresetManager.cs
@@ -129,7 +129,45 @@ public static class GraphicsPresetManager
 			return;
 		}
 
-		data.ApplyTo(settings);
+		_presetDepth++;
+		try
+		{
+			data.ApplyTo(settings);
+		}
+		finally
+		{
+			_presetDepth--;
+		}
+	}
+
+	public static void SelectPreset(ISettingsContext settings, GraphicsPreset preset)
+	{
+		if (preset == GraphicsPreset.Custom)
+		{
+			settings.Set(SharedSettingKeys.Graphics.Preset, preset);
+			return;
+		}
+
+		_presetDepth++;
+		try
+		{
+			settings.Set(SharedSettingKeys.Graphics.Preset, preset);
+		}
+		finally
+		{
+			_presetDepth--;
+		}
+
+		ApplyPreset(settings, preset);
+	}
+
+	public static void ApplyCurrentPreset(ISettingsContext settings)
+	{
+		GraphicsPreset preset = settings.Get<GraphicsPreset>(SharedSettingKeys.Graphics.Preset);
+		if (preset != GraphicsPreset.Custom)
+		{
+			ApplyPreset(settings, preset);
+		}
 	}
 
 	private static int _presetDepth;
@@ -139,25 +177,20 @@ public static class GraphicsPresetManager
 		if (!key.StartsWith(SharedSettingKeys.Graphics.Prefix))
 			return;
 
+		if (_presetDepth > 0)
+			return;
+
 		if (key == SharedSettingKeys.Graphics.Preset)
 		{
 			GraphicsPreset preset = (GraphicsPreset)normalizedValue;
 			if (preset == GraphicsPreset.Custom)
 				return;
 
-			_presetDepth++;
-			try
-			{
-				ApplyPreset(settings, preset);
-			}
-			finally
-			{
-				_presetDepth--;
-			}
+			ApplyPreset(settings, preset);
 			return;
 		}
 
-		if (_presetDepth > 0 || !IsPresetManagedKey(key))
+		if (!IsPresetManagedKey(key))
 			return;
 
 		GraphicsPreset currentPreset = settings.Get<GraphicsPreset>(SharedSettingKeys.Graphics.Preset);


### PR DESCRIPTION
## Summary

Fixes graphics preset application on first launch so settings are applied even when the selected preset already matches the default value.

Since medium is the default preset, the system wouldn't detect it as changed when the medium settings are applied, leaving the default post processing effects enabled such as SSR, SDFGI etc, which causes a lot of lag for first time players on low end hardware

## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

Helped debug, all code written by me