### PR TITLE
[Refactor] Network packet sequence handling

### DIFF
--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -1241,23 +1241,23 @@ public partial class NetworkedObject : IScriptObject
 
 		NetworkedObject? existingObj = null;
 
-		if (existingObj == null)
+
+		if (this is Instance i3)
 		{
-			if (this is Instance i)
-			{
-				existingObj = i.FindChild(objName);
-			}
-			else
-			{
-				existingObj = FindNonInstanceChild(objName);
-			}
+			existingObj = i3.FindChild(objName);
 		}
+		else
+		{
+			existingObj = FindNonInstanceChild(objName);
+		}
+
 
 		if (existingObj != null)
 		{
 			NetworkedObject netObj = existingObj;
 
-			if (data.Sequence < netObj.AppliedSequence) return; // Decline sequence
+			// Decline any packet with a sequence number older or equal to the latest applied.
+			if (data.Sequence <= netObj.AppliedSequence) return;
 
 			netObj.Root = Root;
 			netObj.ExistInNetwork = true;


### PR DESCRIPTION
## Summary

**Refactor:**
- Removed a ``if (existingObj == null)`` check. Since ``existingObj`` is initialized to ``null`` immediately before the block, so the condition would always be ``true``.
- Updated the sequence number check. Changed the check from ``data.Sequence < netObj.AppliedSequence`` to ``data.Sequence <= netObj.AppliedSequence``. This prevents the system from re-processing packets that have a sequence number equal to the ones already applied, ensuring protection against duplicate packets.

This might Fix potential Bugs or Lags from Users that have a unreliable Network and it reduces CPU usage.

<img width="1032" height="190" alt="image" src="https://github.com/user-attachments/assets/bf465a65-2cf1-4820-bd36-8c1ae4f7ff67" />
Own Execution time (Blue) down almost 50% (Tested on a Map with 1000 Instances for 30 sec).
Its a minor optimization at low scales but might can become more beneficial as map complexity and online time of a Player grow.

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [x] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use
None