### PR TITLE
Make the Creator badge above all other badges if the player is the creator

### DIFF
--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -338,9 +338,9 @@ public sealed partial class Player : NPC
 
 	public static string GetBadgeIconPath(Player player)
 	{
-		string badgeName = !string.IsNullOrEmpty(player.UserRoleClass) ? player.UserRoleClass
+		string badgeName = player.IsCreator ? "creator"
+			: !string.IsNullOrEmpty(player.UserRoleClass) ? player.UserRoleClass
 			: player.IsAdmin ? "admin"
-			: player.IsCreator ? "creator"
 			: "";
 
 		if (string.IsNullOrEmpty(badgeName))


### PR DESCRIPTION
## Summary
i have made a commit so that the in game badge for a player is always the creator badge if the player is a creator
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion
I had made a suggestion in the polytoria discord assuming this was an intended feature where the plus badge has taken priority over the creator badge

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
before
<img width="522" height="137" alt="1" src="https://github.com/user-attachments/assets/ad9640fa-bd02-4ed0-8905-6881e4bce783" />
after
<img width="360" height="138" alt="2" src="https://github.com/user-attachments/assets/ffb8f78a-5625-4364-bb4c-417ba2ed3ad8" />

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None

<!-- Describe AI use, or write "None" if not applicable --> 