### PR TITLE
Add tool equip cooldown on drop

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -1038,6 +1038,7 @@ public partial class NPC : Physical
 		{
 			tool.Reparent(Root.Environment);
 			InternalDetachTool();
+			tool.InvokeDropped();
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -101,6 +101,7 @@ public sealed partial class Tool : RigidBody
 	private readonly HashSet<Instance> _registeredInstances = [];
 	private bool _hasDynChild = false;
 	private CollisionShape3D? _toolCollision;
+	private Timer _equipTimer = null!;
 
 	private void OnToolImageLoaded(Resource? resource)
 	{
@@ -110,19 +111,27 @@ public sealed partial class Tool : RigidBody
 
 	private void OnToolTouched(Physical physical)
 	{
-		if (physical is NPC npc)
+		if (physical is NPC npc && _holder == null && Parent is not (Inventory or Player) && _equipTimer.IsStopped())
 		{
-			if (_holder == null && Parent is not Inventory && Parent is not Player)
-			{
-				npc.EquipTool(this);
-			}
+			npc.EquipTool(this);
 		}
+	}
+
+	public override void InitGDNode()
+	{
+		GDNode.AddChild(_equipTimer = new()
+		{
+			OneShot = true,
+			// rough estimate from 1.0
+			WaitTime = 1.5f,
+		}, @internal: Node.InternalMode.Back);
+		base.InitGDNode();
 	}
 
 	public override void EnterTree()
 	{
 		base.EnterTree();
-		if (Parent is not Inventory && Parent is not NPC)
+		if (Parent is not (Inventory or NPC))
 		{
 			CanCollide = true;
 			Anchored = false;
@@ -132,6 +141,7 @@ public sealed partial class Tool : RigidBody
 			};
 			GDNode.AddChild(_toolCollision, @internal: Node.InternalMode.Back);
 			AddCollisionShape(_toolCollision);
+			_equipTimer.Start();
 		}
 		else
 		{

--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -21,6 +21,9 @@ public sealed partial class Tool : RigidBody
 	private ImageAsset? _iconImage;
 	private NPC? _holder = null;
 
+	private double _dropEquipCooldown;
+	private Timer _equipTimer = null!;
+
 	[Editable, ScriptProperty]
 	public bool Droppable
 	{
@@ -64,6 +67,17 @@ public sealed partial class Tool : RigidBody
 		}
 	}
 
+	[Editable, ScriptProperty, DefaultValue(1.5)]
+	public float DropEquipCooldown
+	{
+		get => (float)_dropEquipCooldown;
+		set
+		{
+			_equipTimer.WaitTime = _dropEquipCooldown = value;
+			OnPropertyChanged();
+		}
+	}
+
 	[SyncVar, ScriptProperty]
 	public NPC? Holder
 	{
@@ -101,7 +115,6 @@ public sealed partial class Tool : RigidBody
 	private readonly HashSet<Instance> _registeredInstances = [];
 	private bool _hasDynChild = false;
 	private CollisionShape3D? _toolCollision;
-	private Timer _equipTimer = null!;
 
 	private void OnToolImageLoaded(Resource? resource)
 	{
@@ -119,12 +132,7 @@ public sealed partial class Tool : RigidBody
 
 	public override void InitGDNode()
 	{
-		GDNode.AddChild(_equipTimer = new()
-		{
-			OneShot = true,
-			// rough estimate from 1.0
-			WaitTime = 1.5f,
-		}, @internal: Node.InternalMode.Back);
+		GDNode.AddChild(_equipTimer = new() { OneShot = true }, @internal: Node.InternalMode.Back);
 		base.InitGDNode();
 	}
 
@@ -348,6 +356,6 @@ public sealed partial class Tool : RigidBody
 
 	internal void InvokeDropped()
 	{
-		_equipTimer.Start();
+		if (_dropEquipCooldown > 0.05) _equipTimer.Start(_dropEquipCooldown);
 	}
 }

--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -141,7 +141,6 @@ public sealed partial class Tool : RigidBody
 			};
 			GDNode.AddChild(_toolCollision, @internal: Node.InternalMode.Back);
 			AddCollisionShape(_toolCollision);
-			_equipTimer.Start();
 		}
 		else
 		{
@@ -160,6 +159,7 @@ public sealed partial class Tool : RigidBody
 
 		if (HasAuthority)
 		{
+			_equipTimer.Start();
 			Touched.Connect(OnToolTouched);
 		}
 

--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -179,7 +179,7 @@ public sealed partial class Tool : RigidBody
 			_toolCollision = null;
 		}
 
-		if (Root.Network.IsServer)
+		if (HasAuthority)
 		{
 			Touched.Disconnect(OnToolTouched);
 		}

--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -159,7 +159,6 @@ public sealed partial class Tool : RigidBody
 
 		if (HasAuthority)
 		{
-			_equipTimer.Start();
 			Touched.Connect(OnToolTouched);
 		}
 
@@ -345,5 +344,10 @@ public sealed partial class Tool : RigidBody
 	{
 		Holder = null;
 		Unequipped?.Invoke();
+	}
+
+	internal void InvokeDropped()
+	{
+		_equipTimer.Start();
 	}
 }


### PR DESCRIPTION
## Summary

adds a tool equip cooldown that can be activated using `Tool.InvokeDropped()`. has the same ~1.5 second cooldown from 1.0. also touched up some other surrounding code

###### `Tool.InvokeDropped()` only starts the cooldown's timer. I would really like to see a `Dropped` event or something but that's probably out of scope for this PR

## Related issue or discussion

Fixes #437

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [X] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img src=https://github.com/user-attachments/assets/2fc79852-c0e2-4ba6-ac24-b3065cabb466>

## AI/LLM use

None