### PR TITLE
Move world backup logic off main thread

### DIFF
--- a/Polytoria/scripts/creator/CreatorSession.cs
+++ b/Polytoria/scripts/creator/CreatorSession.cs
@@ -935,47 +935,44 @@ return module";
 		CreatorService.Interface.StatusBar?.SetStatus("Backing up world...");
 
 		string backupFolderPath = PolyFolderPath.PathJoin("backups");
-		if (!Directory.Exists(backupFolderPath))
-		{
-			Directory.CreateDirectory(backupFolderPath);
-		}
+		Directory.CreateDirectory(backupFolderPath);
+
+		List<DirectoryInfo> backupFolders = [.. Directory.GetDirectories(backupFolderPath)
+			.Select(path => new DirectoryInfo(path))
+			.OrderBy(dir => dir.Name)];
 
 		int maxCount = CreatorSettingsService.Instance.Get<int>(CreatorSettingKeys.Backup.MaxBackupCount);
 
-		// Delete oldest folder
-		List<DirectoryInfo> backupFolders = [.. Directory.GetDirectories(backupFolderPath)
-			.Select(path => new DirectoryInfo(path))
-			.OrderBy(dir => dir.CreationTime)];
+		string formattedTime = DateTime.Now.ToString("yyyy-MM-dd-HHmmss");
+		string snapshotFolder = backupFolderPath.PathJoin(formattedTime);
+		Directory.CreateDirectory(snapshotFolder);
+
+		try
+		{
+			await Task.WhenAll(OpenedWorlds.Select(async game =>
+			{
+				if (game.WorldFilePath == null)
+				{
+					PT.PrintWarn("Skipping game instance, no linked world file path");
+					return;
+				}
+
+				string writeTo = Path.Combine(snapshotFolder, game.WorldFilePath);
+				Directory.CreateDirectory(Path.GetDirectoryName(writeTo)!);
+
+				await Task.Run(() => PolyFormat.SaveWorldToFile(game, writeTo));
+			}));
+		}
+		catch
+		{
+			if (Directory.Exists(snapshotFolder))
+				Directory.Delete(snapshotFolder, true);
+			throw;
+		}
 
 		if (backupFolders.Count >= maxCount)
-		{
-			DirectoryInfo oldestFolder = backupFolders.First();
-			Directory.Delete(oldestFolder.FullName, true);
-		}
+			Directory.Delete(backupFolders.First().FullName, true);
 
-		DateTime time = DateTime.Now;
-		string formattedTime = time.ToString("yyyy-MM-dd-hhmmss");
-
-		string snapshotFolder = backupFolderPath.PathJoin(formattedTime);
-		if (!Directory.Exists(snapshotFolder))
-		{
-			Directory.CreateDirectory(snapshotFolder);
-		}
-
-		foreach (World game in OpenedWorlds)
-		{
-			if (game.WorldFilePath == null) { PT.PrintWarn("Skipping game instance, no linked world file path"); continue; }
-			string fpath = game.WorldFilePath;
-			string writeTo = snapshotFolder + "/" + fpath;
-			string baseDir = writeTo.GetBaseDir();
-
-			if (!Directory.Exists(baseDir))
-			{
-				Directory.CreateDirectory(baseDir);
-			}
-
-			PolyFormat.SaveWorldToFile(game, writeTo);
-		}
 		CreatorService.Interface.StatusBar?.SetStatus("World backed up!");
 	}
 

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -251,12 +251,12 @@ public sealed partial class PolytorianModel : CharacterModel
 		FaceImage = null;
 		_headMat.NextPass = _faceMat;
 
-		_shirtMats[0] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
-		_shirtMats[1] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
-		_shirtMats[2] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
+		_shirtMats[0] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
+		_shirtMats[1] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
+		_shirtMats[2] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
 
-		_pantsMats[0] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
-		_pantsMats[1] = new() { Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor, RenderPriority = 1 };
+		_pantsMats[0] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
+		_pantsMats[1] = new() { Transparency = BaseMaterial3D.TransparencyEnum.Alpha, RenderPriority = 1 };
 
 		_faceMat.Transparency = BaseMaterial3D.TransparencyEnum.Alpha;
 
@@ -454,7 +454,7 @@ public sealed partial class PolytorianModel : CharacterModel
 				StandardMaterial3D m = new()
 				{
 					AlbedoTexture = c.ClothTexture,
-					Transparency = BaseMaterial3D.TransparencyEnum.AlphaScissor,
+					Transparency = BaseMaterial3D.TransparencyEnum.Alpha,
 					RenderPriority = 1
 				};
 				if (head == null) { head = m; tail = m; }


### PR DESCRIPTION
## Summary

World backups no longer occur on the main thread, reducing (eliminating when possible) creator lag when backups are being saved.
Can also be expanded to manual saving too, but didn't include in this PR incase there is an issue with this change.

## Related issue or discussion

Fixes #446 
Related to #446 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

No visual changes.

## AI/LLM use

None