### PR TITLE
Free subview and dispose old photo in CaptureService

### DIFF
--- a/Polytoria/scripts/datamodel/services/CaptureService.cs
+++ b/Polytoria/scripts/datamodel/services/CaptureService.cs
@@ -239,7 +239,11 @@ public sealed partial class CaptureService : Instance
 		img.FixAlphaEdges();
 		img.GenerateMipmaps();
 
+
+		CurrentPhoto?.Dispose();
 		CurrentPhoto = ImageTexture.CreateFromImage(img);
+
+		subview.QueueFree();
 
 		PostPhotoTaken();
 	}


### PR DESCRIPTION
## Summary

Frees the subviewport created by TakePhoto (thanks RiyDoesNothing for noticing that! I was very focused on the wrong thing, lol), and also disposes the old CurrentPhoto.

## Related issue or discussion

Related to #371

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

eventually gave up trying to find it myself and got chadgpt to figure out why tf GetTexture() leaked 800mb (spoiler: it wasnt even GetTexture() </3)