### PR TITLE
Improve Sound looping

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -128,6 +128,20 @@ public sealed partial class Sound : Dynamic
 		set
 		{
 			_loop = value;
+
+			switch (_currentStream)
+			{
+				case AudioStreamMP3 aStream:
+					aStream.LoopOffset = 0;
+					aStream.Loop = value;
+					break;
+				case AudioStreamOggVorbis aStream:
+					aStream.LoopOffset = 0;
+					aStream.Loop = value;
+					break;
+					// unused in Polytoria
+					//case AudioStreamWav aStream:
+			}
 			OnPropertyChanged();
 		}
 	}
@@ -296,18 +310,11 @@ public sealed partial class Sound : Dynamic
 
 	private void OnPlayerFinished()
 	{
-		// Loop the audio
-		if (Loop)
+		// Event is not fired on looping sound
+		Playing = false;
+		if (HasAuthority)
 		{
-			Play();
-		}
-		else
-		{
-			Playing = false;
-			if (HasAuthority)
-			{
-				ServerIsPlaying = false;
-			}
+			ServerIsPlaying = false;
 		}
 	}
 
@@ -474,6 +481,7 @@ public sealed partial class Sound : Dynamic
 		_currentStream = (AudioStream)audio;
 		_audioPlayer?.Stream = (AudioStream)audio;
 		_audioPlayer3D?.Stream = (AudioStream)audio;
+		Loop = _loop; // reapply to new stream
 
 		Loaded.Invoke();
 


### PR DESCRIPTION
## Summary

Fixes sound looping by actually using loop property instead of firing `Play()` on `Finished` signal.

## Related issue or discussion

Fixes #388
Related to #344

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
Before:
<img width="960" height="740" alt="image" src="https://github.com/user-attachments/assets/bf35b2fd-e7c2-40ee-a851-b22853a49302" />
After:
<img width="960" height="740" alt="image" src="https://github.com/user-attachments/assets/a676c3eb-8315-42ea-abd4-546355ad9291" />

## AI/LLM use

I gave Claude half a bottle of dry gin to be my advisor and help me translate my intentions from C99 to C#.