### PR TITLE
Fix Stat Reparent Crash

### DIFF
--- a/Polytoria/scripts/client/ui/playerlist/UILeaderboard.cs
+++ b/Polytoria/scripts/client/ui/playerlist/UILeaderboard.cs
@@ -89,7 +89,7 @@ public partial class UILeaderboard : Control
 		base._Process(delta);
 	}
 
-	private void OnStatDefinitionChanged(Stat _)
+	private void OnStatDefinitionChanged(Stat stat)
 	{
 		CreateHeader();
 		Refresh();
@@ -377,13 +377,14 @@ public partial class UILeaderboard : Control
 		if (statsBox == null)
 			return;
 
-		while (statsBox.GetChildCount() > 0)
+		foreach (Node node in statsBox.GetChildren())
 		{
-			statsBox.GetChild(0).QueueFree();
+			node.QueueFree();
 		}
 
 		foreach (var stat in Stats.GetStats())
 		{
+			if (stat.IsDeleted) continue;
 			Label headerLabel = new()
 			{
 				Text = stat.GetDisplayName(),

--- a/Polytoria/scripts/client/ui/playerlist/UILeaderboard.cs
+++ b/Polytoria/scripts/client/ui/playerlist/UILeaderboard.cs
@@ -41,6 +41,7 @@ public partial class UILeaderboard : Control
 		_players.PlayerRemoved.Connect(RemovePlayer);
 
 		Stats.StatAdded.Connect(OnStatDefinitionChanged);
+		Stats.StatPropertyChanged.Connect(OnStatDefinitionChanged);
 		Stats.StatRemoved.Connect(OnStatDefinitionChanged);
 
 		Teams.TeamAdded.Connect(TeamChanged);
@@ -60,6 +61,7 @@ public partial class UILeaderboard : Control
 		_players.PlayerRemoved.Disconnect(RemovePlayer);
 
 		Stats.StatAdded.Disconnect(OnStatDefinitionChanged);
+		Stats.StatPropertyChanged.Disconnect(OnStatDefinitionChanged);
 		Stats.StatRemoved.Disconnect(OnStatDefinitionChanged);
 
 		Teams.TeamAdded.Disconnect(TeamChanged);

--- a/Polytoria/scripts/client/ui/playerlist/stats/UIUserCardStat.cs
+++ b/Polytoria/scripts/client/ui/playerlist/stats/UIUserCardStat.cs
@@ -20,11 +20,17 @@ public partial class UIUserCardStat : Node
 		_nameLabel.Text = TargetStat.GetDisplayName();
 		_valueLabel.Text = TargetStat.GetDisplayValue(UIUserCard.TargetPlayer);
 		UIUserCard.TargetPlayer.StatChanged.Connect(OnPlayerStatChanged);
+
+		TargetStat.PropertyChanged.Connect(() =>
+		{
+			_nameLabel.Text = TargetStat.GetDisplayName();
+		});
 	}
 
 	private void OnPlayerStatChanged(Stat k, object? _)
 	{
 		if (k != TargetStat) return;
+		_nameLabel.Text = TargetStat.GetDisplayName();
 		_valueLabel.Text = TargetStat.GetDisplayValue(UIUserCard.TargetPlayer);
 	}
 }

--- a/Polytoria/scripts/datamodel/Stats.cs
+++ b/Polytoria/scripts/datamodel/Stats.cs
@@ -13,6 +13,7 @@ public sealed partial class Stats : Instance
 {
 	public PTSignal<Stat> StatAdded { get; private set; } = new();
 	public PTSignal<Stat> StatRemoved { get; private set; } = new();
+	public PTSignal<Stat> StatPropertyChanged { get; private set; } = new();
 
 	public override void Init()
 	{
@@ -41,6 +42,10 @@ public sealed partial class Stats : Instance
 	{
 		if (instance is Stat stat)
 		{
+			stat.PropertyChanged.Connect(() =>
+			{
+				StatPropertyChanged.Invoke(stat);
+			});
 			StatAdded.Invoke(stat);
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes game crash when a `Stat` gets reparented / deleted.
Also makes it update the `Stat`'s name on the leaderboard when the `DisplayName` changes. 

One minor thing is that when the stats get deleted and there are no more stats, the leaderboard won't be as large as a game that has no stats.

## Related issue or discussion

Fixes #545

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/14997f59-9385-4e2c-8ea1-a601a13b8c40


## AI/LLM use

None