### PR TITLE
Add clothing reformatting and resizing

### DIFF
--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -43,6 +43,7 @@ public sealed partial class PolytorianModel : CharacterModel
 	private const int ClothingWidth = 1024;
 	private const int ClothingHeight = 1024;
 	private static readonly Rect2I _clothingRect = new(0, 0, ClothingWidth, ClothingHeight);
+	private static readonly Image.Format _clothingFormat = Image.Format.Rgba8;
 
 	private int _loadAppearanceCount = 0;
 
@@ -429,7 +430,7 @@ public sealed partial class PolytorianModel : CharacterModel
 		Clothing[] clothings = GetChildrenOfClass<Clothing>();
 		if (clothings.Length != 0)
 		{
-			Image result = Image.CreateEmpty(ClothingWidth, ClothingHeight, false, Image.Format.Rgba8);
+			Image result = Image.CreateEmpty(ClothingWidth, ClothingHeight, false, _clothingFormat);
 			// the loop draws from back to front, like a painter
 			// clothing is ordered from front to back
 			clothings.Reverse();
@@ -438,7 +439,14 @@ public sealed partial class PolytorianModel : CharacterModel
 				Texture2D? texture = clothing.ClothTexture;
 				// Skip unloaded ones
 				if (texture != null)
-					result.BlendRect(texture.GetImage(), _clothingRect, Vector2I.Zero);
+				{
+					Image image = texture.GetImage();
+					// just in case the clothing isn't the correct format or size
+					// Godot will skip these if the format or size already match
+					image.Convert(_clothingFormat);
+					image.Resize(ClothingWidth, ClothingHeight);
+					result.BlendRect(image, _clothingRect, Vector2I.Zero);
+				}
 			}
 			composite = ImageTexture.CreateFromImage(result);
 		}

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -42,8 +42,8 @@ public sealed partial class PolytorianModel : CharacterModel
 
 	private const int ClothingWidth = 1024;
 	private const int ClothingHeight = 1024;
+	private const Image.Format ClothingFormat = Image.Format.Rgba8;
 	private static readonly Rect2I _clothingRect = new(0, 0, ClothingWidth, ClothingHeight);
-	private static readonly Image.Format _clothingFormat = Image.Format.Rgba8;
 
 	private int _loadAppearanceCount = 0;
 
@@ -430,7 +430,7 @@ public sealed partial class PolytorianModel : CharacterModel
 		Clothing[] clothings = GetChildrenOfClass<Clothing>();
 		if (clothings.Length != 0)
 		{
-			Image result = Image.CreateEmpty(ClothingWidth, ClothingHeight, false, _clothingFormat);
+			Image result = Image.CreateEmpty(ClothingWidth, ClothingHeight, false, ClothingFormat);
 			// the loop draws from back to front, like a painter
 			// clothing is ordered from front to back
 			clothings.Reverse();
@@ -443,7 +443,7 @@ public sealed partial class PolytorianModel : CharacterModel
 					Image image = texture.GetImage();
 					// just in case the clothing isn't the correct format or size
 					// Godot will skip these if the format or size already match
-					image.Convert(_clothingFormat);
+					image.Convert(ClothingFormat);
 					image.Resize(ClothingWidth, ClothingHeight);
 					result.BlendRect(image, _clothingRect, Vector2I.Zero);
 				}


### PR DESCRIPTION
## Summary

forces all clothing images to have the RGBA8 format and a size of 1024x1024, just in case they mismatch (like in the case of `201310`)

## Related issue or discussion

Fixes #556

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None