### PR TITLE
Move physics logic of NPC and Player to PhysicsProcess (#624)

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -562,10 +562,8 @@ public partial class NPC : Physical
 		_nametag.Position = NametagOffset + _fixedNametagOffset;
 	}
 
-	public override void Process(double delta)
+	public override void PhysicsProcess(double delta)
 	{
-		base.Process(delta);
-
 		if (Root == null) return;
 		if (Anchored || IsHidden) return;
 		if (!Root.IsLoaded) return;
@@ -601,97 +599,6 @@ public partial class NPC : Physical
 
 		if (Root.Network.LocalPeerID != NetworkAuthority && ExistInNetwork) return;
 
-		bool isOnFloor = CharBody3D.IsOnFloor();
-		bool isOnCeiling = CharBody3D.IsOnCeiling();
-		bool playerNPCOverride = this is Player p && !p.CanMove;
-
-		CharacterModel.CharacterModelStateEnum finalState = CharacterModel.CharacterModelStateEnum.Idle;
-		Vector3? walkTarget = null;
-		float animSpeed = 1;
-
-		if (MoveTarget != null)
-		{
-			walkTarget = MoveTarget.GetGlobalPosition();
-		}
-
-		if (_navAgent != null)
-		{
-			walkTarget = _navAgent.GetNextPathPosition();
-
-			// Adjust Nav agent position in-case of unstable Y position changes
-			_navAgentContainer?.GlobalPosition = _navAgentContainer.GlobalPosition with { Y = walkTarget.Value.Y };
-		}
-
-		if (walkTarget.HasValue)
-		{
-			Vector3 velo = GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Position.Y });
-			CharacterVelocity = new(velo.X * WalkSpeed, CharacterVelocity.Y, velo.Z * WalkSpeed);
-			GDNode3D.GlobalRotationDegrees = new Vector3(Rotation.X, Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Rotation.Y), Mathf.Atan2(CharacterVelocity.X, CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, BodyRotateLerp))), Rotation.Z);
-
-			float distanceToTarget = GetGlobalPosition().DistanceTo(walkTarget.Value);
-
-			if (distanceToTarget > 0.5f)
-			{
-				finalState = CharacterModel.CharacterModelStateEnum.Walking;
-				animSpeed = WalkSpeed / 8;
-				TryStepUp();
-			}
-		}
-		else if (this is not Player || playerNPCOverride)
-		{
-			CharacterVelocity = new(0, CharacterVelocity.Y, 0);
-		}
-
-		if (!isOnFloor)
-		{
-			finalState = CharacterModel.CharacterModelStateEnum.Jumping;
-		}
-
-		if (this is not Player || playerNPCOverride)
-		{
-			Character?.SetState(finalState);
-			Character?.SetAnimSpeed(animSpeed);
-		}
-
-		// Apply gravity
-		if (!isOnFloor)
-		{
-			CharacterVelocity.Y += Root.Environment.Gravity.Y * (float)delta;
-		}
-		else if (isOnFloor && CharacterVelocity.Y < 0)
-		{
-			// Cancel downward velocity when on floor
-			CharacterVelocity.Y = 0;
-		}
-
-		// Prevent sticking
-		if (isOnCeiling && CharacterVelocity.Y > 0)
-		{
-			CharacterVelocity.Y = 0;
-		}
-
-		UpdateVelocityInternal(CharacterVelocity);
-		if (this is not Player)
-		{
-			CharBody3D.Velocity = Velocity;
-			CharBody3D.MoveAndSlide();
-		}
-
-		if (isOnFloor != _lastOnFloorState)
-		{
-			_lastOnFloorState = isOnFloor;
-
-			// On floor change
-			if (isOnFloor)
-			{
-				_coyoteUsed = false;
-				Landed.Invoke();
-			}
-		}
-	}
-
-	public override void PhysicsProcess(double delta)
-	{
 		if (CharBody3D != null)
 		{
 			bool isOnFloor = CharBody3D.IsOnFloor();
@@ -704,7 +611,95 @@ public partial class NPC : Physical
 			{
 				_timeSinceGrounded += (float)delta;
 			}
+
+			bool isOnCeiling = CharBody3D.IsOnCeiling();
+			bool playerNPCOverride = this is Player p && !p.CanMove;
+
+			CharacterModel.CharacterModelStateEnum finalState = CharacterModel.CharacterModelStateEnum.Idle;
+			Vector3? walkTarget = null;
+			float animSpeed = 1;
+
+			if (MoveTarget != null)
+			{
+				walkTarget = MoveTarget.GetGlobalPosition();
+			}
+
+			if (_navAgent != null)
+			{
+				walkTarget = _navAgent.GetNextPathPosition();
+
+				// Adjust Nav agent position in-case of unstable Y position changes
+				_navAgentContainer?.GlobalPosition = _navAgentContainer.GlobalPosition with { Y = walkTarget.Value.Y };
+			}
+
+			if (walkTarget.HasValue)
+			{
+				Vector3 velo = GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Position.Y });
+				CharacterVelocity = new(velo.X * WalkSpeed, CharacterVelocity.Y, velo.Z * WalkSpeed);
+				GDNode3D.GlobalRotationDegrees = new Vector3(Rotation.X, Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Rotation.Y), Mathf.Atan2(CharacterVelocity.X, CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, BodyRotateLerp))), Rotation.Z);
+
+				float distanceToTarget = GetGlobalPosition().DistanceTo(walkTarget.Value);
+
+				if (distanceToTarget > 0.5f)
+				{
+					finalState = CharacterModel.CharacterModelStateEnum.Walking;
+					animSpeed = WalkSpeed / 8;
+					TryStepUp();
+				}
+			}
+			else if (this is not Player || playerNPCOverride)
+			{
+				CharacterVelocity = new(0, CharacterVelocity.Y, 0);
+			}
+
+			if (!isOnFloor)
+			{
+				finalState = CharacterModel.CharacterModelStateEnum.Jumping;
+			}
+
+			if (this is not Player || playerNPCOverride)
+			{
+				Character?.SetState(finalState);
+				Character?.SetAnimSpeed(animSpeed);
+			}
+
+			// Apply gravity
+			if (!isOnFloor)
+			{
+				CharacterVelocity.Y += Root.Environment.Gravity.Y * (float)delta;
+			}
+			else if (isOnFloor && CharacterVelocity.Y < 0)
+			{
+				// Cancel downward velocity when on floor
+				CharacterVelocity.Y = 0;
+			}
+
+			// Prevent sticking
+			if (isOnCeiling && CharacterVelocity.Y > 0)
+			{
+				CharacterVelocity.Y = 0;
+			}
+
+			UpdateVelocityInternal(CharacterVelocity);
+			if (this is not Player)
+			{
+				CharBody3D.Velocity = Velocity;
+				CharBody3D.MoveAndSlide();
+			}
+
+			if (isOnFloor != _lastOnFloorState)
+			{
+				_lastOnFloorState = isOnFloor;
+
+				// On floor change
+				if (isOnFloor)
+				{
+					_coyoteUsed = false;
+					Landed.Invoke();
+				}
+			}
 		}
+
 		base.PhysicsProcess(delta);
 	}
 

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -550,55 +550,6 @@ public sealed partial class Player : NPC
 		{
 			return;
 		}
-
-		if (Anchored)
-		{
-			// just in case it's anchored cuz ragdoll
-			if (Character is PolytorianModel pt && pt.Ragdolling == false)
-			{
-				UpdateCamera(delta);
-			}
-			AfkTick(delta);
-			return;
-		}
-
-		Camera? cam = Root.Environment.CurrentCamera;
-
-		// Apply camera modifier if enabled
-		if (UseHeadTurning && cam != null && cam.Mode == Camera.CameraModeEnum.Follow && cam.Target == CamAttach)
-		{
-			Character?.ApplyCameraModifier(cam);
-		}
-
-		if (IsSitting)
-		{
-			// Add stamina while sitting
-			AddStaminaTick(delta);
-			UpdateCamera(delta);
-			return;
-		}
-
-		if (PlayerMovement != null)
-		{
-			var snapshot = PlayerMovement.SampleInput(delta);
-			PlayerMovement.ProcessInput(snapshot);
-		}
-		else
-		{
-			IsMoving = Velocity.Length() > 0.01f;
-		}
-
-		// Stop animation on move
-		if (IsMoving && !AllowAnimationWhileMoving)
-		{
-			Character?.Animator?.StopAnimation();
-		}
-
-		// Update camera right after position set
-		UpdateCamera(delta);
-		AfkTick(delta);
-
-		ApplyPushForce();
 	}
 
 	private void UpdateCamera(double delta)
@@ -709,6 +660,55 @@ public sealed partial class Player : NPC
 		{
 			EndClimb();
 		}
+
+		if (Anchored)
+		{
+			// just in case it's anchored cuz ragdoll
+			if (Character is PolytorianModel pt2 && pt2.Ragdolling == false)
+			{
+				UpdateCamera(delta);
+			}
+			AfkTick(delta);
+			return;
+		}
+
+		Camera? cam = Root.Environment.CurrentCamera;
+
+		// Apply camera modifier if enabled
+		if (UseHeadTurning && cam != null && cam.Mode == Camera.CameraModeEnum.Follow && cam.Target == CamAttach)
+		{
+			Character?.ApplyCameraModifier(cam);
+		}
+
+		if (IsSitting)
+		{
+			// Add stamina while sitting
+			AddStaminaTick(delta);
+			UpdateCamera(delta);
+			return;
+		}
+
+		if (PlayerMovement != null)
+		{
+			var snapshot = PlayerMovement.SampleInput(delta);
+			PlayerMovement.ProcessInput(snapshot);
+		}
+		else
+		{
+			IsMoving = Velocity.Length() > 0.01f;
+		}
+
+		// Stop animation on move
+		if (IsMoving && !AllowAnimationWhileMoving)
+		{
+			Character?.Animator?.StopAnimation();
+		}
+
+		// Update camera right after position set
+		UpdateCamera(delta);
+		AfkTick(delta);
+
+		ApplyPushForce();
 
 		base.PhysicsProcess(delta);
 	}


### PR DESCRIPTION
## Summary

Physics logic in NPC and Player moved from Process to PhysicsProcess. The reason this bug happens is because godot processes Process every frame versus PhysicsProcess at intervals.

## Related issue or discussion

Fixes #624 
Related to #411

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/f122c143-e565-418c-90ad-5e69ffd45703

## AI/LLM use

None