### PR TITLE
Fix weird behavior when picking multiple emojis from picker

### DIFF
--- a/Polytoria/scripts/client/ui/chat/UIEmojiPicker.cs
+++ b/Polytoria/scripts/client/ui/chat/UIEmojiPicker.cs
@@ -204,15 +204,25 @@ public partial class UIEmojiPicker : Control
 
 	public static void InsertEmojiAtCursor(LineEdit field, string emojiName)
 	{
+		if (string.IsNullOrEmpty(emojiName)) return;
+
 		int cursorPos = field.CaretColumn;
 		string text = field.Text;
 
+		int lastSpace = text.LastIndexOf(' ', cursorPos - 1);
+		int searchFrom = lastSpace >= 0 ? lastSpace : 0;
 		int colonIdx = text.LastIndexOf(':', cursorPos - 1);
-		int splitPoint = colonIdx >= 0 && colonIdx != cursorPos - 1 ? colonIdx : cursorPos;
+		int splitPoint = colonIdx >= searchFrom ? colonIdx : cursorPos;
+
 		string before = text[..splitPoint];
 		string after = text[cursorPos..];
-		field.Text = before + $":{emojiName}:" + after;
-		field.CaretColumn = splitPoint + emojiName.Length + 2;
+		string insertion = $":{emojiName}:";
+
+		if (after.Length == 0 || after[0] != ' ')
+			insertion += ' ';
+
+		field.Text = before + insertion + after;
+		field.CaretColumn = splitPoint + insertion.Length;
 	}
 
 	private void OnEmojiSelected(string emojiName)


### PR DESCRIPTION
## Summary

This was already addressed by PR #409 to fix #394, but it still had an issue when placing emojis after normal text.
Also now places a space between consecutively picked emojis for aesthetics.

Fixes #394

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

**Previous Behavior**

https://github.com/user-attachments/assets/ad6cbe20-fc5c-4dc0-a907-67f252aac15d

## AI/LLM use

None