### PR TITLE
Play sounds on the server

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -403,7 +403,6 @@ public sealed partial class Sound : Dynamic
 			{
 				ServerIsPlaying = true;
 			}
-			// TODO: mute audio on server without breaking Playing
 			_audioPlayer?.Play();
 			_audioPlayer3D?.Play();
 		}
@@ -415,7 +414,7 @@ public sealed partial class Sound : Dynamic
 
 	private void InternalPlayOneShot(float volume)
 	{
-		// we can get away with this since Playing doesn't change here method
+		// can safely mute on the server since this method doesn't change any properties
 		if (Root.Network.IsServer) return;
 
 		if (_audioPlayer != null)

--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -403,8 +403,7 @@ public sealed partial class Sound : Dynamic
 			{
 				ServerIsPlaying = true;
 			}
-			// Mute audio on server
-			if (Root.Network.IsServer) return;
+			// TODO: mute audio on server without breaking Playing
 			_audioPlayer?.Play();
 			_audioPlayer3D?.Play();
 		}
@@ -416,6 +415,9 @@ public sealed partial class Sound : Dynamic
 
 	private void InternalPlayOneShot(float volume)
 	{
+		// we can get away with this since Playing doesn't change here method
+		if (Root.Network.IsServer) return;
+
 		if (_audioPlayer != null)
 		{
 			AudioStreamPlayer clone = (AudioStreamPlayer)_audioPlayer.Duplicate();


### PR DESCRIPTION
## Summary

removes the `Root.Network.IsServer` check from `Sound.InternalPlay`, which fixes `Sound.Playing` not changing on the server. also adds a `Root.Network.IsServer` check to `Sound.InternalPlayOneShot` since that doesn't need to play on the server (doesn't change any properties)

ideally, the server should probably be using a timer to track when the sound should end, but this is a good fix for now. this probably won't cause significant performance issues anyway since audio playback is already disabled on the server (the `--headless` flag sets the audio driver to `Dummy`)

## Related issue or discussion

Fixes #444

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [X] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None