### PR TITLE
Make the Bitmap32 property foldable

### DIFF
--- a/Polytoria/scenes/creator/properties/Bitmap32Property.tscn
+++ b/Polytoria/scenes/creator/properties/Bitmap32Property.tscn
@@ -1,209 +1,204 @@
-[gd_scene format=3 uid="uid://d0532b8keypg4"]
+[gd_scene format=3 uid="uid://djaplmcqf30hb"]
 
 [ext_resource type="Script" uid="uid://bap7hmix7py3v" path="res://scripts/creator/properties/Bitmap32Property.cs" id="1_tif4l"]
 
-[sub_resource type="Theme" id="Theme_o2x8x"]
-LineEdit/constants/minimum_character_width = 0
-SpinBox/constants/field_and_buttons_separation = 0
-
-[node name="Bitmap32" type="GridContainer" unique_id=1874667752]
-clip_contents = true
-custom_minimum_size = Vector2(0, 24)
-offset_right = 206.0
-offset_bottom = 892.0
-size_flags_horizontal = 3
-theme = SubResource("Theme_o2x8x")
-columns = 8
+[node name="Bitmap32Property" type="FoldableContainer" unique_id=469484354]
+title = "Bitmap32"
+title_text_overrun_behavior = 1
 script = ExtResource("1_tif4l")
 
-[node name="Button1" type="Button" parent="." unique_id=1104038676]
+[node name="Buttons" type="GridContainer" parent="." unique_id=1497079579]
+layout_mode = 2
+columns = 8
+
+[node name="Button1" type="Button" parent="Buttons" unique_id=2002383134]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "1"
 
-[node name="Button2" type="Button" parent="." unique_id=691590719]
+[node name="Button2" type="Button" parent="Buttons" unique_id=699232536]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "2"
 
-[node name="Button3" type="Button" parent="." unique_id=1686559890]
+[node name="Button3" type="Button" parent="Buttons" unique_id=591273501]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "3"
 
-[node name="Button4" type="Button" parent="." unique_id=287362496]
+[node name="Button4" type="Button" parent="Buttons" unique_id=2018420750]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "4"
 
-[node name="Button5" type="Button" parent="." unique_id=1543873362]
+[node name="Button5" type="Button" parent="Buttons" unique_id=1790731753]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "5"
 
-[node name="Button6" type="Button" parent="." unique_id=1626966035]
+[node name="Button6" type="Button" parent="Buttons" unique_id=1443463486]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "6"
 
-[node name="Button7" type="Button" parent="." unique_id=1480884533]
+[node name="Button7" type="Button" parent="Buttons" unique_id=1165447760]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "7"
 
-[node name="Button8" type="Button" parent="." unique_id=644930786]
+[node name="Button8" type="Button" parent="Buttons" unique_id=305514214]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "8"
 
-[node name="Button9" type="Button" parent="." unique_id=730730021]
+[node name="Button9" type="Button" parent="Buttons" unique_id=1522773217]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "9"
 
-[node name="Button10" type="Button" parent="." unique_id=1609046417]
+[node name="Button10" type="Button" parent="Buttons" unique_id=678225990]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "10"
 
-[node name="Button11" type="Button" parent="." unique_id=365017928]
+[node name="Button11" type="Button" parent="Buttons" unique_id=28642211]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "11"
 
-[node name="Button12" type="Button" parent="." unique_id=2116608094]
+[node name="Button12" type="Button" parent="Buttons" unique_id=811297273]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "12"
 
-[node name="Button13" type="Button" parent="." unique_id=460327753]
+[node name="Button13" type="Button" parent="Buttons" unique_id=1053231140]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "13"
 
-[node name="Button14" type="Button" parent="." unique_id=854297000]
+[node name="Button14" type="Button" parent="Buttons" unique_id=393518078]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "14"
 
-[node name="Button15" type="Button" parent="." unique_id=1232521664]
+[node name="Button15" type="Button" parent="Buttons" unique_id=1932339851]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "15"
 
-[node name="Button16" type="Button" parent="." unique_id=1153963228]
+[node name="Button16" type="Button" parent="Buttons" unique_id=1739197605]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "16"
 
-[node name="Button17" type="Button" parent="." unique_id=737011442]
+[node name="Button17" type="Button" parent="Buttons" unique_id=803759637]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "17
 "
 
-[node name="Button18" type="Button" parent="." unique_id=495044317]
+[node name="Button18" type="Button" parent="Buttons" unique_id=1608678534]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "18"
 
-[node name="Button19" type="Button" parent="." unique_id=1355814322]
+[node name="Button19" type="Button" parent="Buttons" unique_id=944655020]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "19"
 
-[node name="Button20" type="Button" parent="." unique_id=562483692]
+[node name="Button20" type="Button" parent="Buttons" unique_id=1522497286]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "20"
 
-[node name="Button21" type="Button" parent="." unique_id=2053882952]
+[node name="Button21" type="Button" parent="Buttons" unique_id=1765788096]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "21"
 
-[node name="Button22" type="Button" parent="." unique_id=486907771]
+[node name="Button22" type="Button" parent="Buttons" unique_id=353171517]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "22"
 
-[node name="Button23" type="Button" parent="." unique_id=432478840]
+[node name="Button23" type="Button" parent="Buttons" unique_id=1893144623]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "23"
 
-[node name="Button24" type="Button" parent="." unique_id=1047791652]
+[node name="Button24" type="Button" parent="Buttons" unique_id=806072536]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "24"
 
-[node name="Button25" type="Button" parent="." unique_id=1396547370]
+[node name="Button25" type="Button" parent="Buttons" unique_id=168437212]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "25"
 
-[node name="Button26" type="Button" parent="." unique_id=528106732]
+[node name="Button26" type="Button" parent="Buttons" unique_id=1935471718]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "26"
 
-[node name="Button27" type="Button" parent="." unique_id=679836793]
+[node name="Button27" type="Button" parent="Buttons" unique_id=368845146]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "27"
 
-[node name="Button28" type="Button" parent="." unique_id=1864662982]
+[node name="Button28" type="Button" parent="Buttons" unique_id=1937807555]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "28"
 
-[node name="Button29" type="Button" parent="." unique_id=853712189]
+[node name="Button29" type="Button" parent="Buttons" unique_id=1945992167]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "29"
 
-[node name="Button30" type="Button" parent="." unique_id=1064930090]
+[node name="Button30" type="Button" parent="Buttons" unique_id=1041816305]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "30"
 
-[node name="Button31" type="Button" parent="." unique_id=2021517066]
+[node name="Button31" type="Button" parent="Buttons" unique_id=2026773996]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12
 text = "31"
 
-[node name="Button32" type="Button" parent="." unique_id=658007399]
+[node name="Button32" type="Button" parent="Buttons" unique_id=538695506]
 custom_minimum_size = Vector2(22, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 12

--- a/Polytoria/scripts/creator/properties/Bitmap32Property.cs
+++ b/Polytoria/scripts/creator/properties/Bitmap32Property.cs
@@ -10,7 +10,7 @@ using System.Reflection.Metadata;
 
 namespace Polytoria.Creator.Properties;
 
-public sealed partial class Bitmap32Property : GridContainer, IProperty<uint>
+public sealed partial class Bitmap32Property : FoldableContainer, IProperty<uint>
 {
 	private readonly StyleBoxFlat _onStyle = new()
 	{
@@ -51,10 +51,12 @@ public sealed partial class Bitmap32Property : GridContainer, IProperty<uint>
 		Value = (uint)value;
 	}
 
+	private GridContainer _buttonGrid = null!;
+
 	public void Refresh()
 	{
 		int i = 1;
-		foreach (Node n in GetChildren())
+		foreach (Node n in _buttonGrid.GetChildren())
 		{
 			if (n is Button btn)
 			{
@@ -71,10 +73,12 @@ public sealed partial class Bitmap32Property : GridContainer, IProperty<uint>
 
 	public override void _Ready()
 	{
+		_buttonGrid = GetNode<GridContainer>("Buttons");
+		Folded = true;
 		Refresh();
 
 		int i = 1;
-		foreach (Node n in GetChildren())
+		foreach (Node n in _buttonGrid.GetChildren())
 		{
 			if (n is Button btn)
 			{


### PR DESCRIPTION
## Summary

Makes the Bitmap32 properties (CollisionLayers and CollisionMask) foldable

## Related issue or discussion

None

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="321" height="269" alt="grafik" src="https://github.com/user-attachments/assets/eb50aa08-1a21-4a83-bf51-9cc3c84558e8" />

## AI/LLM use

None