### PR TITLE
Add big emoji support to bubble chat and fix bubble sizing

### DIFF
--- a/Polytoria/scripts/client/spatial/chat/BubbleItem.cs
+++ b/Polytoria/scripts/client/spatial/chat/BubbleItem.cs
@@ -3,13 +3,23 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using Godot;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Polytoria.Client.UI.Chat;
 
 public partial class BubbleItem : Control
 {
 	private const float BubbleTimeLength = 5;
-	private const float BubbleSizeOffset = 55;
+	private const int BigEmojiSize = 64;
+	private const int InlineEmojiSize = 42;
+	private const int EmojiPadding = 16;
+	private const int EmojiColumns = 4;
+	private const int EmojiSpacing = 10;
+
+	private static readonly Regex EmojiOnlyRegex = new(@"^\s*(\[img=\d+x\d+\][^\[]*\[/img\]\s*)+$", RegexOptions.Compiled);
+	private static readonly Regex ImgSizeRegex = new(@"\[img=\d+x\d+\]", RegexOptions.Compiled);
+
 	private AnimationPlayer _animPlay = null!;
 	public string Content = null!;
 
@@ -19,22 +29,22 @@ public partial class BubbleItem : Control
 		_animPlay = GetNode<AnimationPlayer>("AnimationPlayer");
 		Label testLabel = GetNode<Label>("TestLabel");
 		RichTextLabel textLabel = GetNode<RichTextLabel>("Pivot/Layout/Container/RichTextLabel");
-		textLabel.Text = Content;
-		testLabel.Text = Content;
+		Control bubbleLayout = GetNode<Control>("Pivot/Layout");
 
-		// Wait for textlabel's size to update
+		await ApplyLabelContent(textLabel, testLabel);
+
+		// Wait for layout to settle
+		await ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
+		float targetHeight = bubbleLayout.Size.Y;
+		CustomMinimumSize = new Vector2(0, targetHeight);
+
+		// Wait one more frame for the container to reflow
 		await ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
 
-		testLabel.Visible = false;
-
-		// Apply size based on test label
-		textLabel.CustomMinimumSize = new(Mathf.Clamp(testLabel.Size.X + 48, 48, 320), 0);
-		textLabel.Size = textLabel.CustomMinimumSize;
-
 		Tween tween = CreateTween();
-		PropertyTweener tweener = tween.TweenProperty(this, "custom_minimum_size", new Vector2(0, textLabel.Size.Y + BubbleSizeOffset), 0.4f);
-		tweener.SetEase(Tween.EaseType.Out);
-		tweener.SetTrans(Tween.TransitionType.Back);
+		tween.TweenProperty(this, "custom_minimum_size", new Vector2(0, targetHeight), 0.4f)
+			.SetEase(Tween.EaseType.Out)
+			.SetTrans(Tween.TransitionType.Back);
 		tween.Play();
 
 		_animPlay.Play("appear");
@@ -44,9 +54,47 @@ public partial class BubbleItem : Control
 		Disappear();
 	}
 
+	private async Task ApplyLabelContent(RichTextLabel textLabel, Label testLabel)
+	{
+		string trimmedContent = Content.Trim();
+
+		int emojiCount = ImgSizeRegex.Matches(trimmedContent).Count;
+		bool isEmojiOnly = EmojiOnlyRegex.IsMatch(trimmedContent);
+
+		if (isEmojiOnly && emojiCount is > 0 and <= EmojiColumns)
+		{
+			textLabel.Text = ImgSizeRegex.Replace(Content, $"[img={BigEmojiSize}x{BigEmojiSize}]");
+			testLabel.Visible = false;
+
+			await ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
+
+			int width = emojiCount * BigEmojiSize + (emojiCount - 1) * EmojiSpacing + EmojiPadding;
+			textLabel.CustomMinimumSize = new(width, 0);
+		}
+		else
+		{
+			textLabel.Text = ImgSizeRegex.Replace(Content, $"[img={InlineEmojiSize}x{InlineEmojiSize}]");
+			testLabel.Text = Content;
+
+			await ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
+
+			testLabel.Visible = false;
+
+			// Apply size based on test label
+			textLabel.CustomMinimumSize = new(Mathf.Clamp(testLabel.Size.X + 48, 48, 320), 0);
+		}
+
+		// Wait for the layout to fully recompute with the updated minimum size
+		await ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
+	}
+
 	public async void Disappear()
 	{
-		if (!IsInsideTree()) { return; }
+		if (!IsInsideTree())
+		{
+			return;
+		}
+
 		_animPlay.Play("disappear");
 		await ToSignal(_animPlay, AnimationPlayer.SignalName.AnimationFinished);
 		QueueFree();


### PR DESCRIPTION
## Summary

Refactors the bubble chat system (specifically the items) to improve how emojis are rendered. Messages that only contain 1-4 emojis are displayed at a larger size (64px) rather than just inlined, which can make the message hard to read. Messages with more than 4 emojis or mixed content fall back to inlined rendering. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Before:
<img width="1152" height="648" alt="Godot_v4 6 3-stable_mono_win64_1qtBKIn6EK" src="https://github.com/user-attachments/assets/fd9bf3c6-c526-4dec-9b77-ffb9f43a4a7c" />

After:
<img width="1152" height="648" alt="Godot_v4 6 3-stable_mono_win64_Uauo4R0Cra" src="https://github.com/user-attachments/assets/ee7fda96-a6d2-4ecf-bcf6-155a0f9c9bf8" />

## AI/LLM use

The only area I used AI in was an issue where a multi-lined emoji message would overlap a single lined message, however I reverted the change it made and changed how the system worked to move around it.