### PR TITLE
Fix collision layer bugs

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -510,7 +510,7 @@ public sealed partial class Camera : Dynamic
 				query.HitFromInside = false;
 
 				// Fliter only clipping layers
-				query.CollisionMask = 1 << 5;
+				query.CollisionMask = Entity.CameraClipCollisionLayerMask;
 
 				Dictionary? result = spaceState.IntersectRay(query);
 

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -706,10 +706,12 @@ public partial class Dynamic : Instance
 		}
 		else
 		{
-			if(this is Physical p)
+			if (this is Physical p)
 			{
 				p.SetCollisionLayer(3, false);
-			} else {
+			}
+			else
+			{
 				_boundArea3D.CollisionLayer = 0;
 			}
 		}

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -697,17 +697,21 @@ public partial class Dynamic : Instance
 		{
 			if (this is Physical p && p.CanCollide)
 			{
-				_boundArea3D.CollisionLayer = (1 << 3);
+				p.SetCollisionLayer(3, true);
 			}
 			else
 			{
 				_boundArea3D.CollisionLayer = (1 << 2);
 			}
-			_boundArea3D.CollisionLayer = (1 << 2);
 		}
 		else
 		{
-			_boundArea3D.CollisionLayer = 0;
+			if(this is Physical p)
+			{
+				p.SetCollisionLayer(3, false);
+			} else {
+				_boundArea3D.CollisionLayer = 0;
+			}
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Entity.cs
+++ b/Polytoria/scripts/datamodel/Entity.cs
@@ -10,8 +10,9 @@ namespace Polytoria.Datamodel;
 [Abstract]
 public abstract partial class Entity : RigidBody
 {
+	internal const uint CameraClipCollisionLayerMask = 1u << 5;
+
 	private bool _isSpawn = false;
-	private uint _camCollisionLayer = uint.MaxValue;
 
 	private Color _color = new(1, 1, 1);
 	private bool _castShadows = true;
@@ -74,8 +75,8 @@ public abstract partial class Entity : RigidBody
 
 	public override void Init()
 	{
-		UpdateCamLayer();
 		base.Init();
+		UpdateCamLayer();
 	}
 
 	public override void PreDelete()
@@ -87,24 +88,15 @@ public abstract partial class Entity : RigidBody
 
 	internal void UpdateCamLayer()
 	{
-		uint targetLayer;
-		if (Color.A > 0.5)
-		{
-			// Set layer for solid
-			targetLayer = 1u << 0 | 1u << 5;
-		}
-		else
-		{
-			// Set layer for transparent
-			targetLayer = 1u;
-		}
+		ApplyCollisionObjectLayers();
+	}
 
-		if (_camCollisionLayer == targetLayer)
-		{
-			return;
-		}
+	protected override uint GetAppliedCollisionLayers()
+	{
+		uint layers = base.GetAppliedCollisionLayers();
 
-		_camCollisionLayer = targetLayer;
-		GDRigidBody.CollisionLayer = targetLayer;
+		return Color.A > 0.5f
+			? layers | CameraClipCollisionLayerMask
+			: layers & ~CameraClipCollisionLayerMask;
 	}
 }

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -166,6 +166,23 @@ public partial class Physical : Dynamic
 		}
 	}
 
+	protected virtual uint GetAppliedCollisionLayers()
+	{
+		return _collisionLayers;
+	}
+
+	protected void ApplyCollisionObjectLayers()
+	{
+		CollisionObject3D? collisionObject3D = GetCollisionObject();
+		if (collisionObject3D == null)
+		{
+			return;
+		}
+
+		collisionObject3D.CollisionLayer = GetAppliedCollisionLayers();
+		collisionObject3D.CollisionMask = _collisionMask;
+	}
+
 	internal void UpdateFreeze()
 	{
 		bool finalVal = _anchored;
@@ -211,18 +228,13 @@ public partial class Physical : Dynamic
 	internal void UpdateCollision()
 	{
 		if (IsDeleted) return;
+
+		ApplyCollisionObjectLayers();
+
 		if (OverrideCanCollide)
 		{
 			SetCollisionDisabled(!OverrideCanCollideTo);
 			return;
-		}
-
-		CollisionObject3D? collisionObject3D = GetCollisionObject();
-
-		if (collisionObject3D != null)
-		{
-			collisionObject3D.CollisionLayer = _collisionLayers;
-			collisionObject3D.CollisionMask = _collisionMask;
 		}
 
 		// Set each collision
@@ -1136,7 +1148,7 @@ public partial class Physical : Dynamic
 			Scale = new(1.01f, 1.01f, 1.01f)
 		};
 
-		PhysicalArea.SetCollisionMaskValue(2, true);
+		SetCollisionMask(2, true);
 
 		PhysicalArea.AreaEntered += AreaEntered;
 		PhysicalArea.AreaExited += AreaExited;

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -435,8 +435,8 @@ public sealed partial class Player : NPC
 	public override void InitGDNode()
 	{
 		base.InitGDNode();
-		CharBody3D.CollisionLayer = 2;
-		CharBody3D.CollisionMask = 3;
+		CollisionLayers = 2;
+		CollisionMask = 3;
 	}
 
 	public override void Init()
@@ -523,11 +523,11 @@ public sealed partial class Player : NPC
 	{
 		if (Root.Players.PlayerCollisionEnabled)
 		{
-			CharBody3D.SetCollisionMaskValue(2, true);
+			SetCollisionMask(2, true);
 		}
 		else
 		{
-			CharBody3D.SetCollisionMaskValue(2, false);
+			SetCollisionMask(2, false);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Replaces all relevant places where CollisionLayer/CollisionMask gets assigned/changed to work correctly.

Specifically, this fixes turning off player collisions and the camera clipping.

## Related issue or discussion

Fixes #474

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)


## AI/LLM use

debugging why tf the camera clip layer wasnt getting applied (where it recommended adding a overridable GetAppliedCollisionLayers, which I did add)