### PR TITLE
[Feature] Interactive Viewport Axis

### DIFF
--- a/Polytoria/scenes/creator/misc/viewport_axis.tscn
+++ b/Polytoria/scenes/creator/misc/viewport_axis.tscn
@@ -156,7 +156,7 @@ material_override = SubResource("StandardMaterial3D_8jdmp")
 mesh = SubResource("BoxMesh_p6s2d")
 
 [node name="Label3DLeft" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=410713094]
-transform = Transform3D(-4.371139e-08, 0, 1, 0, 1, 0, -1, 0, -4.371139e-08, 0.51, 0, -4.4585615e-08)
+transform = Transform3D(-4.371139e-08, 0, -1, 0, 1, 0, 1, 0, -4.371139e-08, -0.51, 0, 0)
 double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "L"
@@ -165,7 +165,7 @@ font_size = 112
 outline_size = 0
 
 [node name="Label3DRight" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=2116042962]
-transform = Transform3D(1.3113416e-07, 0, -1, 0, 1, 0, 1, 0, 1.3113416e-07, -0.51, 0, 4.4585615e-08)
+transform = Transform3D(-4.371138e-08, 0, 1, 0, 1, 0, -1, 0, -4.371138e-08, 0.51, 0, 0)
 double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "R"
@@ -192,7 +192,7 @@ font_size = 112
 outline_size = 0
 
 [node name="Label3DFront" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=1262443344]
-transform = Transform3D(-1, 7.301438e-30, -8.742278e-08, 0, 1, -8.351872e-23, 8.742278e-08, 8.351872e-23, -1, -4.4585615e-08, 0, -0.51)
+transform = Transform3D(1, -1.4602876e-29, 1.7484555e-07, 0, 1, -8.351872e-23, -1.7484555e-07, -8.351872e-23, 1, 8.917123e-08, 0, 0.51)
 double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "F"
@@ -201,7 +201,7 @@ font_size = 112
 outline_size = 0
 
 [node name="Label3DBack" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=1609789718]
-transform = Transform3D(1, 0, 1.7484555e-07, 0, 1, 0, -1.7484555e-07, 0, 1, 4.4585615e-08, 0, 0.51)
+transform = Transform3D(-1, 0, -2.6226832e-07, 0, 1, 0, 2.6226832e-07, 0, -1, -8.917123e-08, 0, -0.51)
 double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "B"

--- a/Polytoria/scenes/creator/misc/viewport_axis.tscn
+++ b/Polytoria/scenes/creator/misc/viewport_axis.tscn
@@ -6,18 +6,17 @@
 [sub_resource type="Environment" id="Environment_mv8nn"]
 background_mode = 1
 background_color = Color(0.3403393, 0.34033933, 0.3403393, 1)
-
-[sub_resource type="BoxShape3D" id="BoxShape3D_mv8nn"]
-size = Vector3(0.2, 1, 0.2)
+ambient_light_source = 2
+ambient_light_color = Color(1, 1, 1, 1)
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_lvvhg"]
 shading_mode = 0
 albedo_color = Color(0.84, 0, 0, 1)
 
 [sub_resource type="CylinderMesh" id="CylinderMesh_mv8nn"]
-top_radius = 0.16
-bottom_radius = 0.04
-height = 0.73
+top_radius = 0.04
+bottom_radius = 0.01
+height = 1.4
 radial_segments = 8
 rings = 1
 
@@ -29,13 +28,15 @@ albedo_color = Color(0.14760001, 0.82, 0.3941466, 1)
 shading_mode = 0
 albedo_color = Color(0, 0.2833333, 1, 1)
 
+[sub_resource type="BoxShape3D" id="BoxShape3D_mv8nn"]
+
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_8jdmp"]
+albedo_color = Color(0.8646751, 0.86467516, 0.8646751, 1)
 
 [sub_resource type="BoxMesh" id="BoxMesh_p6s2d"]
-size = Vector3(0.5, 0.5, 0.5)
 
 [node name="ViewportAxis" type="Control" unique_id=1356262339 node_paths=PackedStringArray("_pivot", "_container")]
-custom_minimum_size = Vector2(100, 100)
+custom_minimum_size = Vector2(128, 128)
 layout_mode = 3
 anchors_preset = 1
 anchor_left = 1.0
@@ -45,18 +46,21 @@ offset_top = 16.0
 offset_right = -16.0
 offset_bottom = 16.0
 grow_horizontal = 0
+mouse_default_cursor_shape = 1
 script = ExtResource("1_mv8nn")
 _pivot = NodePath("TextureRect/SubViewport/Node3D")
 _container = NodePath("TextureRect/SubViewport")
 
 [node name="TextureRect" type="SubViewportContainer" parent="." unique_id=1622363265]
+modulate = Color(1, 1, 1, 0.9019608)
 layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = -87.0
-offset_bottom = 87.0
+offset_left = -128.0
+offset_bottom = 128.0
 grow_horizontal = 0
+pivot_offset_ratio = Vector2(1, 0)
 stretch = true
 mouse_target = true
 
@@ -64,7 +68,8 @@ mouse_target = true
 own_world_3d = true
 transparent_bg = true
 handle_input_locally = false
-size = Vector2i(87, 87)
+physics_object_picking = true
+size = Vector2i(128, 128)
 render_target_update_mode = 4
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="TextureRect/SubViewport" unique_id=1353520945]
@@ -72,117 +77,134 @@ environment = SubResource("Environment_mv8nn")
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="TextureRect/SubViewport" unique_id=756222310]
 transform = Transform3D(0.49999994, -0.8535535, -0.14644656, 0.5, 0.1464466, 0.8535534, -0.7071069, -0.4999999, 0.5, 0, 0, 0)
+visible = false
 light_energy = 2.0
 
-[node name="X" type="Area3D" parent="TextureRect/SubViewport" unique_id=1674040262]
-transform = Transform3D(1.3113416e-07, 1, -4.371139e-08, 0, -4.371139e-08, -1, -1, 1.3113416e-07, -5.7320566e-15, 0, 0, 0)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="TextureRect/SubViewport/X" unique_id=582125111]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
-shape = SubResource("BoxShape3D_mv8nn")
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="TextureRect/SubViewport/X" unique_id=1416688725]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+[node name="X" type="MeshInstance3D" parent="TextureRect/SubViewport" unique_id=1416688725]
+transform = Transform3D(1.3113416e-07, 1, -4.371139e-08, 0, -4.371139e-08, -1, -1, 1.3113416e-07, -5.7320566e-15, 0.19999999, -0.5, -0.49999994)
 material_override = SubResource("StandardMaterial3D_lvvhg")
 mesh = SubResource("CylinderMesh_mv8nn")
 
 [node name="Label3D" type="Label3D" parent="TextureRect/SubViewport/X" unique_id=439217787]
-transform = Transform3D(1, 0, 0, 0, 1, -8.351872e-23, 0, -8.351872e-23, 1, 4.371139e-08, 1, -0.23372589)
+transform = Transform3D(1, 0, 0, 0, 1, -7.516684e-22, 0, -7.5166837e-22, 1, 0, 0.70000005, -0.23399997)
 billboard = 1
 double_sided = false
+texture_filter = 1
 modulate = Color(0.8392157, 0, 0, 1)
 text = "X"
 font = ExtResource("2_lvvhg")
-font_size = 60
-outline_size = 0
+font_size = 80
+outline_size = 16
 uppercase = true
 
-[node name="Label3D2" type="Label3D" parent="TextureRect/SubViewport/X" unique_id=331110724]
-transform = Transform3D(1, 0, 0, 0, 1, -8.351872e-23, 0, -8.351872e-23, 1, -4.371139e-08, -1, -0.2337258)
-billboard = 1
-double_sided = false
-modulate = Color(0.8392157, 0, 0, 1)
-text = "-X"
-font = ExtResource("2_lvvhg")
-font_size = 60
-outline_size = 0
-uppercase = true
-
-[node name="Y" type="Area3D" parent="TextureRect/SubViewport" unique_id=591630807]
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="TextureRect/SubViewport/Y" unique_id=97005872]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
-shape = SubResource("BoxShape3D_mv8nn")
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="TextureRect/SubViewport/Y" unique_id=1429337988]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+[node name="Y" type="MeshInstance3D" parent="TextureRect/SubViewport" unique_id=1429337988]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 0.19999999, -0.5)
 material_override = SubResource("StandardMaterial3D_mv8nn")
 mesh = SubResource("CylinderMesh_mv8nn")
 
 [node name="Label3D2" type="Label3D" parent="TextureRect/SubViewport/Y" unique_id=371806389]
-transform = Transform3D(-4.371139e-08, -1, 4.371139e-08, 0, -4.371139e-08, -1, 1, -4.371139e-08, 1.9106855e-15, 0.0023145676, 1.2337259, 0.005479336)
+transform = Transform3D(-4.371139e-08, -1, 4.371139e-08, 0, -4.371139e-08, -1, 1, -4.371139e-08, 1.9106855e-15, 0.122999996, 0.70000005, 0.122999996)
 billboard = 1
 double_sided = false
+texture_filter = 1
 modulate = Color(0.14509805, 0.8156863, 0.40392157, 1)
 text = "Y"
 font = ExtResource("2_lvvhg")
-font_size = 60
-outline_size = 0
+font_size = 80
+outline_size = 16
 uppercase = true
 
-[node name="Label3D3" type="Label3D" parent="TextureRect/SubViewport/Y" unique_id=461807005]
-transform = Transform3D(-4.371139e-08, -1, 4.371139e-08, 0, -4.371139e-08, -1, 1, -4.371139e-08, 1.9106855e-15, 0.0023145676, -0.7662741, 0.005479336)
-billboard = 1
-double_sided = false
-modulate = Color(0.14509805, 0.8156863, 0.40392157, 1)
-text = "-Y"
-font = ExtResource("2_lvvhg")
-font_size = 60
-outline_size = 0
-uppercase = true
-
-[node name="Z" type="Area3D" parent="TextureRect/SubViewport" unique_id=259901094]
-transform = Transform3D(1, 0, 0, 0, -4.371139e-08, -1, 0, 1, -4.371139e-08, 0, 0, 0)
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="TextureRect/SubViewport/Z" unique_id=860474917]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
-shape = SubResource("BoxShape3D_mv8nn")
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="TextureRect/SubViewport/Z" unique_id=1545854099]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+[node name="Z" type="MeshInstance3D" parent="TextureRect/SubViewport" unique_id=1545854099]
+transform = Transform3D(1, 0, 0, 0, -4.371139e-08, -1, 0, 1, -4.371139e-08, -0.5, -0.5, 0.19999999)
 material_override = SubResource("StandardMaterial3D_q87ol")
 mesh = SubResource("CylinderMesh_mv8nn")
 
 [node name="Label3D3" type="Label3D" parent="TextureRect/SubViewport/Z" unique_id=24771300]
-transform = Transform3D(-4.371139e-08, -1, 4.371139e-08, 1, -4.3711385e-08, 4.3711392e-08, -4.371139e-08, 4.3711392e-08, 1, 0, 1, -0.23372595)
+transform = Transform3D(-4.371139e-08, -1, 4.371139e-08, 1, -4.3711385e-08, 4.3711392e-08, -4.371139e-08, 4.3711392e-08, 1, 0, 0.70000005, -0.23399997)
 billboard = 1
 double_sided = false
+texture_filter = 1
 modulate = Color(0, 0.28235295, 1, 1)
 text = "Z"
 font = ExtResource("2_lvvhg")
-font_size = 60
-outline_size = 0
-uppercase = true
-
-[node name="Label3D4" type="Label3D" parent="TextureRect/SubViewport/Z" unique_id=519724349]
-transform = Transform3D(-4.371139e-08, -1, 4.371139e-08, 1, -4.3711385e-08, 4.3711392e-08, -4.371139e-08, 4.3711392e-08, 1, 0, -1, -0.23372586)
-billboard = 1
-double_sided = false
-modulate = Color(0, 0.28235295, 1, 1)
-text = "-Z"
-font = ExtResource("2_lvvhg")
-font_size = 60
-outline_size = 0
+font_size = 80
+outline_size = 16
 uppercase = true
 
 [node name="Node3D" type="Node3D" parent="TextureRect/SubViewport" unique_id=1029460526]
 transform = Transform3D(1, 0, 0, 0, 0.99999994, 0, 0, 0, 1, 0, 0, 0)
 
 [node name="Camera3D" type="Camera3D" parent="TextureRect/SubViewport/Node3D" unique_id=720621715]
-transform = Transform3D(1, 0, 0, 0, 1.0000001, 0, 0, 0, 1, 0, 0.28109196, 2)
+transform = Transform3D(1, 0, 0, 0, 1.0000001, 0, 0, 0, 1, 0, 0, 2)
 projection = 1
-size = 2.38
+size = 2.4
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="TextureRect/SubViewport" unique_id=173651762]
+[node name="RayCast3D" type="RayCast3D" parent="TextureRect/SubViewport/Node3D/Camera3D" unique_id=53225599]
+enabled = false
+hit_back_faces = false
+collide_with_areas = true
+collide_with_bodies = false
+
+[node name="Cube" type="Area3D" parent="TextureRect/SubViewport" unique_id=1842935059]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="TextureRect/SubViewport/Cube" unique_id=1137341051]
+transform = Transform3D(1.25, 0, 0, 0, 1.25, 0, 0, 0, 1.25, 0, 0, 0)
+shape = SubResource("BoxShape3D_mv8nn")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="TextureRect/SubViewport/Cube" unique_id=173651762]
 material_override = SubResource("StandardMaterial3D_8jdmp")
 mesh = SubResource("BoxMesh_p6s2d")
+
+[node name="Label3DLeft" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=410713094]
+transform = Transform3D(-4.371139e-08, 0, 1, 0, 1, 0, -1, 0, -4.371139e-08, 0.51, 0, -4.4585615e-08)
+double_sided = false
+modulate = Color(0, 0, 0, 1)
+text = "L"
+font = ExtResource("2_lvvhg")
+font_size = 96
+outline_size = 0
+
+[node name="Label3DRight" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=2116042962]
+transform = Transform3D(1.3113416e-07, 0, -1, 0, 1, 0, 1, 0, 1.3113416e-07, -0.51, 0, 4.4585615e-08)
+double_sided = false
+modulate = Color(0, 0, 0, 1)
+text = "R"
+font = ExtResource("2_lvvhg")
+font_size = 96
+outline_size = 0
+
+[node name="Label3DTop" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=196398492]
+transform = Transform3D(-1, 8.742278e-08, 3.821371e-15, 0, -4.371139e-08, 1, 8.742278e-08, 1, 4.371139e-08, 0, 0.51, 0)
+double_sided = false
+modulate = Color(0, 0, 0, 1)
+text = "T"
+font = ExtResource("2_lvvhg")
+font_size = 96
+outline_size = 0
+
+[node name="Label3DBottom" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=1911737577]
+transform = Transform3D(1, 0, 0, 0, -4.371139e-08, -1, 0, 1, -4.371139e-08, 0, -0.51, 0)
+double_sided = false
+modulate = Color(0, 0, 0, 1)
+text = "BT"
+font = ExtResource("2_lvvhg")
+font_size = 96
+outline_size = 0
+
+[node name="Label3DFront" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=1262443344]
+transform = Transform3D(-1, 7.301438e-30, -8.742278e-08, 0, 1, -8.351872e-23, 8.742278e-08, 8.351872e-23, -1, -4.4585615e-08, 0, -0.51)
+double_sided = false
+modulate = Color(0, 0, 0, 1)
+text = "F"
+font = ExtResource("2_lvvhg")
+font_size = 96
+outline_size = 0
+
+[node name="Label3DBack" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=1609789718]
+transform = Transform3D(1, 0, 1.7484555e-07, 0, 1, 0, -1.7484555e-07, 0, 1, 4.4585615e-08, 0, 0.51)
+double_sided = false
+modulate = Color(0, 0, 0, 1)
+text = "B"
+font = ExtResource("2_lvvhg")
+font_size = 96
+outline_size = 0

--- a/Polytoria/scenes/creator/misc/viewport_axis.tscn
+++ b/Polytoria/scenes/creator/misc/viewport_axis.tscn
@@ -52,7 +52,7 @@ _pivot = NodePath("TextureRect/SubViewport/Node3D")
 _container = NodePath("TextureRect/SubViewport")
 
 [node name="TextureRect" type="SubViewportContainer" parent="." unique_id=1622363265]
-modulate = Color(1, 1, 1, 0.9019608)
+modulate = Color(1, 1, 1, 0.8627451)
 layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
@@ -161,7 +161,7 @@ double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "L"
 font = ExtResource("2_lvvhg")
-font_size = 96
+font_size = 112
 outline_size = 0
 
 [node name="Label3DRight" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=2116042962]
@@ -170,7 +170,7 @@ double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "R"
 font = ExtResource("2_lvvhg")
-font_size = 96
+font_size = 112
 outline_size = 0
 
 [node name="Label3DTop" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=196398492]
@@ -179,7 +179,7 @@ double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "T"
 font = ExtResource("2_lvvhg")
-font_size = 96
+font_size = 112
 outline_size = 0
 
 [node name="Label3DBottom" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=1911737577]
@@ -188,7 +188,7 @@ double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "BT"
 font = ExtResource("2_lvvhg")
-font_size = 96
+font_size = 112
 outline_size = 0
 
 [node name="Label3DFront" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=1262443344]
@@ -197,7 +197,7 @@ double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "F"
 font = ExtResource("2_lvvhg")
-font_size = 96
+font_size = 112
 outline_size = 0
 
 [node name="Label3DBack" type="Label3D" parent="TextureRect/SubViewport/Cube/MeshInstance3D" unique_id=1609789718]
@@ -206,5 +206,5 @@ double_sided = false
 modulate = Color(0, 0, 0, 1)
 text = "B"
 font = ExtResource("2_lvvhg")
-font_size = 96
+font_size = 112
 outline_size = 0

--- a/Polytoria/scripts/creator/ui/misc/ViewportAxis.cs
+++ b/Polytoria/scripts/creator/ui/misc/ViewportAxis.cs
@@ -12,15 +12,25 @@ public partial class ViewportAxis : Node
 	[Export] public WorldContainerOverlay Overlay = null!;
 	[Export] private Node3D _pivot = null!;
 	[Export] private Node _container = null!;
-	
-	private Polytoria.Datamodel.Camera _worldCamera = null;
+
+	private Polytoria.Datamodel.Camera? _worldCamera = null;
 	private SubViewportContainer _rect = null!;
 	private Camera3D _axisCamera = null!;
 	private RayCast3D _raycast = null!;
 	private Area3D _cube = null!;
-	
-	private Label3D _highlighted = null;
-	
+	private Label3D? _highlighted = null;
+
+	private Vector3 _tweenStart, _tweenTarget;
+	private float _tweenProgress = 1f;
+	private const float _tweenDuration = .2f;
+
+	private readonly Dictionary<Key, (Vector3 noMod, Vector3 withMod)> KeyToRotation = new()
+	{
+		{ Key.Kp1, (new Vector3(0, 180, 0),  new Vector3(0, 0, 0)) },
+		{ Key.Kp3, (new Vector3(0, -90, 0),  new Vector3(0, 90, 0)) },
+		{ Key.Kp7, (new Vector3(-90, 0, 0),  new Vector3(90, 0, 0)) }
+	};
+
 	public override void _Ready()
 	{
 		_rect = GetNode<SubViewportContainer>("TextureRect");
@@ -33,43 +43,62 @@ public partial class ViewportAxis : Node
 
 	public override void _Process(double delta)
 	{
+		if (_tweenProgress < 1f)
+		{
+			_tweenProgress = Mathf.Min(_tweenProgress + (float)delta / _tweenDuration, 1f);
+			float t = Mathf.SmoothStep(0, 1, _tweenProgress);
+			_worldCamera?.Rotation = _tweenStart.Lerp(_tweenTarget, t);
+		}
+
 		_worldCamera = Overlay.World.CreatorContext.Freelook;
 		_pivot.GlobalRotation = _worldCamera.Camera3D.GlobalRotation;
 	}
 
-	public void HandleInput(InputEvent @event)
+	public bool HandleInput(InputEvent @event)
 	{
-		ProjectMouse();
-		if (!_raycast.IsColliding()) 
+		if (@event is InputEventMouse && (!ProjectMouse() || !_raycast.IsColliding()))
 		{
 			Unhighlight();
-			return;
+			return false;
 		}
-		
+
 		Vector3 normal = _raycast.GetCollisionNormal();
-		if (@event is InputEventMouseMotion _) HighlightLabel(normal);
-		else if (@event is InputEventMouseButton { ButtonIndex: MouseButton.Left, Pressed: true } _)
+		switch (@event)
 		{
-			if (_worldCamera != null)
-			{
-				Vector3 up = Mathf.Abs(normal.Y) > 0.9f ? Vector3.Back : Vector3.Up;
-				Basis targetBasis = Basis.LookingAt(-normal, up);
-				_worldCamera.Rotation = targetBasis.GetEuler() * (180f / Mathf.Pi);
-			}
+			case InputEventMouseMotion:
+				HighlightLabel(normal);
+				break;
+			case InputEventMouseButton { ButtonIndex: MouseButton.Left, Pressed: true }:
+				if (_worldCamera != null)
+				{
+					Vector3 up = Mathf.Abs(normal.Y) > 0.9f ? Vector3.Back : Vector3.Up;
+					Basis targetBasis = Basis.LookingAt(-normal, up);
+					RotateWorldCamera(targetBasis.GetEuler() * (180f / Mathf.Pi));
+				}
+				return true;
+			case InputEventKey eventKey:
+				if (eventKey.Echo || !eventKey.Pressed) break;
+				if (!KeyToRotation.TryGetValue(eventKey.Keycode, out var rotations)) break;
+				RotateWorldCamera(eventKey.CtrlPressed ? rotations.withMod : rotations.noMod);
+				return true;
 		}
+		return false;
 	}
-	
-	private void ProjectMouse()
+
+	private bool ProjectMouse()
 	{
 		var mousePos = _rect.GetLocalMousePosition();
+		if (mousePos.X < 0 && mousePos.Y < 0) return false;
+
 		var rayOrigin = _axisCamera.ProjectRayOrigin(mousePos);
 		var rayNormal = _axisCamera.ProjectRayNormal(mousePos);
 		_raycast.Position = _axisCamera.ToLocal(rayOrigin);
 		_raycast.TargetPosition = _axisCamera.ToLocal(rayOrigin + rayNormal * 10f);
 		_raycast.ForceRaycastUpdate();
+		return true;
 	}
-	
-	private readonly Dictionary<Vector3I, string> labelSuffixes = new Dictionary<Vector3I, string>
+
+	private readonly Dictionary<Vector3I, string> labelSuffixes = new()
 	{
 		{ Vector3I.Left, "Right" },
 		{ Vector3I.Right, "Left" },
@@ -78,14 +107,14 @@ public partial class ViewportAxis : Node
 		{ Vector3I.Forward, "Front" },
 		{ Vector3I.Back, "Back" }
 	};
-	
+
 	private void Unhighlight()
 	{
 		if (_highlighted == null) return;
 		_highlighted.Modulate = Colors.Black;
 		_highlighted = null;
 	}
-	
+
 	private void HighlightLabel(Vector3 normal)
 	{
 		var normalI = new Vector3I((int)normal.X, (int)normal.Y, (int)normal.Z);
@@ -93,8 +122,33 @@ public partial class ViewportAxis : Node
 		var toHighlight = _cube.GetNode<Label3D>(labelPath);
 		if (_highlighted == toHighlight) return;
 
+		Color color = normalI switch
+		{
+			{ X: not 0 } => new Color(0xd60000ff),
+			{ Y: not 0 } => new Color(0x26d165ff),
+			_ => new Color(0x0048ffff)
+		};
+
 		Unhighlight();
 		_highlighted = toHighlight;
-		_highlighted.Modulate = new Color(0x2196f3ff);
+		_highlighted.Modulate = color;
+	}
+
+	private static float Shorten(float from, float to)
+	{
+		float diff = (to - from + 540f) % 360f - 180f;
+		return from + diff;
+	}
+
+	private void RotateWorldCamera(Vector3 rotation)
+	{
+		_tweenStart = _worldCamera!.Rotation;
+		_tweenTarget = new Vector3(
+			Shorten(_tweenStart.X, rotation.X),
+			Shorten(_tweenStart.Y, rotation.Y),
+			Shorten(_tweenStart.Z, rotation.Z)
+		);
+		if (_tweenStart == _tweenTarget) return;
+		_tweenProgress = 0f;
 	}
 }

--- a/Polytoria/scripts/creator/ui/misc/ViewportAxis.cs
+++ b/Polytoria/scripts/creator/ui/misc/ViewportAxis.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using Godot;
+using System.Collections.Generic;
 
 namespace Polytoria.Creator.UI;
 
@@ -11,10 +12,89 @@ public partial class ViewportAxis : Node
 	[Export] public WorldContainerOverlay Overlay = null!;
 	[Export] private Node3D _pivot = null!;
 	[Export] private Node _container = null!;
+	
+	private Polytoria.Datamodel.Camera _worldCamera = null;
+	private SubViewportContainer _rect = null!;
+	private Camera3D _axisCamera = null!;
+	private RayCast3D _raycast = null!;
+	private Area3D _cube = null!;
+	
+	private Label3D _highlighted = null;
+	
+	public override void _Ready()
+	{
+		_rect = GetNode<SubViewportContainer>("TextureRect");
+		_axisCamera = _pivot.GetNode<Camera3D>("Camera3D");
+		_raycast = _axisCamera.GetNode<RayCast3D>("RayCast3D");
+		_cube = _container.GetNode<Area3D>("Cube");
+
+		_raycast.Enabled = true;
+	}
 
 	public override void _Process(double delta)
 	{
-		Camera3D cam = Overlay.World.CreatorContext.Freelook.Camera3D;
-		_pivot.GlobalRotation = cam.GlobalRotation;
+		_worldCamera = Overlay.World.CreatorContext.Freelook;
+		_pivot.GlobalRotation = _worldCamera.Camera3D.GlobalRotation;
+	}
+
+	public void HandleInput(InputEvent @event)
+	{
+		ProjectMouse();
+		if (!_raycast.IsColliding()) 
+		{
+			Unhighlight();
+			return;
+		}
+		
+		Vector3 normal = _raycast.GetCollisionNormal();
+		if (@event is InputEventMouseMotion _) HighlightLabel(normal);
+		else if (@event is InputEventMouseButton { ButtonIndex: MouseButton.Left, Pressed: true } _)
+		{
+			if (_worldCamera != null)
+			{
+				Vector3 up = Mathf.Abs(normal.Y) > 0.9f ? Vector3.Back : Vector3.Up;
+				Basis targetBasis = Basis.LookingAt(-normal, up);
+				_worldCamera.Rotation = targetBasis.GetEuler() * (180f / Mathf.Pi);
+			}
+		}
+	}
+	
+	private void ProjectMouse()
+	{
+		var mousePos = _rect.GetLocalMousePosition();
+		var rayOrigin = _axisCamera.ProjectRayOrigin(mousePos);
+		var rayNormal = _axisCamera.ProjectRayNormal(mousePos);
+		_raycast.Position = _axisCamera.ToLocal(rayOrigin);
+		_raycast.TargetPosition = _axisCamera.ToLocal(rayOrigin + rayNormal * 10f);
+		_raycast.ForceRaycastUpdate();
+	}
+	
+	private readonly Dictionary<Vector3I, string> labelSuffixes = new Dictionary<Vector3I, string>
+	{
+		{ Vector3I.Left, "Right" },
+		{ Vector3I.Right, "Left" },
+		{ Vector3I.Up, "Top" },
+		{ Vector3I.Down, "Bottom" },
+		{ Vector3I.Forward, "Front" },
+		{ Vector3I.Back, "Back" }
+	};
+	
+	private void Unhighlight()
+	{
+		if (_highlighted == null) return;
+		_highlighted.Modulate = Colors.Black;
+		_highlighted = null;
+	}
+	
+	private void HighlightLabel(Vector3 normal)
+	{
+		var normalI = new Vector3I((int)normal.X, (int)normal.Y, (int)normal.Z);
+		var labelPath = "MeshInstance3D/Label3D" + labelSuffixes[normalI];
+		var toHighlight = _cube.GetNode<Label3D>(labelPath);
+		if (_highlighted == toHighlight) return;
+
+		Unhighlight();
+		_highlighted = toHighlight;
+		_highlighted.Modulate = new Color(0x2196f3ff);
 	}
 }

--- a/Polytoria/scripts/creator/ui/misc/ViewportAxis.cs
+++ b/Polytoria/scripts/creator/ui/misc/ViewportAxis.cs
@@ -26,9 +26,9 @@ public partial class ViewportAxis : Node
 
 	private readonly Dictionary<Key, (Vector3 noMod, Vector3 withMod)> KeyToRotation = new()
 	{
-		{ Key.Kp1, (new Vector3(0, 180, 0),  new Vector3(0, 0, 0)) },
-		{ Key.Kp3, (new Vector3(0, -90, 0),  new Vector3(0, 90, 0)) },
-		{ Key.Kp7, (new Vector3(-90, 0, 0),  new Vector3(90, 0, 0)) }
+		{ Key.Kp1, (new Vector3(0, 0, 0),  new Vector3(0, 180, 0)) },
+		{ Key.Kp3, (new Vector3(0, 90, 0),  new Vector3(0, -90, 0)) },
+		{ Key.Kp7, (new Vector3(-90, 180, 0),  new Vector3(90, 0, 0)) }
 	};
 
 	public override void _Ready()
@@ -100,12 +100,12 @@ public partial class ViewportAxis : Node
 
 	private readonly Dictionary<Vector3I, string> labelSuffixes = new()
 	{
-		{ Vector3I.Left, "Right" },
-		{ Vector3I.Right, "Left" },
+		{ Vector3I.Left, "Left" },
+		{ Vector3I.Right, "Right" },
 		{ Vector3I.Up, "Top" },
 		{ Vector3I.Down, "Bottom" },
-		{ Vector3I.Forward, "Front" },
-		{ Vector3I.Back, "Back" }
+		{ Vector3I.Forward, "Back" },
+		{ Vector3I.Back, "Front" }
 	};
 
 	private void Unhighlight()

--- a/Polytoria/scripts/creator/ui/tabs/world/WorldContainer.cs
+++ b/Polytoria/scripts/creator/ui/tabs/world/WorldContainer.cs
@@ -71,6 +71,7 @@ public sealed partial class WorldContainer : SubViewportContainer
 		{
 			GrabFocus();
 		}
+		Overlay.GetNode<ViewportAxis>("ViewportAxis").HandleInput(@event);
 		_subViewport.PushInput(@event);
 		GodotInputEvent?.Invoke(@event);
 	}

--- a/Polytoria/scripts/creator/ui/tabs/world/WorldContainer.cs
+++ b/Polytoria/scripts/creator/ui/tabs/world/WorldContainer.cs
@@ -23,6 +23,7 @@ public sealed partial class WorldContainer : SubViewportContainer
 	public WorldContainerOverlay Overlay = null!;
 	public UIGizmos UIGizmos = null!;
 	internal event Action<InputEvent>? GodotInputEvent;
+	private ViewportAxis _overlayAxis = null!;
 
 	public WorldContainer(World game)
 	{
@@ -45,6 +46,7 @@ public sealed partial class WorldContainer : SubViewportContainer
 		Overlay = Globals.CreateInstanceFromScene<WorldContainerOverlay>(ContainerOverlayPath);
 		Overlay.World = game;
 		Overlay.Container = this;
+		_overlayAxis = Overlay.GetNode<ViewportAxis>("ViewportAxis");
 		_subViewport.AddChild(Overlay);
 	}
 
@@ -71,7 +73,10 @@ public sealed partial class WorldContainer : SubViewportContainer
 		{
 			GrabFocus();
 		}
-		Overlay.GetNode<ViewportAxis>("ViewportAxis").HandleInput(@event);
+
+		var handledByAxis = _overlayAxis.HandleInput(@event);
+		if (handledByAxis) return;
+
 		_subViewport.PushInput(@event);
 		GodotInputEvent?.Invoke(@event);
 	}


### PR DESCRIPTION
## Summary

This PR replaces the viewport axis with a new and improved one. Changes:
- I disabled the directional lighting that was previously applied to the axis.
- I made the central cube much larger.
- I removed the arrows pointing towards -X, -Y and -Z.
- I moved the arrows for +X, +Y and +Z to meet in one corner of the cube.
- I made the overlay slightly transparent.
- I made each side of the cube interactable by projecting rays from the mouse onto the cube.
- Each side of the cube has a label to denote the face (F = **F**ront, L = **L**eft, BT = **B**ot**t**om etc.)
- Depending on the axis, labels are highlighted differently.
- Clicking on any face snaps the camera rotation accordingly.
- Numpad keys can be used to snap to any of the 6 sides. The keybinds assigned are the same ones found in Blender.
- Snapping is done through a short smooth transition (a fifth of a second) rather than instantly.
- If an input is "consumed" by the viewport axis, it is not replicated over to the world subviewport. This is to avoid accidental selections while clicking on the cube. (see changes in `WorldContainer.cs`)

## Related issue or discussion

Related to #267 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

[polytoria_viewportAxis.mp4](https://github.com/user-attachments/assets/51718ae9-9a6c-45d4-9d74-2e1e6a08760f)


## AI/LLM use

Minimal usage for debugging rotation logic. All code has been manually evaluated and written.