### PR TITLE
Fix inverted stamina regen calculation

### DIFF
--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -612,7 +612,7 @@ public sealed partial class Player : NPC
 	internal void AddStaminaTick(double delta)
 	{
 		if (!UseStamina) { return; }
-		Stamina += (float)(delta / StaminaRegen);
+		Stamina += (float)(delta * StaminaRegen);
 		if (Stamina > MaxStamina)
 		{
 			Stamina = MaxStamina;
@@ -622,7 +622,7 @@ public sealed partial class Player : NPC
 	internal void RemoveStaminaTick(double delta)
 	{
 		if (!UseStamina) { return; }
-		Stamina -= (float)(delta / StaminaBurn);
+		Stamina -= (float)(delta * StaminaBurn);
 		if (Stamina < 0)
 		{
 			Stamina = 0;


### PR DESCRIPTION
## Summary

Increasing stamina regen slows down stamina regen, this pr fixes it

## Related issue or discussion

Fixes #72

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [ ] Ran `dotnet restore`
- [ ] Ran `dotnet format`
- [ ] Ran `dotnet build`
- [ ] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None