### PR TITLE
Don't use AlphaScissor for Image3d

### DIFF
--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -230,7 +230,7 @@ public sealed partial class Image3D : Dynamic
 			_transparencyType = tex.GetImage().DetectAlpha() switch
 			{
 				Godot.Image.AlphaMode.Blend => BaseMaterial3D.TransparencyEnum.Alpha,
-				Godot.Image.AlphaMode.Bit => BaseMaterial3D.TransparencyEnum.AlphaScissor,
+				Godot.Image.AlphaMode.Bit => BaseMaterial3D.TransparencyEnum.Alpha,
 				_ => BaseMaterial3D.TransparencyEnum.Disabled,
 			};
 			UpdateMaterialTransparency();


### PR DESCRIPTION
## Summary

Fixes crashes and freezes in very odd cases that I dont even know fully, one of them being overlapping two checkerboard image3ds

Only relevant on some systems though. I don't know for sure but I suspect its just Intel iGPUs with that issue. The same issue was caused by clothing on my trash Intel iGPU laptop, which was fixed by the recent PR that changed the clothing to Alpha instead of AlphaScissor. Intel iGPUs might genuinely have some sort of problem with AlphaScissor.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)


## AI/LLM use

Help with debugging that stupid crash