### PR TITLE
add a force blend alpha setting

### DIFF
--- a/Polytoria/scripts/client/ClientEntry.cs
+++ b/Polytoria/scripts/client/ClientEntry.cs
@@ -201,6 +201,7 @@ public sealed partial class ClientEntry : Node3D
 		settings.Init();
 
 		AssetLoader.Singleton.MaxConcurrentRequests = ClientSettingsService.Instance.Get<int>(SharedSettingKeys.Advanced.AssetQueue);
+		Image3D.ForceBlendAlpha = ClientSettingsService.Instance.Get<bool>(SharedSettingKeys.Advanced.ForceBlendAlpha);
 
 		settings.AddChild(new DisplaySettingsApplier { Name = "DisplaySettingsApplier" }, true, InternalMode.Front);
 		settings.AddChild(new AudioSettingsApplier { Name = "AudioSettingsApplier" }, true, InternalMode.Front);

--- a/Polytoria/scripts/creator/CreatorEntry.cs
+++ b/Polytoria/scripts/creator/CreatorEntry.cs
@@ -7,6 +7,7 @@ using Polytoria.Client.Settings.Appliers;
 using Polytoria.Creator.Managers;
 using Polytoria.Creator.Settings;
 using Polytoria.Creator.Utils;
+using Polytoria.Datamodel;
 using Polytoria.Datamodel.Creator;
 using Polytoria.Shared;
 using Polytoria.Shared.AssetLoaders;
@@ -40,6 +41,7 @@ public partial class CreatorEntry : Node
 		creatorSettingsService.AddChild(new GraphicsSettingsApplier { Name = GraphicsSettingsApplier.NodeName, Settings = creatorSettingsService }, true, InternalMode.Front);
 
 		GetViewport().GuiEmbedSubwindows = true;
+		Image3D.ForceBlendAlpha = creatorSettingsService.Get<bool>(SharedSettingKeys.Advanced.ForceBlendAlpha);
 
 		// Open project
 		cmdargs.TryGetValue("proj", out string? creatorFilePath);

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -31,6 +31,7 @@ public sealed partial class Image3D : Dynamic
 	private bool _faceCamera;
 	private bool _doubleSided;
 	private TextureFilterEnum _textureFilter;
+	public static bool ForceBlendAlpha = false;
 
 	[Editable, ScriptProperty]
 	public ImageAsset? Image
@@ -243,7 +244,7 @@ public sealed partial class Image3D : Dynamic
 			_transparencyType = tex.GetImage().DetectAlpha() switch
 			{
 				Godot.Image.AlphaMode.Blend => BaseMaterial3D.TransparencyEnum.Alpha,
-				Godot.Image.AlphaMode.Bit => BaseMaterial3D.TransparencyEnum.Alpha,
+				Godot.Image.AlphaMode.Bit => ForceBlendAlpha ? BaseMaterial3D.TransparencyEnum.Alpha : BaseMaterial3D.TransparencyEnum.AlphaScissor,
 				_ => BaseMaterial3D.TransparencyEnum.Disabled,
 			};
 			UpdateMaterialTransparency();

--- a/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
@@ -42,5 +42,6 @@ public static class SharedSettingKeys
 	public static class Advanced
 	{
 		public const string AssetQueue = "advanced.asset_queue";
+		public const string ForceBlendAlpha = "advanced.force_blend_alpha";
 	}
 }

--- a/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingsRegistry.cs
@@ -359,6 +359,20 @@ public static class SharedSettingsRegistry
 					]
 				}
 			},
+			{
+				SharedSettingKeys.Advanced.ForceBlendAlpha,
+				new SettingDef<bool>
+				{
+					Key = SharedSettingKeys.Advanced.ForceBlendAlpha,
+					SectionKey = "advanced",
+					Label = "Force Blend Alpha",
+					Description = "Forces Image3Ds to have the \"Alpha\" blend mode instead of \"AlphaScissor\" which might fix some crashes on worse GPUs.",
+					ValueKind = SettingValueKind.Bool,
+					RequiresRestart = true,
+					DefaultValue = false,
+					ControlKind = SettingControlKind.Toggle,
+				}
+			},
 		};
 
 		SettingDef.ValidateAll(defs.Values);


### PR DESCRIPTION
## Summary

added a "force blend alpha" setting so that image3ds will still have alphascissor for most people and so that those who experience crashes with the alphascissor might change it

## Related issue or discussion

Fixes #522

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

help in understading how the code works (though i mostly figured everything out myself)