### PR TITLE
improve world saving performance

### DIFF
--- a/Polytoria/scripts/datamodel/creator/CreatorService.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorService.cs
@@ -230,11 +230,14 @@ public sealed partial class CreatorService : Node, IScriptObject
 		Interface.StatusBar?.SetEmpty();
 	}
 
-	public static void SaveCurrentFile()
+	public static void SaveCurrentFile(out float savingTime)
 	{
+		savingTime = 0f;
+
 		if (World.Current == null) { CreatorService.Interface.StatusBar?.SetStatus("No current game opened, did not save"); return; }
 		if (CurrentSession == null) { CreatorService.Interface.StatusBar?.SetStatus("No session, did not save"); return; }
 		string placePath = CurrentSession.GlobalizePath(World.Current.WorldFilePath!);
+		var start = Time.GetTicksUsec();
 
 		Interface.LoadOverlay?.SetTitle("Saving world");
 		Interface.LoadOverlay?.SetStatus("Saving world");
@@ -254,9 +257,15 @@ public sealed partial class CreatorService : Node, IScriptObject
 		Interface.LoadOverlay?.SetStatus("Saving index...");
 		Interface.LoadOverlay?.SetProgress(1);
 
+		savingTime = (Time.GetTicksUsec() - start) / 1000f;
 		CurrentSession.Save();
-		Interface.StatusBar?.SetStatus("Saved to " + placePath + " at " + DateTime.Now.ToString("HH:mm:ss"));
+		Interface.StatusBar?.SetStatus("Saved to " + placePath + " at " + DateTime.Now.ToString("HH:mm:ss") + " in " + savingTime.ToString("0.00") + " milliseconds");
 		Interface.LoadOverlay?.Hide();
+	}
+
+	public static void SaveCurrentFile()
+	{
+		SaveCurrentFile(out _);
 	}
 
 	public static void SaveCurrentFileAs()

--- a/Polytoria/scripts/formats/PolyFormat.cs
+++ b/Polytoria/scripts/formats/PolyFormat.cs
@@ -619,7 +619,7 @@ public static partial class PolyFormat
 		IEnumerable<PropertyInfo> creatorProperties = obj.GetEditableProperties();
 
 		IEnumerable<PropertyInfo> saveIncludes = objType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy)
-			.Where(p => p.GetCustomAttribute<SaveIncludeAttribute>() != null);
+			.Where(p => p.GetCustomAttributeCached<SaveIncludeAttribute>() != null);
 
 		HashSet<string> existingNames = [.. creatorProperties.Select(p => p.Name)];
 		creatorProperties = creatorProperties.Concat(
@@ -628,14 +628,14 @@ public static partial class PolyFormat
 
 		foreach (PropertyInfo prop in creatorProperties)
 		{
-			if (prop.IsDefined(typeof(Attributes.ObsoleteAttribute))) continue;
-			if (prop.IsDefined(typeof(SaveIgnoreAttribute))) continue;
+			if (prop.IsDefinedCached(typeof(Attributes.ObsoleteAttribute))) continue;
+			if (prop.IsDefinedCached(typeof(SaveIgnoreAttribute))) continue;
 			if (prop.CanRead)
 			{
 				object? val = prop.GetValue(obj);
 				if (val == null) continue;
 
-				DefaultValueAttribute? df = prop.GetCustomAttribute<DefaultValueAttribute>();
+				DefaultValueAttribute? df = prop.GetCustomAttributeCached<DefaultValueAttribute>();
 				if (df != null)
 				{
 					try
@@ -718,7 +718,7 @@ public static partial class PolyFormat
 				foreach (Instance child in instance.GetChildren())
 				{
 					Type ct = child.GetType();
-					if (ct.GetCustomAttribute<SaveIgnoreAttribute>() != null) continue;
+					if (ct.GetCustomAttributeCached<SaveIgnoreAttribute>() != null) continue;
 					if (child.ModelRoot != null && instance.EditableChildren)
 					{
 						// Save editable children

--- a/Polytoria/scripts/utils/ReflectionCache.cs
+++ b/Polytoria/scripts/utils/ReflectionCache.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Polytoria.Utils;
+
+public static class ReflectionCache
+{
+	private static readonly Dictionary<MemberInfo, Dictionary<Type, bool>> _isDefinedCache = new();
+	private static readonly Dictionary<MemberInfo, Dictionary<Type, Attribute?>> _customAttributeCache = new();
+
+	public static bool IsDefinedCached(this MemberInfo mi, Type attributeType)
+	{
+		if (!_isDefinedCache.TryGetValue(mi, out var inner))
+		{
+			inner = [];
+			_isDefinedCache[mi] = inner;
+		}
+
+		if (inner.TryGetValue(attributeType, out var cachedResult))
+			return cachedResult;
+
+		var result = mi.IsDefined(attributeType);
+		inner[attributeType] = result;
+
+		return result;
+	}
+
+	public static T? GetCustomAttributeCached<T>(this MemberInfo mi) where T : Attribute
+	{
+		var attributeType = typeof(T);
+
+		if (!_customAttributeCache.TryGetValue(mi, out var inner))
+		{
+			inner = [];
+			_customAttributeCache[mi] = inner;
+		}
+
+		if (inner.TryGetValue(attributeType, out var cachedAttr))
+			return (T?)cachedAttr;
+
+		var attr = mi.GetCustomAttribute<T>();
+		inner[attributeType] = attr;
+
+		return attr;
+	}
+}

--- a/Polytoria/scripts/utils/ReflectionCache.cs.uid
+++ b/Polytoria/scripts/utils/ReflectionCache.cs.uid
@@ -1,0 +1,1 @@
+uid://jaceoqt03jsu


### PR DESCRIPTION
## Summary

Optimizes world saving by caching MemberInfo.GetCustomAttribute and MemberInfo.IsDefined.

In my testing with the Egg Hunt 2024 map and always 30 save runs, the average save time went from 1006ms to 208ms. I couldn't determine any further paths worth optimizing with dotTrace.

## Related issue or discussion

Related to #446 (should improve the situation, but obviously wont totally get rid of the short lag)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

Optimizing cache key generation (which unironically helped cause it costed like 70ms on avg per save run when I did it by concatenating the hashcodes lmfao)