### PR TITLE
Add NetworkedObject.Destroying event

### DIFF
--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -341,6 +341,8 @@ public partial class NetworkedObject : IScriptObject
 	[ScriptProperty] public PTSignal TreeEntered { get; private set; } = new();
 	[ScriptProperty] public PTSignal TreeExited { get; private set; } = new();
 
+	[ScriptProperty] public PTSignal Destroying { get; private set; } = new();
+
 	public NetworkedObject()
 	{
 		InitializeRpcMethods();
@@ -1823,6 +1825,7 @@ public partial class NetworkedObject : IScriptObject
 		{
 			await Globals.Singleton.WaitAsync(time);
 		}
+
 		InternalDestroy(false);
 	}
 
@@ -1842,6 +1845,8 @@ public partial class NetworkedObject : IScriptObject
 		if (GetType().IsDefined(typeof(InternalAttribute), false) && !forceDestroy) throw new InvalidOperationException("Cannot destroy an internal class");
 		if (this is Player && !forceDestroy) throw new InvalidOperationException("Cannot destroy a player, use Kick instead.");
 		if (IsDeleted) return;
+
+		Destroying?.Invoke();
 
 		NetworkedObject? parent = NetworkParent;
 


### PR DESCRIPTION
## Summary

Adds a Destroying event to NetworkedObjects, which gets invoked right before an NetworkedObject gets destroyed.

## Related issue or discussion

Fixes #41 
There already was a PR (#61) but the PRs author closed it and never opened a new one. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None