### PR TITLE
Add trackpad pinch zoom support

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -20,6 +20,7 @@ public sealed partial class Camera : Dynamic
 	public const float ClipSafeMargin = 2.0f;
 	public const float DefaultZoomDistance = 10.0f;
 	public const float DefaultScrollSensitivity = 15.0f;
+	private const float TrackpadPinchZoomSensitivity = 0.75f;
 
 	// override default +Z forward orientation as that would be incorrect for the camera
 	[ScriptProperty] new public Vector3 Forward => -GetGlobalTransform().Basis.Z.Normalized();
@@ -713,6 +714,10 @@ public sealed partial class Camera : Dynamic
 				}
 			}
 		}
+		else if (@event is InputEventMagnifyGesture magnifyGesture)
+		{
+			ZoomByMagnifyGesture(magnifyGesture);
+		}
 
 		if (Mode == CameraModeEnum.Scripted) return;
 
@@ -849,6 +854,19 @@ public sealed partial class Camera : Dynamic
 	private void SnapBackward()
 	{
 		Position += Forward * -_moveSpeed / 10;
+	}
+
+	private void ZoomByMagnifyGesture(InputEventMagnifyGesture magnifyGesture)
+	{
+		float zoomDelta = Mathf.Clamp(magnifyGesture.Factor - 1f, -1f, 1f);
+
+		if (Mathf.IsZeroApprox(zoomDelta))
+		{
+			return;
+		}
+
+		_targetZoom -= ScrollSensitivity * TrackpadPinchZoomSensitivity * zoomDelta;
+		LimitZoomDistance();
 	}
 
 	public void ReceiveDragTouchInput(InputEventScreenDrag dragEvent)


### PR DESCRIPTION
## Summary

Previously, the only way to zoom in/out on MacBook was through the I and O keys kindly added in release 2.0.4. Of course, it's more intuitive on multitouch trackpads to use the pinch gesture. This PR adds support for general trackpad pinch to zoom by handling magnify gesture input in `Camera.cs`.

The gesture updates the existing `_targetZoom` camera zoom flow to ensure it's consistent with the existing scroll wheel zoom behavior.

## Related issue or discussion
N/A

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

I don't think a video is needed because this is an input handling change, using the same behavior as the existing scroll wheel zoom.

## AI/LLM use

I asked AI to help me understand the Git workflow and commands, since this is only my second commit on GitHub and I'm new to contributing on GitHub pull requests. That said, I read the contributor guidelines and made sure to follow the required steps, including signing off the commit and running the required dotnet commands on the local project.