### PR TITLE
Fix NPC.NavDestinationReached

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -404,7 +404,10 @@ public partial class NPC : Physical
 	public bool IsOnCeiling => CharBody3D.IsOnCeiling();
 
 	[ScriptProperty] public float NavDestinationDistance => _navAgent == null ? Mathf.Inf : _navAgent.DistanceToTarget();
-	[ScriptProperty] public bool NavDestinationReached => _navAgent != null && _navAgent.IsTargetReached();
+	
+	[ScriptProperty]
+	public bool NavDestinationReached { get; private set; } = false;
+	
 	[ScriptProperty] public bool NavDestinationValid => _navAgent != null && _navAgent.IsTargetReachable();
 
 	public Vector3 CharacterVelocity = Vector3.Zero;
@@ -1083,6 +1086,7 @@ public partial class NPC : Physical
 			}
 
 			_navAgent.NavigationFinished += OnNavFinished;
+			NavDestinationReached = false;
 		}
 		_navAgent.TargetPosition = pos;
 	}
@@ -1091,6 +1095,7 @@ public partial class NPC : Physical
 	{
 		_navAgentContainer?.QueueFree();
 		_navAgent = null;
+		NavDestinationReached = true;
 		NavFinished.Invoke();
 	}
 

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -404,10 +404,10 @@ public partial class NPC : Physical
 	public bool IsOnCeiling => CharBody3D.IsOnCeiling();
 
 	[ScriptProperty] public float NavDestinationDistance => _navAgent == null ? Mathf.Inf : _navAgent.DistanceToTarget();
-	
+
 	[ScriptProperty]
 	public bool NavDestinationReached { get; private set; } = false;
-	
+
 	[ScriptProperty] public bool NavDestinationValid => _navAgent != null && _navAgent.IsTargetReachable();
 
 	public Vector3 CharacterVelocity = Vector3.Zero;


### PR DESCRIPTION
## Summary

changes `NavDestinationReached` to manually track whether a navigation finished (set to true in `OnNavFinished` and to false in `SetNavDestination`)

I accidentally deleted the local branch for #614 this repost was unintentional :broken_heart:

## Related issue or discussion

Fixes #611

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [X] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None