### PR TITLE
Sound.Finished event

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -207,6 +207,7 @@ public sealed partial class Sound : Dynamic
 				: _audioPlayer3D != null ? (float)_audioPlayer3D.Stream.GetLength() : 0;
 
 	[ScriptProperty] public PTSignal Loaded { get; private set; } = new();
+	[ScriptProperty] public PTSignal Finished { get; private set; } = new();
 
 	[SyncVar]
 	public bool ServerIsPlaying
@@ -316,6 +317,7 @@ public sealed partial class Sound : Dynamic
 		{
 			ServerIsPlaying = false;
 		}
+		Finished.Invoke();
 	}
 
 	[ScriptMethod]


### PR DESCRIPTION
## Summary

adds an event to `Sound` that is invoked when the playback of the sound is finished (similar to roblox's `Sound.Ended` event)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

none!