### PR TITLE
Move asset load settings to shared

### DIFF
--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -29,7 +29,7 @@ warnings/check_invalid_track_paths=false
 [application]
 
 config/name="Polytoria"
-config/version="2.0.8"
+config/version="2.0.9"
 run/main_scene="uid://c2tql65t73ak5"
 config/use_custom_user_dir=true
 config/custom_user_dir_name="PolytoriaClient"
@@ -387,6 +387,11 @@ textedit_replace={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":72,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+textedit_toggle_comment={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":47,"key_label":0,"unicode":47,"location":0,"echo":false,"script":null)
+]
+}
 ui_paste_into={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":86,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
@@ -410,11 +415,6 @@ zoom_out={
 open_console={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194339,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
-]
-}
-textedit_toggle_comment={
-"deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":47,"key_label":0,"unicode":47,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/Polytoria/scripts/client/ClientEntry.cs
+++ b/Polytoria/scripts/client/ClientEntry.cs
@@ -22,6 +22,7 @@ using Polytoria.Shared;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Polytoria.Shared.AssetLoaders;
 
 namespace Polytoria.Client;
 
@@ -198,6 +199,8 @@ public sealed partial class ClientEntry : Node3D
 
 		// Use init flow in case it can be stopped by Rendering device switcher
 		settings.Init();
+
+		AssetLoader.Singleton.MaxConcurrentRequests = ClientSettingsService.Instance.Get<int>(SharedSettingKeys.Advanced.AssetQueue);
 
 		settings.AddChild(new DisplaySettingsApplier { Name = "DisplaySettingsApplier" }, true, InternalMode.Front);
 		settings.AddChild(new AudioSettingsApplier { Name = "AudioSettingsApplier" }, true, InternalMode.Front);

--- a/Polytoria/scripts/client/settings/ClientSettingKeys.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingKeys.cs
@@ -34,6 +34,5 @@ public static class ClientSettingKeys
 	public static class Advanced
 	{
 		public const string ShowAdvancedSettings = "advanced.show_advanced_settings";
-		public const string AssetQueue = "advanced.asset_queue";
 	}
 }

--- a/Polytoria/scripts/client/settings/ClientSettingsRegistry.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingsRegistry.cs
@@ -185,26 +185,6 @@ public static class ClientSettingsRegistry
 				DefaultValue = true,
 			});
 
-		defs.Add(ClientSettingKeys.Advanced.AssetQueue,
-			new SettingDef<int>
-			{
-				Key = ClientSettingKeys.Advanced.AssetQueue,
-				SectionKey = "advanced",
-				Label = "Asset Queue",
-				Description = "Change how many assets can load at once. Higher = faster, with more potential lag.",
-				ValueKind = SettingValueKind.Int,
-				ControlKind = SettingControlKind.Dropdown,
-				RequiresRestart = true,
-				DefaultValue = 5,
-				Options =
-				[
-					new() { Value = 5, Label = "Default (5)" },
-					new() { Value = 15, Label = "Fast (15)" },
-					new() { Value = 30, Label = "Aggressive (30)" },
-					new() { Value = 60, Label = "SPEED (60)" },
-				]
-			});
-
 		SettingDef.ValidateAll(defs.Values);
 		return defs;
 	}

--- a/Polytoria/scripts/creator/CreatorEntry.cs
+++ b/Polytoria/scripts/creator/CreatorEntry.cs
@@ -9,8 +9,9 @@ using Polytoria.Creator.Settings;
 using Polytoria.Creator.Utils;
 using Polytoria.Datamodel.Creator;
 using Polytoria.Shared;
+using Polytoria.Shared.AssetLoaders;
+using Polytoria.Shared.Settings;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 namespace Polytoria.Creator;
@@ -33,6 +34,8 @@ public partial class CreatorEntry : Node
 		};
 		AddChild(creatorSettingsService, true, InternalMode.Front);
 		creatorSettingsService.Init();
+
+		AssetLoader.Singleton.MaxConcurrentRequests = creatorSettingsService.Get<int>(SharedSettingKeys.Advanced.AssetQueue);
 
 		creatorSettingsService.AddChild(new GraphicsSettingsApplier { Name = GraphicsSettingsApplier.NodeName, Settings = creatorSettingsService }, true, InternalMode.Front);
 

--- a/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
@@ -21,6 +21,7 @@ public static class CreatorSettingsRegistry
 		new() { Key = "backup", Label = "Backup", IconPath = DefaultSectionIcon, SortOrder = 5 },
 		new() { Key = "code_editor", Label = "Code Editor", IconPath = DefaultSectionIcon, SortOrder = 6 },
 		new() { Key = "popups", Label = "Popups", IconPath = DefaultSectionIcon, SortOrder = 7 },
+		new() { Key = "advanced", Label = "Advanced", IconPath = DefaultSectionIcon, SortOrder = 8 }
 	];
 
 	public static readonly IReadOnlyDictionary<string, SettingDef> Definitions = Build();

--- a/Polytoria/scripts/shared/asset_loaders/AssetLoader.cs
+++ b/Polytoria/scripts/shared/asset_loaders/AssetLoader.cs
@@ -4,7 +4,6 @@
 
 using Godot;
 using Polytoria.Providers.AssetLoaders;
-using Polytoria.Client.Settings;
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -16,6 +15,7 @@ public partial class AssetLoader : Node
 {
 
 	private readonly record struct AssetCacheKey(ResourceType Type, uint ID, Vector2I? Resize);
+	private const int DefaultMaxConcurrentRequests = 5;
 
 	public AssetLoader()
 	{
@@ -33,6 +33,8 @@ public partial class AssetLoader : Node
 
 	private readonly ConcurrentDictionary<AssetCacheKey, CacheItem> _cache = [];
 	private readonly ConcurrentDictionary<AssetCacheKey, Lazy<Task<CacheItem>>> _pendingRequests = [];
+	public int MaxConcurrentRequests { get; set; } = DefaultMaxConcurrentRequests;
+
 	private SemaphoreSlim _loadSlots = null!;
 
 	public IAssetProvider AssetProvider = null!;
@@ -69,7 +71,6 @@ public partial class AssetLoader : Node
 	{
 		if (_loadSlots == null)
 		{
-			int MaxConcurrentRequests = ClientSettingsService.Instance.Get<int>(ClientSettingKeys.Advanced.AssetQueue);
 			_loadSlots = new(MaxConcurrentRequests);
 		}
 

--- a/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
@@ -36,4 +36,9 @@ public static class SharedSettingKeys
 		public const string SsilRadius = "graphics.post_processing.ssil_radius";
 		public const string NormalMaps = "graphics.post_processing.normal_maps";
 	}
+
+	public static class Advanced
+	{
+		public const string AssetQueue = "advanced.asset_queue";
+	}
 }

--- a/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
@@ -292,6 +292,27 @@ public static class SharedSettingsRegistry
 					Step = 1f
 				}
 			},
+			{
+				SharedSettingKeys.Advanced.AssetQueue,
+				new SettingDef<int>
+				{
+					Key = SharedSettingKeys.Advanced.AssetQueue,
+					SectionKey = "advanced",
+					Label = "Asset Queue",
+					Description = "Change how many assets can load at once. Higher = faster, with more potential lag.",
+					ValueKind = SettingValueKind.Int,
+					ControlKind = SettingControlKind.Dropdown,
+					RequiresRestart = true,
+					DefaultValue = 5,
+					Options =
+					[
+						new() { Value = 5, Label = "Default (5)" },
+						new() { Value = 15, Label = "Fast (15)" },
+						new() { Value = 30, Label = "Aggressive (30)" },
+						new() { Value = 60, Label = "SPEED (60)" },
+					]
+				}
+			},
 		};
 
 		SettingDef.ValidateAll(defs.Values);


### PR DESCRIPTION
## Summary

Moves asset load settings to the shared registry instead of client. #364 adds asset loading settings, however they were added to client settings which causes asset loading to break in the creator. Also bumps version to 2.0.9

## Related issue or discussion

Fixes #473

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None