### PR TITLE
Network: Uncap Transform Sync and Reduce Bandwidth

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -10,6 +10,7 @@ using Polytoria.Creator.Spatial;
 using Polytoria.Datamodel.Interfaces;
 #endif
 using Polytoria.Utils;
+using Polytoria.Utils.DTOs;
 using System;
 using System.Collections.Generic;
 
@@ -98,7 +99,7 @@ public partial class Dynamic : Instance
 		}
 	}
 
-	[Editable, ScriptProperty, NoSync, CloneIgnore, SaveIgnore]
+	[Editable, ScriptProperty, CloneIgnore, SaveIgnore]
 	public Vector3 Size
 	{
 		get => GetGlobalTransform().Basis.Scale;
@@ -113,10 +114,6 @@ public partial class Dynamic : Instance
 			var oldN = NodeSize;
 			NodeSize = scale;
 			PropagateParentSizeChanged(oldN);
-			if (AutoUpdateNetTransform)
-			{
-				UpdateNetTransformReliable();
-			}
 			OnPropertyChanged();
 		}
 	}
@@ -157,7 +154,7 @@ public partial class Dynamic : Instance
 		}
 	}
 
-	[Editable, ScriptProperty, CloneIgnore, NoSync]
+	[Editable, ScriptProperty, CloneIgnore]
 	public Vector3 LocalSize
 	{
 		get
@@ -169,12 +166,6 @@ public partial class Dynamic : Instance
 			var oldN = NodeSize;
 			ApplyLocalSize(value);
 			PropagateParentSizeChanged(oldN);
-
-			if (AutoUpdateNetTransform)
-			{
-				UpdateNetTransformReliable();
-			}
-
 			OnPropertyChanged();
 		}
 	}
@@ -586,20 +577,24 @@ public partial class Dynamic : Instance
 	/// <param name="fromPeer"></param>
 	/// <param name="newTransform"></param>
 	/// <returns></returns>
-	internal virtual Transform3D TransformNetworkPass(int fromPeer, Transform3D newTransform)
+	internal virtual TransformPayloadDto TransformNetworkPass(int fromPeer, TransformPayloadDto newTransform)
 	{
 		return newTransform;
 	}
 
-	internal virtual bool TransformNetworkCheck(Transform3D newTransform)
+	internal virtual bool TransformNetworkCheck(TransformPayloadDto newTransform)
 	{
 		return true;
 	}
 
-	internal void UpdateTransformFromNet(Transform3D transform, bool isReliable, bool lerpTransform)
+	internal void UpdateTransformFromNet(TransformPayloadDto transform, bool isReliable, bool lerpTransform)
 	{
 		if (OverrideNetworkTransform) return;
-		_netTransform = transform;
+		Vector3 scale = GetLocalTransform().Basis.Scale;
+		_netTransform = new Transform3D(
+			new Basis(transform.Rotation).Scaled(scale),
+			transform.Position
+		);
 		_isDirty = true;
 
 		// TODO: SetPhysicsProcess affects Physical.cs's tick, but could also affect other behaviour.
@@ -613,8 +608,8 @@ public partial class Dynamic : Instance
 			_lerpUnreliable = false;
 			SetPhysicsProcessWAuthor(false);
 
-			_currentTransform = transform;
-			SetLocalTransform(transform);
+			_currentTransform = _netTransform;
+			SetLocalTransform(_netTransform);
 		}
 		else if (lerpTransform && !Root.Network.IsServer)
 		{

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -16,7 +16,6 @@ namespace Polytoria.Datamodel;
 [Instantiable]
 public partial class NPC : Physical
 {
-	public override float SyncInterval { get; protected set; } = 0.05f;
 	private const float CoyoteTime = 0.15f;
 	private const float NavigationDistance = 1f;
 	public const float BodyRotateLerp = 10f;

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -36,7 +36,6 @@ public partial class Physical : Dynamic
 		public List<Node> CollisionSyncNodes { get; } = [];
 	}
 
-	public virtual float SyncInterval { get; protected set; } = 0.1f;
 	private const float TouchedGapCheck = 20f;
 	private bool _anchored = true;
 	private bool _canCollide = true;
@@ -49,8 +48,6 @@ public partial class Physical : Dynamic
 
 	private int _touchedListenerCount = 0;
 	private bool _canTouch = false;
-
-	private double _syncClock = 0;
 
 	private readonly Dictionary<Physical, int> _touchContacts = [];
 
@@ -525,16 +522,10 @@ public partial class Physical : Dynamic
 		UpdateTransformTick(delta);
 		if (Root == null || Root?.Network == null) { return; }
 
-		_syncClock += delta;
-
 		// Sync if has authority and not anchored, if so. sync in interval
-		if (_syncClock > SyncInterval)
+		if (NetTransformAuthority == Root.Network.LocalPeerID && !Anchored)
 		{
-			_syncClock = 0;
-			if (NetTransformAuthority == Root.Network.LocalPeerID && !Anchored)
-			{
-				UpdateNetTransform();
-			}
+			UpdateNetTransform();
 		}
 		base.PhysicsProcess(delta);
 	}

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -13,6 +13,7 @@ using Polytoria.Scripting;
 using Polytoria.Networking;
 using Polytoria.Shared;
 using Polytoria.Utils;
+using Polytoria.Utils.DTOs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1074,18 +1075,7 @@ public sealed partial class Player : NPC
 		}
 	}
 
-	internal override Transform3D TransformNetworkPass(int fromPeer, Transform3D newTransform)
-	{
-		if (fromPeer != 1)
-		{
-			// Prevent scaling from client
-			Vector3 existingScale = GetLocalTransform().Basis.Scale;
-			newTransform.Basis = newTransform.Basis.Orthonormalized().Scaled(existingScale);
-		}
-		return newTransform;
-	}
-
-	internal override bool TransformNetworkCheck(Transform3D newTransform)
+	internal override bool TransformNetworkCheck(TransformPayloadDto newTransform)
 	{
 		// TODO: Make sanity checks here
 		return true;

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -1015,6 +1015,8 @@ public sealed partial class NetworkService : Instance
 	[JsonSerializable(typeof(Vector3Dto))]
 	[JsonSerializable(typeof(ColorDto))]
 	[JsonSerializable(typeof(Transform3DDto))]
+	[JsonSerializable(typeof(UnitQuaternionDto))]
+	[JsonSerializable(typeof(TransformPayloadDto))]
 
 	[JsonSerializable(typeof(NetPropNetworkedObjectRef))]
 	[JsonSerializable(typeof(NetPropReplicateData))]

--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -87,11 +87,10 @@ public partial class NetworkTransformSync : Instance
 		{
 			if (item is Dynamic dyn)
 			{
-				Transform3D transform3D = dyn.GetLocalTransform();
 				data.Add(new()
 				{
 					NetID = dyn.NetworkedObjectID,
-					Value = Transform3DDto.ToFloatArray(transform3D)
+					Value = TransformPayloadDto.ToArray(dyn.GetLocalTransform())
 				});
 			}
 		}
@@ -107,7 +106,7 @@ public partial class NetworkTransformSync : Instance
 		{
 			// There might be newer pending transforms
 			if (_pendingTransforms.ContainsKey(item.NetID)) { continue; }
-			RecvUpdateTransformHandler(item.NetID, Transform3DDto.FromFloatArray(item.Value), 1, true, false);
+			RecvUpdateTransformHandler(item.NetID, TransformPayloadDto.FromArray(item.Value), 1, true, false);
 		}
 
 		if (isFirstInit)
@@ -128,18 +127,18 @@ public partial class NetworkTransformSync : Instance
 		// Check if self has the network authority
 		if (!CheckDynAuthor(dyn, NetService.LocalPeerID)) return;
 
-		Transform3D current = dyn.GetLocalTransform();
+		TransformPayloadDto payload = TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform());
 		string objID = dyn.NetworkedObjectID;
 
 		if (sendTo != 0)
 		{
 			if (isReliable)
 			{
-				RpcId(sendTo, nameof(NetRecvUpdateTransformReliable), objID, current, lerpTransform);
+				RpcId(sendTo, nameof(NetRecvUpdateTransformReliable), objID, payload, lerpTransform);
 			}
 			else
 			{
-				RpcId(sendTo, nameof(NetRecvUpdateTransform), objID, current, lerpTransform);
+				RpcId(sendTo, nameof(NetRecvUpdateTransform), objID, payload, lerpTransform);
 			}
 		}
 		else
@@ -148,29 +147,29 @@ public partial class NetworkTransformSync : Instance
 			{
 				if (_useNetworkLog) { PT.Print($"[Net] [Transform] {dyn.NetworkPath} Reliable update"); }
 
-				Rpc(nameof(NetRecvUpdateTransformReliable), objID, current, lerpTransform);
+				Rpc(nameof(NetRecvUpdateTransformReliable), objID, payload, lerpTransform);
 			}
 			else
 			{
-				Rpc(nameof(NetRecvUpdateTransform), objID, current, lerpTransform);
+				Rpc(nameof(NetRecvUpdateTransform), objID, payload, lerpTransform);
 			}
 		}
 	}
 
 
 	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.UnreliableOrdered)]
-	private void NetRecvUpdateTransform(string objID, Transform3D transform, bool lerpTransform)
+	private void NetRecvUpdateTransform(string objID, TransformPayloadDto transform, bool lerpTransform)
 	{
 		RecvUpdateTransformHandler(objID, transform, RemoteSenderId, false, lerpTransform);
 	}
 
 	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable)]
-	private void NetRecvUpdateTransformReliable(string objID, Transform3D transform, bool lerpTransform)
+	private void NetRecvUpdateTransformReliable(string objID, TransformPayloadDto transform, bool lerpTransform)
 	{
 		RecvUpdateTransformHandler(objID, transform, RemoteSenderId, true, lerpTransform);
 	}
 
-	private void RecvUpdateTransformHandler(string objID, Transform3D transform, int fromPeer, bool isReliable, bool lerpTransform)
+	private void RecvUpdateTransformHandler(string objID, TransformPayloadDto transform, int fromPeer, bool isReliable, bool lerpTransform)
 	{
 		if (NetService.Root.GetNetObjectFromID(objID) is Dynamic dyn)
 		{
@@ -210,10 +209,10 @@ public partial class NetworkTransformSync : Instance
 		// Check authority
 		if (!CheckDynAuthor(dyn, NetService.LocalPeerID)) return;
 
-		Transform3D current = dyn.GetLocalTransform();
+		TransformPayloadDto payload = TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform());
 		string objID = dyn.NetworkedObjectID;
 
-		RpcId(1, nameof(NetRecvTransformOnServer), objID, current, lerpTransform);
+		RpcId(1, nameof(NetRecvTransformOnServer), objID, payload, lerpTransform);
 	}
 
 	public void BroadcastTransformFromServer(Dynamic dyn, bool lerpTransform, int excludePeer = -1, bool reliable = true)
@@ -222,7 +221,7 @@ public partial class NetworkTransformSync : Instance
 		if (!dyn.IsNetworkReady) return;
 		string objID = dyn.NetworkedObjectID;
 
-		SetPendingBatch(objID, new(dyn, dyn.GetLocalTransform(), lerpTransform, excludePeer)
+		SetPendingBatch(objID, new(dyn, TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform()), lerpTransform, excludePeer)
 		{
 			Reliable = reliable,
 			Forced = true
@@ -230,7 +229,7 @@ public partial class NetworkTransformSync : Instance
 	}
 
 	[NetRpc(AuthorityMode.Any, TransferMode = TransferMode.UnreliableOrdered, CallLocal = false)]
-	private void NetRecvTransformOnServer(string objID, Transform3D transform, bool lerpTransform)
+	private void NetRecvTransformOnServer(string objID, TransformPayloadDto transform, bool lerpTransform)
 	{
 		int fromPeer = RemoteSenderId;
 
@@ -251,10 +250,11 @@ public partial class NetworkTransformSync : Instance
 				SendUpdateTransform(dyn, true, fromPeer);
 				return;
 			}
-			Transform3D processed = dyn.TransformNetworkPass(fromPeer, transform);
+			TransformPayloadDto processed = dyn.TransformNetworkPass(fromPeer, transform);
 
 			// If is equal approx to last, return
-			if (processed.IsEqualApprox(dyn.GetLocalTransform())) return;
+			if (processed.IsEqualApprox(TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform())))
+				return;
 
 			// Update on server
 			dyn.UpdateTransformFromNet(processed, false, lerpTransform);
@@ -345,7 +345,8 @@ public partial class NetworkTransformSync : Instance
 			return;
 
 		// Skip if transform is not changed enough to matter
-		if (!forced && existing.Transform.IsEqualApprox(entry.Transform))
+		// existing.Transform can be null here. Don't ask me why.
+		if (!forced && existing.Transform != null && existing.Transform.IsEqualApprox(entry.Transform))
 			return;
 
 		_pendingBatchUpdate[objID] = entry;
@@ -372,7 +373,7 @@ public partial class NetworkTransformSync : Instance
 		{
 			if (NetService.Root.GetNetObjectFromID(data.ObjID) is Dynamic dyn)
 			{
-				dyn.UpdateTransformFromNet(Transform3DDto.FromFloatArray(data.Transform), isReliable, data.Lerp);
+				dyn.UpdateTransformFromNet(TransformPayloadDto.FromArray(data.Transform), isReliable, data.Lerp);
 			}
 		}
 	}
@@ -388,10 +389,10 @@ public partial class NetworkTransformSync : Instance
 		return list;
 	}
 
-	private struct PendingBatchTransform(Dynamic dyn, Transform3D transform, bool lerpTransform, int excludePeer)
+	private struct PendingBatchTransform(Dynamic dyn, TransformPayloadDto transform, bool lerpTransform, int excludePeer)
 	{
 		public Dynamic Dyn = dyn;
-		public Transform3D Transform = transform;
+		public TransformPayloadDto Transform = transform;
 		public bool LerpTransform = lerpTransform;
 		public int ExcludePeer = excludePeer;
 		public bool Reliable = false;
@@ -400,7 +401,7 @@ public partial class NetworkTransformSync : Instance
 
 	private struct PendingTransform()
 	{
-		public Transform3D Transform;
+		public TransformPayloadDto Transform;
 		public int FromPeer;
 		public int ToPeer = -1;
 	}
@@ -415,10 +416,10 @@ public partial class NetworkTransformSync : Instance
 		[MemoryPackConstructor]
 		public BatchTransformData() { }
 
-		public BatchTransformData(string objID, Transform3D transform, bool lerp)
+		public BatchTransformData(string objID, TransformPayloadDto transform, bool lerp)
 		{
 			ObjID = objID;
-			Transform = Transform3DDto.ToFloatArray(transform);
+			Transform = TransformPayloadDto.ToArray(transform);
 			Lerp = lerp;
 		}
 	}

--- a/Polytoria/scripts/utils/dto/TransformPayload.cs
+++ b/Polytoria/scripts/utils/dto/TransformPayload.cs
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Godot;
+using MemoryPack;
+using System;
+using System.Text.Json.Serialization;
+
+namespace Polytoria.Utils.DTOs;
+
+[MemoryPackable]
+public partial class TransformPayloadDto
+{
+	public float[] Values { get; set; } = null!;
+
+	public Vector3 Position
+	{
+		get => new Vector3(Values[0], Values[1], Values[2]);
+		set
+		{
+			Values[0] = value.X; Values[1] = value.Y; Values[2] = value.Z;
+		}
+	}
+
+	public uint RawRotation
+	{
+		get => BitConverter.ToUInt32(BitConverter.GetBytes(Values[3]), 0);
+		set
+		{
+			Values[3] = BitConverter.ToSingle(BitConverter.GetBytes(value), 0);
+		}
+	}
+
+	public Quaternion Rotation
+	{
+		get => UnitQuaternionDto.FromCompressed(RawRotation);
+		set
+		{
+			RawRotation = UnitQuaternionDto.ToCompressed(value);
+		}
+	}
+
+	[MemoryPackConstructor, JsonConstructor]
+	public TransformPayloadDto() { }
+	public TransformPayloadDto(float[] values)
+	{
+		Values = values;
+	}
+	public TransformPayloadDto(Vector3 position, Quaternion rotation)
+	{
+		Values = ToArray(position, rotation);
+	}
+
+	public bool IsEqualApprox(TransformPayloadDto other) => Position.IsEqualApprox(other.Position) && Rotation.IsEqualApprox(other.Rotation);
+
+	// String helpers because memory pack don't like nested objects
+	public static TransformPayloadDto FromString(string str)
+	{
+		var parts = str.Split('|');
+		return new TransformPayloadDto(Vector3Dto.FromString(parts[0]), UnitQuaternionDto.FromString(parts[1]));
+	}
+
+	public static string ToString(Vector3 Position, Quaternion Rotation)
+	{
+		return $"{Vector3Dto.ToString(Position)}|{UnitQuaternionDto.ToString(Rotation)}";
+	}
+
+	public static float[] ToArray(Vector3 Position, uint Rotation) => [
+		Position.X, Position.Y, Position.Z,
+		BitConverter.ToSingle(BitConverter.GetBytes(Rotation), 0)
+	];
+	public static float[] ToArray(Vector3 Position, Quaternion Rotation) => ToArray(Position, UnitQuaternionDto.ToCompressed(Rotation));
+	public static float[] ToArray(Transform3D t) => ToArray(t.Origin, t.Basis.GetRotationQuaternion());
+	public static float[] ToArray(TransformPayloadDto t) => ToArray(t.Position, t.RawRotation);
+
+	public static TransformPayloadDto FromArray(float[] f) => new(f);
+	public static TransformPayloadDto FromGDTransform(Transform3D t) => new(t.Origin, t.Basis.GetRotationQuaternion());
+}

--- a/Polytoria/scripts/utils/dto/TransformPayload.cs.uid
+++ b/Polytoria/scripts/utils/dto/TransformPayload.cs.uid
@@ -1,0 +1,1 @@
+uid://clkfr45t48n68

--- a/Polytoria/scripts/utils/dto/UnitQuaternion.cs
+++ b/Polytoria/scripts/utils/dto/UnitQuaternion.cs
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Godot;
+using MemoryPack;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Polytoria.Utils.DTOs;
+
+[MemoryPackable]
+public partial class UnitQuaternionDto
+{
+	[JsonInclude] public uint Rotation { get; set; }
+
+	// Constant used for compression.
+	static readonly float _oneSqrtTwo = (float)(1.0f / Math.Sqrt(2.0f));
+
+	[MemoryPackConstructor, JsonConstructor]
+	public UnitQuaternionDto() { }
+	public UnitQuaternionDto(Quaternion v) { Rotation = ToCompressed(v); }
+	public Quaternion ToQuaternion() => FromCompressed(Rotation);
+
+	public static string ToString(Quaternion src)
+	{
+		uint compressed = ToCompressed(src);
+		return $"{compressed}";
+	}
+
+	public static Quaternion FromString(string src)
+	{
+		return FromCompressed(Convert.ToUInt32(src));
+	}
+
+	public static uint ToCompressed(Quaternion src)
+	{
+		int largestComponent = 0;
+		for (int i = 1; i < 4; i++)
+		{
+			if (Math.Abs(src[i]) > Math.Abs(src[largestComponent])) { largestComponent = i; }
+		}
+
+		uint negate = (uint)(src[largestComponent] < 0 ? 1 : 0);
+		uint result = (uint)largestComponent;
+		for (int i = 0; i < 4; i++)
+		{
+			if (i != largestComponent)
+			{
+				uint negbit = (uint)(src[i] < 0 ? 0x1 : 0x0) ^ negate;
+				// 511 == ((1 << 9) - 1)
+				uint magnitude = (uint)(511 * Math.Abs(src[i]) / _oneSqrtTwo + 0.5f);
+				result = (result << 10) | (negbit << 9) | magnitude;
+			}
+		}
+		return result;
+	}
+
+	public static Quaternion FromCompressed(uint src)
+	{
+		Quaternion result = new Quaternion();
+		int largestComponent = (int)(src >> 30);
+		double sumSquares = 0;
+		for (int i = 3; i >= 0; i--)
+		{
+			if (i != largestComponent)
+			{
+				uint magnitude = src & 511;
+				uint negbit = (src >> 9) & 1;
+				src = src >> 10;
+				result[i] = _oneSqrtTwo * (float)magnitude / 511;
+				if (negbit == (uint)1) { result[i] = -result[i]; }
+				sumSquares += result[i] * result[i];
+			}
+		}
+		result[largestComponent] = (float)Math.Sqrt(1 - sumSquares);
+		return result;
+	}
+}
+
+public class UnitQuaternionJsonConverter : JsonConverter<Quaternion>
+{
+	public override Quaternion Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		if (reader.TokenType != JsonTokenType.StartArray)
+		{
+			throw new JsonException("Expected start of array");
+		}
+
+		reader.Read();
+		uint compressed = reader.GetUInt32();
+
+		reader.Read();
+		if (reader.TokenType != JsonTokenType.EndArray)
+		{
+			throw new JsonException("Expected end of array");
+		}
+
+		return UnitQuaternionDto.FromCompressed(compressed);
+	}
+
+	public override void Write(Utf8JsonWriter writer, Quaternion value, JsonSerializerOptions options)
+	{
+		uint compressed = UnitQuaternionDto.ToCompressed(value);
+		writer.WriteStartArray();
+		writer.WriteNumberValue(compressed);
+		writer.WriteEndArray();
+	}
+}

--- a/Polytoria/scripts/utils/dto/UnitQuaternion.cs.uid
+++ b/Polytoria/scripts/utils/dto/UnitQuaternion.cs.uid
@@ -1,0 +1,1 @@
+uid://byjcxt0geyg1m


### PR DESCRIPTION
## Summary

This change replaces `Transform3D` in the network transform sync with a new `TransformPayloadDto`, a class that contains only the necessary transform data that's needed to be applied between server and client. The data for each transform is compressed into four floats. This is achieved by unpacking the position, and by compressing the rotation in the form of a unit quaternion. The rotation is bit-copied into a float in order to send the data as a float array, but it may be nice to consider changing the array to a byte array to allow for further compression. In total, there are 8 less 32-bit values being sent between client and server. This, combined with the existing ZSTD compression, saves a significant amount of bandwidth from server to client.

So much bandwidth is saved from this change that the `SyncInterval` for all objects can be uncapped completely. Now that the send rate for transforms are completely uncapped, this should make all objects appear smoother due to the minimization of packet loss, allowing for a (slightly) better experience. While this isn't the complete solution to the stuttery lockstep replication algorithm, I believe this is a step in the right direction towards a smoother Polytoria experience.

## Related issue or discussion

Related to #12
Fixes #365
(While making this change, I think I managed to fix the above issue.)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [x] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Comparison 1 (Less physics objects. Uncapped networking seems to struggle.)

https://github.com/user-attachments/assets/a2248d6b-8865-496a-bbce-7d8dbe1fe83f

Comparison 2 (A lot more physics objects. Uncapped networking wins big.)

https://github.com/user-attachments/assets/53a21d55-e22b-4788-8236-53322461a236

A look at part rotation (It appears to be fixed, yet laggy due to lockstep.)

https://github.com/user-attachments/assets/c9a9744b-c507-4a7e-8368-6a9a932fc165

## AI/LLM use

No AI/LLMs were used in the making of this patch. In fact, I ended up corrupting the original patch and had to make an entire new branch simply because of one bad rebase. Note to self: rebase is evil.