### PR TITLE
Explicitly resolve fps cap settings

### DIFF
--- a/Polytoria/scripts/client/settings/appliers/DisplaySettingsApplier.cs
+++ b/Polytoria/scripts/client/settings/appliers/DisplaySettingsApplier.cs
@@ -71,8 +71,7 @@ public sealed partial class DisplaySettingsApplier : Node
 
 	private void ApplyFpsCap()
 	{
-		var fpsPreset = ClientSettingsService.Instance.Get<FpsPreset>(SharedSettingKeys.Display.FpsPreset);
-		Engine.MaxFps = fpsPreset != FpsPreset.Custom ? (int)fpsPreset : ClientSettingsService.Instance.Get<int>(SharedSettingKeys.Display.FpsCap);
+		Engine.MaxFps = ResolveFpsCap(ClientSettingsService.Instance);
 	}
 
 	private void ApplyUiScale()
@@ -83,5 +82,23 @@ public sealed partial class DisplaySettingsApplier : Node
 		float osScale = DisplayServer.ScreenGetScale(screenId);
 		finalScale = scale * osScale;
 		GetTree().Root.ContentScaleFactor = finalScale;
+	}
+
+	private static int ResolveFpsCap(ISettingsContext settings)
+	{
+		var preset = settings.Get<FpsPreset>(SharedSettingKeys.Display.FpsPreset);
+
+		return preset switch
+		{
+			FpsPreset.Custom => settings.Get<int>(SharedSettingKeys.Display.FpsCap),
+			FpsPreset.Limitless => 0,
+			FpsPreset.Reduced => 30,
+			FpsPreset.Standard => 60,
+			FpsPreset.Extended => 90,
+			FpsPreset.Smooth => 120,
+			FpsPreset.Slick => 144,
+			FpsPreset.Fluid => 240,
+			_ => 0
+		};
 	}
 }

--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -188,8 +188,7 @@ public partial class CreatorInterface : Control, IScriptObject
 
 	private static void ApplyFpsCap()
 	{
-		var fpsPreset = CreatorSettingsService.Instance.Get<FpsPreset>(SharedSettingKeys.Display.FpsPreset);
-		Engine.MaxFps = fpsPreset != FpsPreset.Custom ? (int)fpsPreset : CreatorSettingsService.Instance.Get<int>(SharedSettingKeys.Display.FpsCap);
+		Engine.MaxFps = ResolveFpsCap(CreatorSettingsService.Instance);
 	}
 
 	public static void CreateNewWorld()
@@ -707,6 +706,24 @@ public partial class CreatorInterface : Control, IScriptObject
 	internal async Task<bool> OnQuitRequested()
 	{
 		return await PromptConfirmation("Are you sure you want to quit? Any unsaved changes will be lost");
+	}
+
+	private static int ResolveFpsCap(ISettingsContext settings)
+	{
+		var preset = settings.Get<FpsPreset>(SharedSettingKeys.Display.FpsPreset);
+
+		return preset switch
+		{
+			FpsPreset.Custom => settings.Get<int>(SharedSettingKeys.Display.FpsCap),
+			FpsPreset.Limitless => 0,
+			FpsPreset.Reduced => 30,
+			FpsPreset.Standard => 60,
+			FpsPreset.Extended => 90,
+			FpsPreset.Smooth => 120,
+			FpsPreset.Slick => 144,
+			FpsPreset.Fluid => 240,
+			_ => 0
+		};
 	}
 }
 


### PR DESCRIPTION
## Summary

Fallback to unlimited fps when fps cap enum cannot be resolved

## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None