### PR TITLE
Adds a pre-`Init()` hook to preemptively catch memory leaks.

### DIFF
--- a/Polytoria/scripts/shared/Globals.cs
+++ b/Polytoria/scripts/shared/Globals.cs
@@ -217,14 +217,16 @@ public sealed partial class Globals : Node
 		base._Input(@event);
 	}
 
-	public static T LoadInstance<T>(World? root = null) where T : Instance
+	public static T LoadInstance<T>(World? root = null, Action<T>? preInit = null) where T : Instance
 	{
-		return (T)LoadNetworkedObject(typeof(T).Name, root)!;
+		Action<NetworkedObject>? wrapped = preInit == null ? null : netObj => preInit((T)netObj);
+		return (T)LoadNetworkedObject(typeof(T).Name, root, wrapped)!;
 	}
 
-	public static T? LoadInstance<T>(string className, World? root = null) where T : Instance
+	public static T? LoadInstance<T>(string className, World? root = null, Action<T>? preInit = null) where T : Instance
 	{
-		return (T?)LoadNetworkedObject(className, root);
+		Action<NetworkedObject>? wrapped = preInit == null ? null : netObj => preInit((T)netObj);
+		return (T?)LoadNetworkedObject(className, root, wrapped);
 	}
 
 	[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
@@ -253,7 +255,7 @@ public sealed partial class Globals : Node
 		return null;
 	}
 
-	public static NetworkedObject? LoadNetworkedObject(string className, World? root = null)
+	public static NetworkedObject? LoadNetworkedObject(string className, World? root = null, Action<NetworkedObject>? preInit = null)
 	{
 		Type? type = GetTypeByName(className);
 		if (type != null)
@@ -262,6 +264,7 @@ public sealed partial class Globals : Node
 			if (obj is NetworkedObject netObj)
 			{
 				netObj.NameOverride = className;
+				preInit?.Invoke(netObj);
 				netObj.Root = root!;
 				return netObj;
 			}


### PR DESCRIPTION
## Summary

This PR adds a hook to `Polytoria.Shared.Globals.LoadInstance` that can be used to perform actions before an `Instance` runs `Init()`. This is helpful for detecting and preventing memory leaks, especially when there's a discrepancy between Godot and Polytoria. It can be used for any case that requires additional instantiation logic before the default `Init()`.

The following example implements `FromGDObject()` to pre-assign a default value that's created on `Init()`, where `FromGDObject()` is implicitly called when Godot provides an object that Polytoria hasn't replicated: https://github.com/Psykatte/polytoria-game/commit/4ccf5cc9c714ba32055b58a58ccb4976ecbeeebf

The branch has been tested by hooking `Console.WriteLine("Hello World!")` to `Polytoria.Client.ClientEntry.ClientEntry()`.

## Related issue or discussion

[Discord discussion](https://discord.com/channels/1464218939679703135/1464218940749119543/1508422882529906699), it will help contributors.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [x] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A.

## AI/LLM use

None.