### PR TITLE
Fix CtrlLock + doubled camera sensitivity

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -634,14 +634,14 @@ public sealed partial class Camera : Dynamic
 	{
 		if (Mode != CameraModeEnum.Follow) return;
 		IsFirstPerson = false;
-		Root.Input.CursorLocked = false;
-		Root.Input.CursorVisible = true;
 		if (resetZoom)
 		{
 			_targetZoom = DefaultZoomDistance;
 		}
 		if (!CtrlLocked)
 		{
+			Root.Input.CursorVisible = true;
+			Root.Input.CursorLocked = false;
 			StopTurning();
 		}
 		FirstPersonExited?.Invoke();
@@ -687,7 +687,7 @@ public sealed partial class Camera : Dynamic
 
 		if (!Root.Input.CursorLocked)
 		{
-			Root.Input.CursorLocked = false;
+			Root.Input.CursorLocked = true;
 			Root.Input.OverrideMousePos = false;
 			return;
 		}
@@ -708,7 +708,6 @@ public sealed partial class Camera : Dynamic
 		if (!Root.Input.CursorLocked)
 		{
 			Root.Input.CursorVisible = true;
-			Root.Input.CursorLocked = false;
 			Root.Input.OverrideMousePos = false;
 			GDNode.GetViewport().WarpMouse(_turnStartPos);
 #if GODOT_WINDOWS
@@ -717,8 +716,8 @@ public sealed partial class Camera : Dynamic
 		}
 		else
 		{
-			Root.Input.CursorVisible = false;
-			Root.Input.CursorLocked = true;
+			Root.Input.CursorVisible = true;
+			Root.Input.CursorLocked = false;
 			Root.Input.OverrideMousePos = false;
 		}
 	}

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -784,15 +784,6 @@ public sealed partial class Camera : Dynamic
 			}
 		}
 
-		if (@event is InputEventMouseMotion mouseEvent)
-		{
-			if (Root.Input.IsTouchscreen) return;
-			if (_turning && Root.Input.CursorLocked)
-			{
-				RotateCamera(mouseEvent.Relative);
-			}
-		}
-
 		// Toggle first person
 		if (@event.IsActionPressed("cam_toggle_firstperson"))
 		{


### PR DESCRIPTION
## Summary
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
This fixes CtrlLock not working as expected potentially from the CursorLocked changes from #549, as well as removing a duplicate camera rotation statement that was supposed to be removed in #535 but got added back in #549 lol.

## Related issue or discussion

Fixes #555
Fixes #560
Related to #535, #549

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
None
<!-- Describe AI use, or write "None" if not applicable -->