### PR TITLE
Fix LookAt looking in the opposite direction

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -420,7 +420,7 @@ public partial class Dynamic : Instance
 		}
 
 		Vector3 lookTarget = pos;
-		
+
 		// Godot's LookAt points at -Z, Polytoria uses +Z as forward
 		if (this is not Camera)
 		{

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -419,7 +419,16 @@ public partial class Dynamic : Instance
 			throw new InvalidOperationException("LookAt Target is invalid");
 		}
 
-		GDNode3D.LookAt(pos, up);
+		Vector3 lookTarget = pos;
+		
+		// Godot's LookAt points at -Z, Polytoria uses +Z as forward
+		if (this is not Camera)
+		{
+			Vector3 origin = GDNode3D.GlobalPosition;
+			lookTarget = origin - (pos - origin);
+		}
+
+		GDNode3D.LookAt(lookTarget, up);
 
 		UpdateNetTransformReliable();
 	}


### PR DESCRIPTION
## Summary

With the Z axis flip, LookAt was looking in the wrong direction, this PR fixes that

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
Before:
<img width="553" height="511" alt="1" src="https://github.com/user-attachments/assets/d982b36a-b8cf-4272-b711-f2a17425f046" />

After:

https://github.com/user-attachments/assets/a9729dec-b995-4cd3-b026-b3ba2eec8d6a


## AI/LLM use

None