### PR TITLE
Add trackpad pan gesture camera rotation

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -21,6 +21,7 @@ public sealed partial class Camera : Dynamic
 	public const float DefaultZoomDistance = 10.0f;
 	public const float DefaultScrollSensitivity = 15.0f;
 	private const float TrackpadPinchZoomSensitivity = 0.75f;
+	private const float TrackpadPanSensitivity = 10.0f;
 
 	// override default +Z forward orientation as that would be incorrect for the camera
 	[ScriptProperty] new public Vector3 Forward => -GetGlobalTransform().Basis.Z.Normalized();
@@ -718,6 +719,10 @@ public sealed partial class Camera : Dynamic
 		{
 			ZoomByMagnifyGesture(magnifyGesture);
 		}
+		else if (@event is InputEventPanGesture panGesture)
+		{
+			RotateByPanGesture(panGesture);
+		}
 
 		if (Mode == CameraModeEnum.Scripted) return;
 
@@ -748,9 +753,7 @@ public sealed partial class Camera : Dynamic
 			if (Root.Input.IsTouchscreen) return;
 			if (_turning)
 			{
-				_targetRotation += new Vector3(mouseEvent.Relative.Y / -5 * VerticalSpeed * 0.02f, mouseEvent.Relative.X / -5 * HorizontalSpeed * 0.02f, 0) * Sensitivity;
-
-				LimitRotation();
+				RotateCamera(mouseEvent.Relative);
 			}
 		}
 
@@ -867,6 +870,25 @@ public sealed partial class Camera : Dynamic
 
 		_targetZoom -= ScrollSensitivity * TrackpadPinchZoomSensitivity * zoomDelta;
 		LimitZoomDistance();
+	}
+
+	private void RotateByPanGesture(InputEventPanGesture panGesture)
+	{
+		if (Mode != CameraModeEnum.Follow) return;
+		if (Root.Input.IsTouchscreen) return;
+
+		RotateCamera(-panGesture.Delta * TrackpadPanSensitivity);
+	}
+
+	private void RotateCamera(Vector2 delta)
+	{
+		_targetRotation += new Vector3(
+			delta.Y / -5 * VerticalSpeed * 0.02f,
+			delta.X / -5 * HorizontalSpeed * 0.02f,
+			0
+		) * Sensitivity;
+
+		LimitRotation();
 	}
 
 	public void ReceiveDragTouchInput(InputEventScreenDrag dragEvent)


### PR DESCRIPTION
## Summary

This PR adds support for rotating the camera using trackpad pan gestures. This means trackpad users can move the camera with a two-finger pan gesture instead of needing to hold right-click, which feels more natural and more intuitive. 

The change reuses the existing camera rotation logic used by right-click drag (I added some existing logic into a small `RotateCamera` function to prevent duplicate code), with a sensitivity multiplier `TrackpadPanSensitivity`.

## Related issue or discussion

https://github.com/Polytoria/polytoria-game/issues/207 (thank you for providing links to documentation, was helpful!)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/a18a500d-1c2b-4767-8a5e-937d84cb22f6

Shows the flick inertia effect pretty nicely!

## AI/LLM use

I asked AI to help me understand the Git commands around stashing local testing changes, as I had unrelated local changes needed for running the project on macOS (might make a separate PR for this in the future, actually).