### PR TITLE
Shift-click to pick multiple emojis from picker

### DIFF
--- a/Polytoria/scripts/client/ui/chat/UIChat.cs
+++ b/Polytoria/scripts/client/ui/chat/UIChat.cs
@@ -465,7 +465,9 @@ public partial class UIChat : Control
 
 	private void InsertEmojiAtCursor(string emojiName)
 	{
-		CloseEmojiPicker();
+		if (!Input.IsKeyPressed(Key.Shift))
+			CloseEmojiPicker();
+		
 		_suppressAutocomplete = true;
 
 		try

--- a/Polytoria/scripts/client/ui/chat/UIChat.cs
+++ b/Polytoria/scripts/client/ui/chat/UIChat.cs
@@ -467,7 +467,7 @@ public partial class UIChat : Control
 	{
 		if (!Input.IsKeyPressed(Key.Shift))
 			CloseEmojiPicker();
-		
+
 		_suppressAutocomplete = true;
 
 		try

--- a/Polytoria/scripts/client/ui/chat/UIEmojiPicker.cs
+++ b/Polytoria/scripts/client/ui/chat/UIEmojiPicker.cs
@@ -218,7 +218,6 @@ public partial class UIEmojiPicker : Control
 	private void OnEmojiSelected(string emojiName)
 	{
 		RecordEmojiUse(emojiName);
-		Visible = false;
 		EmojiPicked?.Invoke(emojiName);
 	}
 }


### PR DESCRIPTION
## Summary

Allows you to hold shift when picking emojis from the emoji picker, which prevents the menu from closing.

Closes #400 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x]  Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Holding shift for the first few clicks:

https://github.com/user-attachments/assets/9efb2b7a-9db7-45f5-b284-f9f8dfa0496b

## AI/LLM use

None