### PR TITLE
Increase Sound volume limit to 2

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -92,7 +92,7 @@ public sealed partial class Sound : Dynamic
 		get => _volume;
 		set
 		{
-			_volume = Mathf.Clamp(value, 0, 1);
+			_volume = Mathf.Clamp(value, 0, 2);
 			UpdateVolume();
 			OnPropertyChanged();
 		}


### PR DESCRIPTION
## Summary
A friend of mine recently had their music added to a game, however it turns out the song volume was lower than expected, but with no way to increase it properly. The only ways to increase it here is to either reupload the audio, which is inconvenient with approval time and brick cost, or to duplicate the Sound and play them at the same exact time, also not the greatest solution. 

This PR increases the limit to 2 to allow increasing volume past the base audio volume. Also it doesn't really make sense if you could only decrease volume and not increase.

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion

N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
Claude Opus Magnus Delivrus Victus 99.999 v2 Gen 5
<!-- Describe AI use, or write "None" if not applicable -->