### PR TITLE
fix selection for instances in HiddenBase

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -692,29 +692,10 @@ public partial class Dynamic : Instance
 	private void SetCreatorBoundActive(bool to)
 	{
 		if (_boundArea3D == null) return;
-		// Ignore model/physical model and camera
-		if (to && this is not IGroup and not Camera && this is not Physical)
-		{
-			if (this is Physical p && p.CanCollide)
-			{
-				p.SetCollisionLayer(3, true);
-			}
-			else
-			{
-				_boundArea3D.CollisionLayer = (1 << 2);
-			}
-		}
-		else
-		{
-			if (this is Physical p)
-			{
-				p.SetCollisionLayer(3, false);
-			}
-			else
-			{
-				_boundArea3D.CollisionLayer = 0;
-			}
-		}
+		_boundArea3D.CollisionLayer =
+			to && this is not IGroup and not Camera and not Physical
+				? 1 << 2
+				: 0u;
 	}
 
 	internal void PropagateUpdateCreatorBounds()


### PR DESCRIPTION
## Summary

fix selection for instances in HiddenBase (general refactor of previously already weird and after my recent collision layer fixes still weird SetCreatorBoundActive method)

## Related issue or discussion

n/a

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

n

## AI/LLM use

n