### PR TITLE
[Feature] Extend Conditional Visibility to Client Settings

### DIFF
--- a/Polytoria/scripts/client/ui/settings/SettingRow.cs
+++ b/Polytoria/scripts/client/ui/settings/SettingRow.cs
@@ -1,11 +1,13 @@
 using Godot;
 using Polytoria.Shared.Settings;
+using System.Linq;
 
 namespace Polytoria.Client.UI;
 
 public sealed partial class SettingRow : PanelContainer
 {
 	public SettingDef Definition = null!;
+	public ISettingsContext Context = null!;
 
 	public override void _Ready()
 	{
@@ -47,7 +49,16 @@ public sealed partial class SettingRow : PanelContainer
 		Control field = SettingFieldFactory.Create(Definition);
 		field.CustomMinimumSize = new Vector2(220, 0);
 		root.AddChild(field);
-
+		
+		if (Definition.Conditions != null)
+		{
+			Visible = Definition.Conditions.Any((cond) =>
+			{
+				object? value = Context.GetUntyped(cond.Target);
+				return cond.UntypedPredicate(value);
+			});
+		}
+		
 		base._Ready();
 	}
 }

--- a/Polytoria/scripts/client/ui/settings/SettingRow.cs
+++ b/Polytoria/scripts/client/ui/settings/SettingRow.cs
@@ -49,7 +49,7 @@ public sealed partial class SettingRow : PanelContainer
 		Control field = SettingFieldFactory.Create(Definition);
 		field.CustomMinimumSize = new Vector2(220, 0);
 		root.AddChild(field);
-		
+
 		if (Definition.Conditions != null)
 		{
 			Visible = Definition.Conditions.Any((cond) =>
@@ -58,7 +58,25 @@ public sealed partial class SettingRow : PanelContainer
 				return cond.UntypedPredicate(value);
 			});
 		}
-		
+
+		Context.Changed += OnExternalChanged;
+
 		base._Ready();
+	}
+
+	private void OnExternalChanged(SettingChangedEvent e)
+	{
+		if (Definition.Conditions != null)
+		{
+			var match = Definition.Conditions.Where(c => c.Target == e.Key);
+			if (match.Any())
+				Visible = match.Any(c => c.UntypedPredicate(e.NewValue));
+		}
+	}
+
+	public override void _ExitTree()
+	{
+		Context?.Changed -= OnExternalChanged;
+		base._ExitTree();
 	}
 }

--- a/Polytoria/scripts/client/ui/settings/SettingsSectionPage.cs
+++ b/Polytoria/scripts/client/ui/settings/SettingsSectionPage.cs
@@ -25,7 +25,8 @@ public sealed partial class SettingsSectionPage : VBoxContainer
 
 			SettingRow row = new()
 			{
-				Definition = def
+				Definition = def,
+				Context = ClientSettingsService.Instance
 			};
 
 			AddChild(row);


### PR DESCRIPTION
## Summary

This PR extends the logic of conditional visibility added by #289 to client settings.

## Related issue or discussion

Related to #465 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Testing with the fps cap from #316 

[polytoria_clientCondvis.mp4](https://github.com/user-attachments/assets/6c8306b6-4a7d-4e3f-a7aa-6a80569d62da)

## AI/LLM use

None.