### PR TITLE
Sound fixes and new LoopStart feature

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -240,9 +240,7 @@ public sealed partial class Sound : Dynamic
 	[ScriptProperty] public bool Loading { get; private set; } = false;
 
 	[ScriptProperty]
-	public float Length => _audioPlayer != null
-				? (float)_audioPlayer.Stream.GetLength()
-				: _audioPlayer3D != null ? (float)_audioPlayer3D.Stream.GetLength() : 0;
+	public float Length => (_currentStream != null ? (float)_currentStream.GetLength() : 0);
 
 	[ScriptProperty] public PTSignal Loaded { get; private set; } = new();
 	[ScriptProperty] public PTSignal Finished { get; private set; } = new();

--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -34,6 +34,7 @@ public sealed partial class Sound : Dynamic
 	private float _volume = 1;
 	private float _time = 0;
 	private bool _loop = false;
+	private float _loopStart = 0;
 	private bool _playInWorld = false;
 	private bool _paused = false;
 	private float _pitch = 1f;
@@ -135,12 +136,33 @@ public sealed partial class Sound : Dynamic
 			switch (_currentStream)
 			{
 				case AudioStreamMP3 aStream:
-					aStream.LoopOffset = 0;
 					aStream.Loop = value;
 					break;
 				case AudioStreamOggVorbis aStream:
-					aStream.LoopOffset = 0;
 					aStream.Loop = value;
+					break;
+					// unused in Polytoria
+					//case AudioStreamWav aStream:
+			}
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float LoopStart
+	{
+		get => _loopStart;
+		set
+		{
+			_loopStart = value;
+
+			switch (_currentStream)
+			{
+				case AudioStreamMP3 aStream:
+					aStream.LoopOffset = value;
+					break;
+				case AudioStreamOggVorbis aStream:
+					aStream.LoopOffset = value;
 					break;
 					// unused in Polytoria
 					//case AudioStreamWav aStream:
@@ -521,7 +543,9 @@ public sealed partial class Sound : Dynamic
 		_currentStream = (AudioStream)audio;
 		_audioPlayer?.Stream = (AudioStream)audio;
 		_audioPlayer3D?.Stream = (AudioStream)audio;
-		Loop = _loop; // reapply to new stream
+		// reapply to new stream
+		LoopStart = _loopStart;
+		Loop = _loop;
 
 		Loaded.Invoke();
 

--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -21,6 +21,7 @@ public sealed partial class Sound : Dynamic
 {
 	public const float SoundDistanceMultipler = 1.25f;
 	private const float MinPitch = 0.001f;
+	private const float MaxVolume = 2;
 	private AudioAsset? _asset;
 	private AudioStreamPlayer? _audioPlayer;
 	private AudioStreamPlayer3D? _audioPlayer3D;
@@ -94,7 +95,7 @@ public sealed partial class Sound : Dynamic
 		get => _volume;
 		set
 		{
-			_volume = Mathf.Clamp(value, 0, 2);
+			_volume = Mathf.Clamp(value, 0, MaxVolume);
 			UpdateVolume();
 			OnPropertyChanged();
 		}
@@ -403,9 +404,9 @@ public sealed partial class Sound : Dynamic
 	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable)]
 	private void NetPlayOneshot(float volume)
 	{
-		if (volume > 1)
+		if (volume > MaxVolume)
 		{
-			volume = 1;
+			volume = MaxVolume;
 		}
 
 		InternalPlayOneShot(volume);

--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -154,6 +154,12 @@ public sealed partial class Sound : Dynamic
 		get => _loopStart;
 		set
 		{
+			// unclamped value is reapplied and clamped when Sound is loaded
+			if (_currentStream != null)
+			{
+				value = (float)Mathf.Clamp(value, 0, _currentStream.GetLength());
+			}
+
 			_loopStart = value;
 
 			switch (_currentStream)


### PR DESCRIPTION
## Summary

A couple of bugfixes to Sound and a new feature: LoopStart
Fix for Length nullpo, Volume not applied to OneShots.

While there is no LoopEnd currently \*glares at Godot\*, you can now has song with looping chorus. Or short musical instrument with attack before loop!

## Related issue or discussion

Fixes #502
Related to #569, #344

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

None