### PR TITLE
Remove ScriptProperty from C0/C1 on Welds

### DIFF
--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -63,7 +63,7 @@ public partial class Weld : Instance
 		}
 	}
 
-	[SyncVar, ScriptProperty]
+	[SyncVar]
 	public Transform3D C0
 	{
 		get => _c0;
@@ -76,7 +76,7 @@ public partial class Weld : Instance
 		}
 	}
 
-	[SyncVar, ScriptProperty]
+	[SyncVar]
 	public Transform3D C1
 	{
 		get => _c1;


### PR DESCRIPTION
## Summary

Temporarily removes the ScriptProperty attribute from Weld.C0 and Weld.C1 until the weld rework which fixes luau defs/autocomplete

## Related issue or discussion

Fixes #449 
Fixes #486

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None