### PR TITLE
Make First Person Respect `Input.CursorLocked` and `Input.CursorVisible`

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -481,12 +481,15 @@ public sealed partial class Camera : Dynamic
 			{
 				if (Root.Input.CursorLocked)
 				{
+					Root.Input.CursorVisible = false;
 					Input.MouseMode = Input.MouseModeEnum.Captured;
 					Root.Input.OverrideMousePosTo = GDNode.GetViewport().GetVisibleRect().GetCenter();
+					Root.Input.OverrideMousePos = true;
+					_turning = true;
 				}
 				else
 				{
-					Input.MouseMode = Input.MouseModeEnum.Visible;
+					_turning = false;
 					Root.Input.OverrideMousePos = false;
 				}
 			}
@@ -685,7 +688,6 @@ public sealed partial class Camera : Dynamic
 		if (!Root.Input.CursorLocked)
 		{
 			Root.Input.CursorLocked = false;
-			Root.Input.CursorVisible = true;
 			Root.Input.OverrideMousePos = false;
 			return;
 		}

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -479,9 +479,16 @@ public sealed partial class Camera : Dynamic
 
 			if ((IsFirstPerson || AlwaysLocked) && Root.Input.IsGameFocused)
 			{
-				// Force mouse captured
-				Input.MouseMode = Input.MouseModeEnum.Captured;
-				Root.Input.OverrideMousePosTo = GDNode.GetViewport().GetVisibleRect().GetCenter();
+				if (Root.Input.CursorLocked)
+				{
+					Input.MouseMode = Input.MouseModeEnum.Captured;
+					Root.Input.OverrideMousePosTo = GDNode.GetViewport().GetVisibleRect().GetCenter();
+				}
+				else
+				{
+					Input.MouseMode = Input.MouseModeEnum.Visible;
+					Root.Input.OverrideMousePos = false;
+				}
 			}
 
 			if (_targetZoom <= 0)
@@ -613,6 +620,8 @@ public sealed partial class Camera : Dynamic
 	{
 		if (Mode != CameraModeEnum.Follow) return;
 		IsFirstPerson = true;
+		Root.Input.CursorLocked = true;
+		Root.Input.CursorVisible = false;
 		_targetZoom = 0;
 		StartTurning();
 		FirstPersonEntered?.Invoke();
@@ -622,6 +631,8 @@ public sealed partial class Camera : Dynamic
 	{
 		if (Mode != CameraModeEnum.Follow) return;
 		IsFirstPerson = false;
+		Root.Input.CursorLocked = false;
+		Root.Input.CursorVisible = true;
 		if (resetZoom)
 		{
 			_targetZoom = DefaultZoomDistance;
@@ -671,6 +682,14 @@ public sealed partial class Camera : Dynamic
 		if (Mode != CameraModeEnum.Follow) return;
 		_turning = true;
 
+		if (!Root.Input.CursorLocked)
+		{
+			Root.Input.CursorLocked = false;
+			Root.Input.CursorVisible = true;
+			Root.Input.OverrideMousePos = false;
+			return;
+		}
+
 		Vector2 screenCenter = GDNode.GetViewport().GetVisibleRect().GetCenter();
 		_turnStartPos = GDNode.GetViewport().GetMousePosition();
 		GDNode.GetViewport().WarpMouse(screenCenter);
@@ -686,12 +705,19 @@ public sealed partial class Camera : Dynamic
 		_turning = false;
 		if (!Root.Input.CursorLocked)
 		{
-			Input.MouseMode = Input.MouseModeEnum.Visible;
+			Root.Input.CursorVisible = true;
+			Root.Input.CursorLocked = false;
 			Root.Input.OverrideMousePos = false;
 			GDNode.GetViewport().WarpMouse(_turnStartPos);
 #if GODOT_WINDOWS
 			GDNode.GetViewport().WarpMouse(_turnStartPos); // Workaround for godotengine/godot#119205
 #endif
+		}
+		else
+		{
+			Root.Input.CursorVisible = false;
+			Root.Input.CursorLocked = true;
+			Root.Input.OverrideMousePos = false;
 		}
 	}
 
@@ -742,11 +768,24 @@ public sealed partial class Camera : Dynamic
 				if (btnEvent.Pressed)
 				{
 					StartTurning();
+					Root.Input.CursorLocked = true;
+					Root.Input.CursorVisible = false;
 				}
 				else
 				{
 					StopTurning();
+					Root.Input.CursorLocked = false;
+					Root.Input.CursorVisible = true;
 				}
+			}
+		}
+
+		if (@event is InputEventMouseMotion mouseEvent)
+		{
+			if (Root.Input.IsTouchscreen) return;
+			if (_turning && Root.Input.CursorLocked)
+			{
+				RotateCamera(mouseEvent.Relative);
 			}
 		}
 

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -767,11 +767,14 @@ public sealed partial class Camera : Dynamic
 				if (AlwaysLocked) return;
 				if (btnEvent.Pressed)
 				{
-					StartTurning();
-					Root.Input.CursorLocked = true;
-					Root.Input.CursorVisible = false;
+					if (!Root.Input.CursorLocked)
+					{
+						StartTurning();
+						Root.Input.CursorLocked = true;
+						Root.Input.CursorVisible = false;
+					}
 				}
-				else
+				else if (_turning)
 				{
 					StopTurning();
 					Root.Input.CursorLocked = false;
@@ -811,7 +814,7 @@ public sealed partial class Camera : Dynamic
 		if (@event is InputEventMouseMotion mouseEvent)
 		{
 			if (Root.Input.IsTouchscreen) return;
-			if (_turning)
+			if (_turning && Root.Input.CursorLocked)
 			{
 				RotateCamera(mouseEvent.Relative);
 			}


### PR DESCRIPTION
## Summary
Makes first person respect `Input.CursorLocked` and `Input.CursorVisible`.

## Related issue or discussion

Fixes #245

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/d657f328-cca2-463a-a5c7-b4da544c7bc0

## AI/LLM use
None.