### PR TITLE
Update clothing materials to use Alpha instead of AlphaScissor

### DIFF
--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -251,12 +251,12 @@ public sealed partial class PolytorianModel : CharacterModel
 		FaceImage = null;
 		_headMat.NextPass = _faceMat;
 
-		_shirtMats[0] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
-		_shirtMats[1] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
-		_shirtMats[2] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
+		_shirtMats[0] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
+		_shirtMats[1] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
+		_shirtMats[2] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
 
-		_pantsMats[0] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
-		_pantsMats[1] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
+		_pantsMats[0] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
+		_pantsMats[1] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
 
 		_faceMat.Transparency = BaseMaterial3D.TransparencyEnum.Alpha;
 
@@ -454,7 +454,7 @@ public sealed partial class PolytorianModel : CharacterModel
 				StandardMaterial3D m = new()
 				{
 					AlbedoTexture = c.ClothTexture,
-					Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor,
+					Transparency = BaseMaterial3D.TransparencyEnum.Alpha,
 					RenderPriority = 1
 				};
 				if (head == null) { head = m; tail = m; }


### PR DESCRIPTION
## Summary

Updates clothing material to use alpha instead of alphascissor

## Related issue or discussion

Fixes #422

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [x] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [ ] Ran `dotnet restore`
- [ ] Ran `dotnet format`
- [ ] Ran `dotnet build`
- [ ] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None