### PR TITLE
make guild owners' .IsCreator value to true

### DIFF
--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -654,9 +654,9 @@ public sealed partial class NetworkService : Instance
 		plr.IsAdmin = userData.IsStaff;
 		plr.UserRoleClass = userData.UserRoleClass ?? "";
 
-		if(Root.WorldInfo.HasValue)
+		if (Root.WorldInfo.HasValue)
 		{
-			if(Root.WorldInfo.Value.Creator.Type == "guild")
+			if (Root.WorldInfo.Value.Creator.Type == "guild")
 			{
 				APIGuildInfo guildInfo = await PolyAPI.GetGuildFromID(Root.WorldInfo.Value.Creator.Id);
 				validateRes.IsCreator = guildInfo.Creator.Id == userData.Id ? true : false;

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -654,6 +654,14 @@ public sealed partial class NetworkService : Instance
 		plr.IsAdmin = userData.IsStaff;
 		plr.UserRoleClass = userData.UserRoleClass ?? "";
 
+		if(Root.WorldInfo.HasValue)
+		{
+			if(Root.WorldInfo.Value.Creator.Type == "guild")
+			{
+				APIGuildInfo guildInfo = await PolyAPI.GetGuildFromID(Root.WorldInfo.Value.Creator.Id);
+				validateRes.IsCreator = guildInfo.Creator.Id == userData.Id ? true : false;
+			}
+		}
 		// Apply validation data
 		plr.IsCreator = validateRes.IsCreator;
 		plr.IsAgeRestricted = validateRes.IsAgeRestricted;

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -621,6 +621,15 @@ public sealed partial class NetworkService : Instance
 			{
 				userData = await PolyAPI.GetUserFromID(validateRes.UserID);
 			}
+
+			if (Root.WorldInfo.HasValue)
+			{
+				if (Root.WorldInfo.Value.Creator.Type == "guild")
+				{
+					APIGuildInfo guildInfo = await PolyAPI.GetGuildFromID(Root.WorldInfo.Value.Creator.Id);
+					validateRes.IsCreator = guildInfo.Creator.Id == userData.Id ? true : false;
+				}
+			}
 		}
 		catch (Exception e)
 		{
@@ -653,15 +662,6 @@ public sealed partial class NetworkService : Instance
 		plr.Name = username;
 		plr.IsAdmin = userData.IsStaff;
 		plr.UserRoleClass = userData.UserRoleClass ?? "";
-
-		if (Root.WorldInfo.HasValue)
-		{
-			if (Root.WorldInfo.Value.Creator.Type == "guild")
-			{
-				APIGuildInfo guildInfo = await PolyAPI.GetGuildFromID(Root.WorldInfo.Value.Creator.Id);
-				validateRes.IsCreator = guildInfo.Creator.Id == userData.Id ? true : false;
-			}
-		}
 		// Apply validation data
 		plr.IsCreator = validateRes.IsCreator;
 		plr.IsAgeRestricted = validateRes.IsAgeRestricted;


### PR DESCRIPTION
## Summary

guild owners are now considered the creator of any game within their guild

## Related issue or discussion

Fixes #585

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)


## AI/LLM use

None