### PR TITLE
Improve ColorDto

### DIFF
--- a/Polytoria/scripts/utils/dto/Color.cs
+++ b/Polytoria/scripts/utils/dto/Color.cs
@@ -13,17 +13,25 @@ namespace Polytoria.Utils.DTOs;
 [MemoryPackable]
 public partial class ColorDto
 {
-	[JsonInclude] public string Hex { get; set; } = "#FFF";
+	[JsonInclude] public uint Rgba { get; set; } = 0xFFFFFFFF;
 
 	[MemoryPackConstructor, JsonConstructor]
 	public ColorDto() { }
 	public ColorDto(Color c)
 	{
-		Hex = c.ToHtml();
+		Rgba =
+			((uint)(byte)(c.R * 255) << 24) |
+			((uint)(byte)(c.G * 255) << 16) |
+			((uint)(byte)(c.B * 255) << 8) |
+			(byte)(c.A * 255);
 	}
 	public Color ToColor()
 	{
-		return Color.FromString(Hex, new(1, 1, 1));
+		return new Color(
+			((Rgba >> 24) & 0xFF) / 255f,
+			((Rgba >> 16) & 0xFF) / 255f,
+			((Rgba >> 8) & 0xFF) / 255f,
+			(Rgba & 0xFF) / 255f);
 	}
 
 	public static string ToString(Color src)


### PR DESCRIPTION
## Summary

Changes the DTO to contain the color as uint instead as hex string

## Related issue or discussion

n/a

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

n/a

## AI/LLM use

I used Claude Mythos OPus 6.7 to write these 3 lines of code ofc
/j