### PR TITLE
Set Min Camera Sensitivty from 0.2f -> 0.1f

### DIFF
--- a/Polytoria/scripts/client/settings/ClientSettingsRegistry.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingsRegistry.cs
@@ -116,7 +116,7 @@ public static class ClientSettingsRegistry
 				ValueKind = SettingValueKind.Float,
 				ControlKind = SettingControlKind.Slider,
 				DefaultValue = 0.6f,
-				MinValue = 0.2f,
+				MinValue = 0.1f,
 				MaxValue = 1.2f,
 				Step = 0.1f
 			});


### PR DESCRIPTION
## Summary

~~2.0.11 made my camera sensitivity uncomfortably high.~~
~~Setting it to 0.1f restores it to match my system cursor speed.~~
~~This PR sets the min camera sensitivity from 0.2f to 0.1f.~~

~~Multiple other people were complaining about this in-game.~~

Leaving this PR open for the sake of providing slower camera speeds for those who want them.

## Related issue or discussion

~~Fixes #560~~ See #561 instead.

## Type of change

~~- [x] Bug fix~~
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

None.