### PR TITLE
Exclude camera parented parts from datamodelbridge

### DIFF
--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -361,6 +361,7 @@ public partial class DatamodelBridge : Node3D
 		{
 			if (!IsInstanceValid(part.GDNode3D) || !part.GDNode3D.IsInsideTree()) return false;
 			if (part.IsDeleted) return false;
+			if (part.IsDescendantOfClass<Camera>()) return false;
 			return true;
 		}
 		return false;


### PR DESCRIPTION
## Summary

Excludes parts parented from datamodel bridge to fix #520 

## Related issue or discussion

Fixes #520 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [ ] Ran `dotnet restore`
- [ ] Ran `dotnet format`
- [ ] Ran `dotnet build`
- [ ] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None