### PR TITLE
Fix NetworkedObject.Equals

### DIFF
--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -1991,7 +1991,7 @@ public partial class NetworkedObject : IScriptObject
 	}
 
 	[ScriptMetamethod(ScriptObjectMetamethod.Eq)]
-	public static bool MetamethodEquals(object? a, object? b) => (a is NetworkedObject netobj) && netobj.Equals(b);
+	public static bool MetamethodEquals(object? a, object? b) => a is NetworkedObject netobj && netobj.Equals(b);
 
 	internal IEnumerable<PropertyInfo> GetEditableProperties()
 	{
@@ -2026,7 +2026,10 @@ public partial class NetworkedObject : IScriptObject
 #pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
 	}
 
-	public override bool Equals(object? obj) => (obj is NetworkedObject netobj) && ((ExistInNetwork && netobj.ExistInNetwork) ? NetworkedObjectID == netobj.NetworkedObjectID : ObjectID == netobj.ObjectID);
+	public override bool Equals(object? obj) =>
+		obj is NetworkedObject netobj &&
+		ExistInNetwork == netobj.ExistInNetwork &&
+		(ExistInNetwork ? NetworkedObjectID == netobj.NetworkedObjectID : ObjectID == netobj.ObjectID);
 
 	public override int GetHashCode()
 	{

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -1991,7 +1991,7 @@ public partial class NetworkedObject : IScriptObject
 	}
 
 	[ScriptMetamethod(ScriptObjectMetamethod.Eq)]
-	public static bool MetamethodEquals(object? a, object? b) => (a is NetworkedObject netobj) && netobj == b;
+	public static bool MetamethodEquals(object? a, object? b) => (a is NetworkedObject netobj) && netobj.Equals(b);
 
 	internal IEnumerable<PropertyInfo> GetEditableProperties()
 	{

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -75,7 +75,7 @@ public partial class NetworkedObject : IScriptObject
 			{
 				selfpreI.RemoveNameFromParent();
 				selfpreI.RemoveLegacyNameFromParent();
-				preI.Children.Remove(selfpreI);
+				preI.Children.RemoveAt(selfpreI.Index);
 				preI.ChildRemoved.Invoke(selfpreI);
 			}
 

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -75,7 +75,7 @@ public partial class NetworkedObject : IScriptObject
 			{
 				selfpreI.RemoveNameFromParent();
 				selfpreI.RemoveLegacyNameFromParent();
-				preI.Children.RemoveAt(selfpreI.Index);
+				preI.Children.Remove(selfpreI);
 				preI.ChildRemoved.Invoke(selfpreI);
 			}
 

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -1991,12 +1991,7 @@ public partial class NetworkedObject : IScriptObject
 	}
 
 	[ScriptMetamethod(ScriptObjectMetamethod.Eq)]
-	public static bool MetamethodEquals(object? a, object? b)
-	{
-		if (a is not NetworkedObject) return false;
-		if (b is not NetworkedObject) return false;
-		return ((NetworkedObject)a).NetworkedObjectID.Equals(((NetworkedObject)b).NetworkedObjectID);
-	}
+	public static bool MetamethodEquals(object? a, object? b) => (a is NetworkedObject netobj) && netobj == b;
 
 	internal IEnumerable<PropertyInfo> GetEditableProperties()
 	{
@@ -2031,10 +2026,7 @@ public partial class NetworkedObject : IScriptObject
 #pragma warning restore IL2070 // 'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method. The parameter of method does not have matching annotations.
 	}
 
-	public override bool Equals(object? obj)
-	{
-		return obj is NetworkedObject item && NetworkedObjectID.Equals(item.NetworkedObjectID);
-	}
+	public override bool Equals(object? obj) => (obj is NetworkedObject netobj) && ((ExistInNetwork && netobj.ExistInNetwork) ? NetworkedObjectID == netobj.NetworkedObjectID : ObjectID == netobj.ObjectID);
 
 	public override int GetHashCode()
 	{


### PR DESCRIPTION
## Summary

changed `NetworkedObject.Equals` logic to support comparing objects not in the network

## Related issue or discussion

Fixes #637

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None