### PR TITLE
Replace ShadowBlendMode with BlendMode

### DIFF
--- a/Polytoria/resources/materials/shadow_mul.tres
+++ b/Polytoria/resources/materials/shadow_mul.tres
@@ -1,0 +1,13 @@
+[gd_resource type="ShaderMaterial" format=3 uid="uid://bgdcio51v2olq"]
+
+[sub_resource type="Shader" id="Shader_elk26"]
+code = "shader_type canvas_item;
+render_mode blend_mul;
+
+void fragment() {
+	COLOR.rgb = mix(vec3(1.0), COLOR.rgb, COLOR.a);
+}
+"
+
+[resource]
+shader = SubResource("Shader_elk26")

--- a/Polytoria/scenes/creator/properties/ShadowLayerProperty.tscn
+++ b/Polytoria/scenes/creator/properties/ShadowLayerProperty.tscn
@@ -40,12 +40,13 @@ layout_mode = 2
 size_flags_horizontal = 3
 selected = 0
 item_count = 4
-popup/item_0/text = "Normal"
+popup/item_0/text = "Mix"
 popup/item_0/id = 0
 popup/item_1/text = "Add"
 popup/item_1/id = 1
 popup/item_2/text = "Subtract"
 popup/item_2/id = 2
+popup/item_3/text = "Multiply"
 popup/item_3/id = 3
 
 [node name="Row2" type="HBoxContainer" parent="VBox" unique_id=1234120449]

--- a/Polytoria/scripts/creator/properties/ShadowLayerProperty.cs
+++ b/Polytoria/scripts/creator/properties/ShadowLayerProperty.cs
@@ -4,6 +4,7 @@
 
 using Godot;
 using Polytoria.Datamodel.Data;
+using Polytoria.Enums;
 using System;
 using ColorPicker = Polytoria.Creator.UI.ColorPicker;
 
@@ -126,7 +127,7 @@ public sealed partial class ShadowLayerProperty : MarginContainer, IProperty<Sha
 
 		_blendMode.ItemSelected += idx =>
 		{
-			_value.BlendMode = (ShadowBlendMode)(int)idx;
+			_value.BlendMode = (BlendModeEnum)idx;
 			EmitChanged();
 		};
 	}

--- a/Polytoria/scripts/datamodel/UIShadow.cs
+++ b/Polytoria/scripts/datamodel/UIShadow.cs
@@ -5,6 +5,7 @@
 using Godot;
 using Polytoria.Attributes;
 using Polytoria.Datamodel.Data;
+using Polytoria.Enums;
 
 namespace Polytoria.Datamodel;
 
@@ -14,6 +15,8 @@ public partial class UIShadow : Instance
 	private ShadowLayer[] _layers = [new ShadowLayer()];
 	private ShadowPanel[] _panels = [];
 	private UIField? _parentView;
+
+	private static readonly ShaderMaterial _multiplyMaterial = GD.Load<ShaderMaterial>("res://resources/materials/shadow_mul.tres");
 
 	private sealed class ShadowPanel
 	{
@@ -115,17 +118,21 @@ public partial class UIShadow : Instance
 			StyleBoxFlat sb = new() { AntiAliasing = true, AntiAliasingSize = 2 };
 			panel.AddThemeStyleboxOverride("panel", sb);
 
-			if (_layers[i].BlendMode != ShadowBlendMode.Normal)
+			BlendModeEnum blendMode = _layers[i].BlendMode;
+			switch (blendMode)
 			{
-				panel.Material = new CanvasItemMaterial
-				{
-					BlendMode = _layers[i].BlendMode switch
+				case BlendModeEnum.Mix:
+					break;
+				case BlendModeEnum.Multiply:
+					// special case because Mul doesn't account for alpha
+					panel.Material = _multiplyMaterial;
+					break;
+				default:
+					panel.Material = new CanvasItemMaterial
 					{
-						ShadowBlendMode.Add => CanvasItemMaterial.BlendModeEnum.Add,
-						ShadowBlendMode.Subtract => CanvasItemMaterial.BlendModeEnum.Sub,
-						_ => CanvasItemMaterial.BlendModeEnum.Mix,
-					}
-				};
+						BlendMode = (CanvasItemMaterial.BlendModeEnum)blendMode
+					};
+					break;
 			}
 
 			_parentView.NodeControl.AddChild(panel);

--- a/Polytoria/scripts/datamodel/data/ShadowLayer.cs
+++ b/Polytoria/scripts/datamodel/data/ShadowLayer.cs
@@ -6,17 +6,10 @@ using Godot;
 using MemoryPack;
 using Polytoria.Attributes;
 using Polytoria.Datamodel.Interfaces;
+using Polytoria.Enums;
 using Polytoria.Scripting;
 
 namespace Polytoria.Datamodel.Data;
-
-[ScriptEnum]
-public enum ShadowBlendMode
-{
-	Normal,
-	Add,
-	Subtract,
-}
 
 [MemoryPackable]
 public partial struct ShadowLayer : IScriptObject, IData
@@ -48,7 +41,7 @@ public partial struct ShadowLayer : IScriptObject, IData
 	}
 
 	[ScriptProperty]
-	public ShadowBlendMode BlendMode { get; set; }
+	public BlendModeEnum BlendMode { get; set; }
 
 	public ShadowLayer()
 	{
@@ -56,7 +49,7 @@ public partial struct ShadowLayer : IScriptObject, IData
 		Offset = new Vector2(0, 4);
 		_radius = 8f;
 		Spread = 0f;
-		BlendMode = ShadowBlendMode.Normal;
+		BlendMode = BlendModeEnum.Mix;
 	}
 
 	object IData.Clone() => new ShadowLayer


### PR DESCRIPTION
## Summary

removes `ShadowBlendMode` entirely and replaces it with `BlendMode`. also adds a special material to make `BlendMode.Multiply` work properly with alpha (issue with Godot)

you can do this now which is Fun
<img width=383 height=236 src=https://github.com/user-attachments/assets/7896d8cd-be74-43bb-a9f8-2bc4d7a898e4>

## Related issue or discussion

Fixes #451

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None