### PR TITLE
Add trust capabilities to HttpService for increased ratelimits

### DIFF
--- a/Polytoria/scripts/datamodel/data/HttpResponseData.cs
+++ b/Polytoria/scripts/datamodel/data/HttpResponseData.cs
@@ -16,6 +16,8 @@ public partial class HttpResponseData : IScriptObject
 	[ScriptProperty] public Dictionary<string, string>? Headers { get; internal set; }
 	[ScriptProperty] public string Body { get; internal set; } = "";
 	[ScriptProperty] public byte[] Buffer { get; internal set; } = [];
+	[ScriptProperty] public bool Trusted { get; internal set; } = false;
+	
 
 	internal HttpResponseMessage responseMsg = null!;
 }

--- a/Polytoria/scripts/datamodel/data/HttpResponseData.cs
+++ b/Polytoria/scripts/datamodel/data/HttpResponseData.cs
@@ -17,7 +17,7 @@ public partial class HttpResponseData : IScriptObject
 	[ScriptProperty] public string Body { get; internal set; } = "";
 	[ScriptProperty] public byte[] Buffer { get; internal set; } = [];
 	[ScriptProperty] public bool Trusted { get; internal set; } = false;
-	
+
 
 	internal HttpResponseMessage responseMsg = null!;
 }

--- a/Polytoria/scripts/datamodel/services/HttpService.cs
+++ b/Polytoria/scripts/datamodel/services/HttpService.cs
@@ -116,7 +116,7 @@ public sealed partial class HttpService : Instance
 	{
 		addedTarget = null;
 
-		if(resHeaders.TryGetValues("X-PT-Trusted-World-Id", out IEnumerable<string>? worldIds))
+		if (resHeaders.TryGetValues("X-PT-Trusted-World-Id", out IEnumerable<string>? worldIds))
 		{
 			worldIds = worldIds.Where(id => int.TryParse(id, out int parsedId) && parsedId == Root.WorldID);
 
@@ -142,7 +142,8 @@ public sealed partial class HttpService : Instance
 				{
 					_trustedTargets.Add((TrustedTarget)addedTarget);
 					return true;
-				} else
+				}
+				else
 				{
 					return false;
 				}
@@ -235,9 +236,9 @@ public sealed partial class HttpService : Instance
 			headers[key] = string.Join(",", val);
 		}
 
-		if(TryAddTrustedTarget(data, res.Headers, out TrustedTarget? addedTarget) && addedTarget != null)
+		if (TryAddTrustedTarget(data, res.Headers, out TrustedTarget? addedTarget) && addedTarget != null)
 		{
-			if(IsTrusted(data))
+			if (IsTrusted(data))
 			{
 				// readjust ratelimits afterwards
 				_requestsThisMinute--;
@@ -255,7 +256,7 @@ public sealed partial class HttpService : Instance
 			Headers = headers,
 			responseMsg = res,
 			// check again whether trusted even when a TrustedTarget was added, because the addedTargets scope might not include the request URL
-			Trusted = trusted || (addedTarget != null && IsTrusted(data)) 
+			Trusted = trusted || (addedTarget != null && IsTrusted(data))
 		};
 
 		return resData;

--- a/Polytoria/scripts/datamodel/services/HttpService.cs
+++ b/Polytoria/scripts/datamodel/services/HttpService.cs
@@ -2,12 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using Godot;
 using Polytoria.Attributes;
 using Polytoria.Datamodel.Data;
 using Polytoria.Scripting;
 using Polytoria.Shared;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -19,9 +21,23 @@ namespace Polytoria.Datamodel.Services;
 [SaveIgnore]
 public sealed partial class HttpService : Instance
 {
+	public record struct HttpServiceLimits(int standard, int trusted) : IScriptObject
+	{
+		[ScriptMetamethod(ScriptObjectMetamethod.ToString)]
+		public static string ToString(HttpServiceLimits? obj)
+		{
+			if (obj == null || !obj.HasValue) return "<HttpServiceLimits>";
+			return $"<HttpServiceLimits: standard={obj.Value.standard}, trusted={obj.Value.trusted}>";
+		}
+	}
+	private record struct TrustedTarget(string origin, string? scopeLimit);
+
 	private const int MaxRequestsPerMinute = 90;
 	private int _requestsThisMinute = 0;
+	private int _trustedRequestsThisMinute = 0;
 	private int _currentMinute;
+
+	private List<TrustedTarget> _trustedTargets = [];
 	private PTHttpClient _client = new();
 
 	public override void Init()
@@ -30,7 +46,12 @@ public sealed partial class HttpService : Instance
 		base.Init();
 	}
 
-	private bool RateLimit()
+	private int GetTrustedRequestAllowance()
+	{
+		return 300 + (Root.Players.PlayersCount * 150);
+	}
+
+	private void CheckRateLimits()
 	{
 		int minute = (int)DateTimeOffset.Now.ToUnixTimeSeconds() / 60;
 
@@ -38,6 +59,23 @@ public sealed partial class HttpService : Instance
 		{
 			_currentMinute = minute;
 			_requestsThisMinute = 0;
+			_trustedRequestsThisMinute = 0;
+		}
+	}
+
+	private bool RateLimit(bool isTrusted = false)
+	{
+		CheckRateLimits();
+
+		if (isTrusted)
+		{
+			if (_trustedRequestsThisMinute >= GetTrustedRequestAllowance())
+			{
+				return false;
+			}
+
+			_trustedRequestsThisMinute++;
+			return true;
 		}
 
 		if (_requestsThisMinute >= MaxRequestsPerMinute)
@@ -47,6 +85,71 @@ public sealed partial class HttpService : Instance
 
 		_requestsThisMinute++;
 		return true;
+	}
+
+	private bool IsTrusted(HttpRequestData data)
+	{
+		if (data.URL == null) return false;
+
+		if (!Uri.TryCreate(data.URL, UriKind.Absolute, out Uri? parsedUri))
+		{
+			return false;
+		}
+
+		string origin = $"{parsedUri.Scheme}://{parsedUri.Host}:{parsedUri.Port}";
+
+		foreach (TrustedTarget target in _trustedTargets)
+		{
+			if (string.Equals(target.origin, origin, StringComparison.OrdinalIgnoreCase))
+			{
+				if (target.scopeLimit == null || parsedUri.AbsolutePath.StartsWith(target.scopeLimit, StringComparison.OrdinalIgnoreCase))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private bool TryAddTrustedTarget(HttpRequestData req, HttpResponseHeaders resHeaders, out TrustedTarget? addedTarget)
+	{
+		addedTarget = null;
+
+		if(resHeaders.TryGetValues("X-PT-Trusted-World-Id", out IEnumerable<string>? worldIds))
+		{
+			worldIds = worldIds.Where(id => int.TryParse(id, out int parsedId) && parsedId == Root.WorldID);
+
+			if (worldIds.Any())
+			{
+				if (req.URL == null) return false;
+
+				if (!Uri.TryCreate(req.URL, UriKind.Absolute, out Uri? parsedUri))
+				{
+					return false;
+				}
+
+				string origin = $"{parsedUri.Scheme}://{parsedUri.Host}:{parsedUri.Port}";
+
+				string? scopeLimit = null;
+				if (resHeaders.TryGetValues("X-PT-Limit-Scope", out IEnumerable<string>? scopeLimits))
+				{
+					scopeLimit = scopeLimits.FirstOrDefault();
+				}
+
+				addedTarget = new TrustedTarget(origin, scopeLimit);
+				if (!_trustedTargets.Contains((TrustedTarget)addedTarget))
+				{
+					_trustedTargets.Add((TrustedTarget)addedTarget);
+					return true;
+				} else
+				{
+					return false;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	private bool LegacyRateLimit(PTCallback? callback = null)
@@ -76,12 +179,14 @@ public sealed partial class HttpService : Instance
 			throw new InvalidOperationException("URL is required");
 		}
 
-		if (!RateLimit())
+		CheckURLPass(data.URL, Root.IsLocalTest);
+
+		var trusted = IsTrusted(data);
+		if (!RateLimit(trusted))
 		{
 			throw new Exception("Http limit exceeded");
 		}
 
-		CheckURLPass(data.URL, Root.IsLocalTest);
 
 		HttpContent? content = null;
 		if (data.Body != null)
@@ -130,6 +235,17 @@ public sealed partial class HttpService : Instance
 			headers[key] = string.Join(",", val);
 		}
 
+		if(TryAddTrustedTarget(data, res.Headers, out TrustedTarget? addedTarget) && addedTarget != null)
+		{
+			if(IsTrusted(data))
+			{
+				// readjust ratelimits afterwards
+				_requestsThisMinute--;
+				_trustedRequestsThisMinute++;
+			}
+			PT.Print($"Added trusted target for {addedTarget.Value.origin}" + (addedTarget.Value.scopeLimit != null ? $" with scope {addedTarget.Value.scopeLimit}" : " with no scope limit"));
+		}
+
 		HttpResponseData resData = new()
 		{
 			Success = res.IsSuccessStatusCode,
@@ -137,7 +253,9 @@ public sealed partial class HttpService : Instance
 			Body = await res.Content.ReadAsStringAsync(),
 			Buffer = await res.Content.ReadAsByteArrayAsync(),
 			Headers = headers,
-			responseMsg = res
+			responseMsg = res,
+			// check again whether trusted even when a TrustedTarget was added, because the addedTargets scope might not include the request URL
+			Trusted = trusted || (addedTarget != null && IsTrusted(data)) 
 		};
 
 		return resData;
@@ -250,6 +368,16 @@ public sealed partial class HttpService : Instance
 		return response.Buffer;
 	}
 
+	[ScriptMethod]
+	public HttpServiceLimits GetLimits()
+	{
+		CheckRateLimits();
+
+		return new HttpServiceLimits(
+			standard: MaxRequestsPerMinute - _requestsThisMinute,
+			trusted: GetTrustedRequestAllowance() - _trustedRequestsThisMinute
+		);
+	}
 
 	[ScriptMethod, Attributes.Obsolete("Use GetAsync instead")]
 	public void Get(string url, PTCallback? callback = null, Dictionary<string, string>? headers = null)


### PR DESCRIPTION
## Summary

Adds the ability for remote servers to include a X-PT-Trusted-World-Id header, which then marks that origin (and the optionally provided scope) as trusted, letting the game server send with an increase ratelimit.

The new ratelimit for trusted targets is (300 + plrCount * 150), so 450 at 1 player, 1500 at 8 players. Question: Should we decrease the player count factor?

Example script (PolyTrack is setup for this rn):
```lua
print(world.WorldID)
local nonTrustedBase = "https://api.polytoria.com/v1/users/1" -- This shouldnt be trusted
local createsTrustButNotTrusted = "https://polytrack.top/" -- Scope limited to /api/ so it wont be trusted, but it creates a trust relationship
local trustedBase = "https://polytrack.top/api/charts/user/2/day?date=2026-05-07T22:48:19.831Z" -- This should be trusted

local function makeRequest(url)
    local reqData = HttpRequestData.New()
    reqData.URL = url
    reqData.Method = Enums.HttpRequestMethod.Get
    
    local response = Http:RequestAsync(reqData)
    if response.Success then
        print("Response from " .. url .. " - Counted towards trust ratelimit: " .. tostring(response.Trusted))
        print(Http:GetLimits())
    else
        print("Failed to get response from " .. url .. " - Error: " .. response.StatusCode)
    end
end

Players.PlayerAdded:Connect(function()
    makeRequest(nonTrustedBase)
    makeRequest(trustedBase)
    makeRequest(createsTrustButNotTrusted)
    makeRequest(trustedBase)
end)
```

And on the other side, an example setup in Caddy looks like this:
```
polytrack.top {
    reverse_proxy 10.0.0.4:13399
    header +X-PT-Trusted-World-Id 0
    header +X-PT-Trusted-World-Id 1234
    header +X-PT-Limit-Scope /api/
}
```

This would allow both worlds with id 0 and 1234 to send more than 90 reqs/min to any route at https://polytrack.top/api/**/*.

With above setup, the output looks like this:
```
• [16:53:07] Response from https://api.polytoria.com/v1/users/1 - Counted towards trust ratelimit: false
• [16:53:07] <HttpServiceLimits: standard=89, trusted=450>
• [16:53:07] Response from https://polytrack.top/api/charts/user/2/day?date=2026-05-07T22:48:19.831Z - Counted towards trust ratelimit: true
• [16:53:07] <HttpServiceLimits: standard=89, trusted=449>
• [16:53:07] Response from https://polytrack.top/ - Counted towards trust ratelimit: false
• [16:53:07] <HttpServiceLimits: standard=88, trusted=449>
• [16:53:08] Response from https://polytrack.top/api/charts/user/2/day?date=2026-05-07T22:48:19.831Z - Counted towards trust ratelimit: true
• [16:53:08] <HttpServiceLimits: standard=88, trusted=448>
```

This PR also adds `Http:GetLimits()` which returns the available requests limits for the current minute.

## Related issue or discussion

discussed in beta server </3

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

na