### PR TITLE
Handle empty parameters in error

### DIFF
--- a/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
@@ -669,7 +669,7 @@ public partial class LuaState : IDisposable
 
 	public int Error(string value, params object[] v)
 	{
-		string message = string.Format(value, v);
+		string message = v.Length > 0 ? string.Format(value, v) : value;
 		lock (_lock)
 			return NativeBindings.luaL_errorL(_state, message);
 	}


### PR DESCRIPTION
## Summary

Luau can crash the entire application if LuaState.Error is called without any parameters, this PR adds a safeguard for that

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None