### PR TITLE
[Bug Fix] Improve UILabel AutoSize for longer texts.

### DIFF
--- a/Polytoria/scripts/datamodel/UILabel.cs
+++ b/Polytoria/scripts/datamodel/UILabel.cs
@@ -257,6 +257,7 @@ public partial class UILabel : UIView
 
 			_label.AutowrapMode = _richLabel.AutowrapMode = _textWrapped ? TextServer.AutowrapMode.WordSmart : TextServer.AutowrapMode.Off;
 
+			if (_autoSize) UpdateAutosize();
 			OnPropertyChanged();
 		}
 	}
@@ -271,7 +272,18 @@ public partial class UILabel : UIView
 		{
 			int mid = (lo + hi) / 2;
 			int scaled = (int)(mid * FontScaleConversion);
-			Vector2 textBounds = font.GetStringSize(_text, _label.HorizontalAlignment, -1, scaled);
+			Vector2 textBounds;
+			if (_textWrapped) 
+			{
+				textBounds = font.GetMultilineStringSize(
+					text: _text,
+					alignment: _label.HorizontalAlignment,
+					width: bounds.X,
+					fontSize: scaled
+				);
+			}
+			else textBounds = font.GetStringSize(_text, _label.HorizontalAlignment, -1, scaled);
+
 			if (textBounds.X <= bounds.X && textBounds.Y <= bounds.Y)
 			{
 				result = mid;
@@ -319,6 +331,7 @@ public partial class UILabel : UIView
 		_label.SetAnchorsAndOffsetsPreset(Control.LayoutPreset.FullRect);
 
 		_label.ClipContents = false;
+		_label.AddThemeConstantOverride("line_spacing", 0);
 
 		Text = "Text";
 		TextColor = new(0, 0, 0);

--- a/Polytoria/scripts/datamodel/UILabel.cs
+++ b/Polytoria/scripts/datamodel/UILabel.cs
@@ -273,7 +273,7 @@ public partial class UILabel : UIView
 			int mid = (lo + hi) / 2;
 			int scaled = (int)(mid * FontScaleConversion);
 			Vector2 textBounds;
-			if (_textWrapped) 
+			if (_textWrapped)
 			{
 				textBounds = font.GetMultilineStringSize(
 					text: _text,


### PR DESCRIPTION
## Summary

Modifies the `AutoSize` code that determines an optimal font size to account for cases where `TextWrapped` is enabled, which is commonly used for fitting multi-line texts within the `UILabel` bounds. This should pretty much fix all problems where lengthy texts are turned into one long, unreadable line.

## Related issue or discussion

Fixes #489

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Sample text before and after (wrapping enabled in both cases):

<img width="568" height="354" alt="image" src="https://github.com/user-attachments/assets/8c4147d4-b8c7-4f4d-9c93-fa753f850fda" />
<img width="568" height="354" alt="image" src="https://github.com/user-attachments/assets/d428ae78-f776-4b2a-9d04-9787340b2299" />


Example of a multi-line (`\n`) text using `AutoSize` at different window sizes (fullscreen, small, wide, tall):

<img width="1464" height="793" alt="image" src="https://github.com/user-attachments/assets/c7cf3d16-6080-4348-842e-5a976ee5916f" />
<img width="892" height="505" alt="image" src="https://github.com/user-attachments/assets/da5c4161-2d2e-4bf8-be11-200557866a3c" />
<img width="1340" height="452" alt="image" src="https://github.com/user-attachments/assets/bcc80cad-ea29-4f31-a933-ca619260320f" />
<img width="845" height="718" alt="image" src="https://github.com/user-attachments/assets/80f9cc83-ad67-4cb3-94e7-a1232099d940" />


## AI/LLM use

None.