### PR TITLE
Fix clock sync

### DIFF
--- a/Polytoria/scripts/datamodel/World.cs
+++ b/Polytoria/scripts/datamodel/World.cs
@@ -241,6 +241,10 @@ public sealed partial class World : Instance
 #if CREATOR
 		Properties.Singleton?.Insert(this);
 #endif
+		if (SessionType == SessionTypeEnum.Client)
+		{
+			RegisterNewNetworkedObject(this, "1");
+		}
 	}
 
 	public override void PreDelete()
@@ -440,12 +444,13 @@ public sealed partial class World : Instance
 	}
 
 
-	internal void RegisterNewNetworkedObject(NetworkedObject netObj)
+	internal void RegisterNewNetworkedObject(NetworkedObject netObj, string? forceId = null)
 	{
 		if (netObj.NetworkedObjectID == "")
 		{
 			_nextId++;
-			netObj.NetworkedObjectID = WorldSessionID + _nextId.ToString();
+			string targetId = WorldSessionID + (forceId ?? _nextId.ToString());
+			netObj.NetworkedObjectID = targetId;
 		}
 	}
 


### PR DESCRIPTION
## Summary

The client creates its `World` instance itself. The `NetworkedObjectID` is normally replicated by the server to the client (see RecvReplicate in `NetworkedObject`, but the `World` instance does not seem to get replicated as far as I can tell, its purely local on both ends.

This prevented the server from sending the clock sync RPC response (clock sync is the only RPC in `World`). The server assumed the client also has the `World` instance registered as id 1, but since it doesn't, the client quietly dropped the response RPC.

To solve this, I decided to do a small workaround by "fake" registering the local `World` instance on client as id 1 (which seems to always be the id the server assigns to it).

To ensure this change doesn't break anything, I checked that:
- The `World` Instance actually never gets registered on client (its `NetworkedObjectId` during my debugging always was string.Empty on client)
- There is no other instance registered with id 1 on the client (since the server assigns the ids (and it assigns id 1 to its own `World` instance, this doesn't happen.

I of course also did a quick glance if anything broke by testing it with run lil bro and multiple clients, and it does seem to replicate everything fine.

<img width="765" height="191" alt="image" src="https://github.com/user-attachments/assets/bf57d5a9-ec1c-472b-b60c-911aaf4813d6" />


## Related issue or discussion

Fixes #548 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

none