### PR TITLE
[Feature]: Added rename to FileBrowser + Code refactor with Rider

### DIFF
--- a/Polytoria/scripts/creator/ui/docks/explorer/ExplorerTree.cs
+++ b/Polytoria/scripts/creator/ui/docks/explorer/ExplorerTree.cs
@@ -53,7 +53,7 @@ public partial class ExplorerTree : Tree
 	{
 		if (@event is InputEventMouseButton mouseEvent)
 		{
-			if (mouseEvent.ButtonIndex == MouseButton.Right && mouseEvent.Pressed)
+			if (mouseEvent is { ButtonIndex: MouseButton.Right, Pressed: true })
 			{
 				TreeItem clickedItem = GetItemAtPosition(mouseEvent.Position);
 				if (clickedItem != null)
@@ -80,7 +80,8 @@ public partial class ExplorerTree : Tree
 		}
 		else if (@event.IsActionPressed("rename"))
 		{
-			EditSelected();
+			AcceptEvent();
+			EditSelected(true);
 		}
 		base._GuiInput(@event);
 	}
@@ -138,62 +139,59 @@ public partial class ExplorerTree : Tree
 
 		List<TreeItem> draggedItems = [];
 
-		if (dragData is InstanceDragData instanceDrag)
+		switch (dragData)
 		{
-			foreach (Instance item in instanceDrag.Instances)
+			case InstanceDragData instanceDrag:
 			{
-				draggedItems.Add(InstanceToItem[item]);
-			}
-		}
-		else if (dragData is FileDragData fileDrag)
-		{
-			if (fileDrag.Files.Length == 1)
-			{
-				string file = fileDrag.Files[0];
-				string fileExt = file.GetExtension();
-
-				if (Globals.ScriptFileExtensions.Contains(fileExt))
+				foreach (Instance item in instanceDrag.Instances)
 				{
-					bool createAsChild = true;
-					string n = CreatorService.GetScriptNameFromPath(file);
-					ScriptTypeEnum st = CreatorService.GetScriptTypeFromPath(file);
+					draggedItems.Add(InstanceToItem[item]);
+				}
 
-					if (createAsChild)
+				break;
+			}
+			case FileDragData fileDrag:
+			{
+				if (fileDrag.Files.Length == 1)
+				{
+					string file = fileDrag.Files[0];
+					string fileExt = file.GetExtension();
+
+					if (Globals.ScriptFileExtensions.Contains(fileExt))
 					{
-						Script s;
+						bool createAsChild = true;
+						string n = CreatorService.GetScriptNameFromPath(file);
+						ScriptTypeEnum st = CreatorService.GetScriptTypeFromPath(file);
 
-						if (st == ScriptTypeEnum.Server)
+						if (createAsChild)
 						{
-							s = Root.New<ServerScript>();
-						}
-						else if (st == ScriptTypeEnum.Client)
-						{
-							s = Root.New<ClientScript>();
-						}
-						else
-						{
-							s = Root.New<ModuleScript>();
-						}
+							Script s = st switch
+							{
+								ScriptTypeEnum.Server => Root.New<ServerScript>(),
+								ScriptTypeEnum.Client => Root.New<ClientScript>(),
+								_ => Root.New<ModuleScript>()
+							};
 
-						s.LinkedScript = Root.Assets.GetFileLinkByPath(file);
-						s.Name = n.ToPascalCase();
+							s.LinkedScript = Root.Assets.GetFileLinkByPath(file);
+							s.Name = n.ToPascalCase();
 
-						s.Parent = target;
-						Root.CreatorContext.Selections.DeselectAll();
-						Root.CreatorContext.Selections.Select(s);
+							s.Parent = target;
+							Root.CreatorContext.Selections.DeselectAll();
+							Root.CreatorContext.Selections.Select(s);
+						}
 					}
-				}
-				else if (fileExt == Globals.ModelFileExtension)
-				{
-					_ = Root.LinkedSession.InsertModel(file, target);
+					else if (fileExt == Globals.ModelFileExtension)
+					{
+						_ = Root.LinkedSession.InsertModel(file, target);
+					}
+
+					Root.PlayerGUI.GrabFocus();
 				}
 
-				Root.PlayerGUI.GrabFocus();
+				break;
 			}
-		}
-		else
-		{
-			return;
+			default:
+				return;
 		}
 
 		Instance? parentTo = null;
@@ -238,38 +236,36 @@ public partial class ExplorerTree : Tree
 
 		foreach (Instance draggedInstance in sortedDraggedInstances)
 		{
-			if (parentTo != null)
+			if (parentTo == null) continue;
+			if (draggedInstance.IsAncestorOf(parentTo) || draggedInstance == parentTo)
+				continue;
+
+			try
 			{
-				if (draggedInstance.IsAncestorOf(parentTo) || draggedInstance == parentTo)
-					continue;
+				Instance? oldParent = draggedInstance.Parent;
+				int oldIndex = draggedInstance.Index;
+				originalState.Add((draggedInstance, oldParent, oldIndex));
 
-				try
+				// Calculate adjustment if moving within same parent
+				int adjustedIndex = insertIndex;
+				if (draggedInstance.Parent == parentTo && draggedInstance.Index < insertIndex)
 				{
-					Instance? oldParent = draggedInstance.Parent;
-					int oldIndex = draggedInstance.Index;
-					originalState.Add((draggedInstance, oldParent, oldIndex));
-
-					// Calculate adjustment if moving within same parent
-					int adjustedIndex = insertIndex;
-					if (draggedInstance.Parent == parentTo && draggedInstance.Index < insertIndex)
-					{
-						// Item is being removed from before the target position
-						adjustedIndex--;
-					}
-
-					finalState.Add((draggedInstance, parentTo, adjustedIndex));
+					// Item is being removed from before the target position
+					adjustedIndex--;
 				}
-				catch (Exception ex)
-				{
-					PT.PrintErr(ex);
-					CreatorService.Interface.PopupAlert(ex.Message);
-					return;
-				}
+
+				finalState.Add((draggedInstance, parentTo, adjustedIndex));
+			}
+			catch (Exception ex)
+			{
+				PT.PrintErr(ex);
+				CreatorService.Interface.PopupAlert(ex.Message);
+				return;
 			}
 		}
 
 		// Add history action
-		if (originalState.Count > 0)
+		if (originalState.Count <= 0) return;
 		{
 			history.NewAction($"Move {originalState.Count} instance(s)");
 
@@ -278,15 +274,13 @@ public partial class ExplorerTree : Tree
 				Root.CreatorContext.Selections.DeselectAll();
 				foreach (var (instance, newParent, newIndex) in finalState)
 				{
-					if (newParent != null)
+					if (newParent == null) continue;
+					if (instance.Parent != newParent)
 					{
-						if (instance.Parent != newParent)
-						{
-							instance.Parent = newParent;
-						}
-						newParent.MoveChild(instance, newIndex);
-						Root.CreatorContext.Selections.Select(instance);
+						instance.Parent = newParent;
 					}
+					newParent.MoveChild(instance, newIndex);
+					Root.CreatorContext.Selections.Select(instance);
 				}
 			}));
 
@@ -297,12 +291,10 @@ public partial class ExplorerTree : Tree
 				for (int i = originalState.Count - 1; i >= 0; i--)
 				{
 					var (instance, oldParent, oldIndex) = originalState[i];
-					if (oldParent != null)
-					{
-						instance.Parent = oldParent;
-						oldParent.MoveChild(instance, oldIndex);
-						Root.CreatorContext.Selections.Select(instance);
-					}
+					if (oldParent == null) continue;
+					instance.Parent = oldParent;
+					oldParent.MoveChild(instance, oldIndex);
+					Root.CreatorContext.Selections.Select(instance);
 				}
 			}));
 

--- a/Polytoria/scripts/creator/ui/docks/explorer/ExplorerTree.cs
+++ b/Polytoria/scripts/creator/ui/docks/explorer/ExplorerTree.cs
@@ -142,54 +142,54 @@ public partial class ExplorerTree : Tree
 		switch (dragData)
 		{
 			case InstanceDragData instanceDrag:
-			{
-				foreach (Instance item in instanceDrag.Instances)
 				{
-					draggedItems.Add(InstanceToItem[item]);
-				}
+					foreach (Instance item in instanceDrag.Instances)
+					{
+						draggedItems.Add(InstanceToItem[item]);
+					}
 
-				break;
-			}
+					break;
+				}
 			case FileDragData fileDrag:
-			{
-				if (fileDrag.Files.Length == 1)
 				{
-					string file = fileDrag.Files[0];
-					string fileExt = file.GetExtension();
-
-					if (Globals.ScriptFileExtensions.Contains(fileExt))
+					if (fileDrag.Files.Length == 1)
 					{
-						bool createAsChild = true;
-						string n = CreatorService.GetScriptNameFromPath(file);
-						ScriptTypeEnum st = CreatorService.GetScriptTypeFromPath(file);
+						string file = fileDrag.Files[0];
+						string fileExt = file.GetExtension();
 
-						if (createAsChild)
+						if (Globals.ScriptFileExtensions.Contains(fileExt))
 						{
-							Script s = st switch
+							bool createAsChild = true;
+							string n = CreatorService.GetScriptNameFromPath(file);
+							ScriptTypeEnum st = CreatorService.GetScriptTypeFromPath(file);
+
+							if (createAsChild)
 							{
-								ScriptTypeEnum.Server => Root.New<ServerScript>(),
-								ScriptTypeEnum.Client => Root.New<ClientScript>(),
-								_ => Root.New<ModuleScript>()
-							};
+								Script s = st switch
+								{
+									ScriptTypeEnum.Server => Root.New<ServerScript>(),
+									ScriptTypeEnum.Client => Root.New<ClientScript>(),
+									_ => Root.New<ModuleScript>()
+								};
 
-							s.LinkedScript = Root.Assets.GetFileLinkByPath(file);
-							s.Name = n.ToPascalCase();
+								s.LinkedScript = Root.Assets.GetFileLinkByPath(file);
+								s.Name = n.ToPascalCase();
 
-							s.Parent = target;
-							Root.CreatorContext.Selections.DeselectAll();
-							Root.CreatorContext.Selections.Select(s);
+								s.Parent = target;
+								Root.CreatorContext.Selections.DeselectAll();
+								Root.CreatorContext.Selections.Select(s);
+							}
 						}
-					}
-					else if (fileExt == Globals.ModelFileExtension)
-					{
-						_ = Root.LinkedSession.InsertModel(file, target);
+						else if (fileExt == Globals.ModelFileExtension)
+						{
+							_ = Root.LinkedSession.InsertModel(file, target);
+						}
+
+						Root.PlayerGUI.GrabFocus();
 					}
 
-					Root.PlayerGUI.GrabFocus();
+					break;
 				}
-
-				break;
-			}
 			default:
 				return;
 		}

--- a/Polytoria/scripts/creator/ui/docks/files/FileBrowserTree.cs
+++ b/Polytoria/scripts/creator/ui/docks/files/FileBrowserTree.cs
@@ -97,6 +97,11 @@ public partial class FileBrowserTree : Tree
 			AcceptEvent();
 			CreatorService.Interface.PromptDeleteFiles(GetSelectedFiles());
 		}
+		else if (@event.IsActionPressed("rename"))
+		{
+			AcceptEvent();
+			EditSelected(true);
+		}
 		base._GuiInput(@event);
 	}
 


### PR DESCRIPTION
## Summary

Added logic to FileBrowserTree.cs to listen for the F2 key.
Improved Code readability with Rider.

## Related issue or discussion

Related to #60 

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)


## AI/LLM use

None