### PR TITLE
Edit Plaintext and Markdown in Built-in Editor

### DIFF
--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -407,6 +407,25 @@ public partial class CreatorInterface : Control, IScriptObject
 		}, "Give Folder name");
 	}
 
+	public void PromptCreateFile(string atPath)
+	{
+		if (CreatorService.CurrentSession == null) return;
+		CreatorSession session = CreatorService.CurrentSession;
+		PromptGiveName("File name...", async name =>
+		{
+			try
+			{
+				string createAt = Path.Join(atPath, name).SanitizePath();
+				await session.CreateFile(createAt);
+			}
+			catch (Exception ex)
+			{
+				PT.PrintErr(ex);
+				PopupAlert(ex.Message, "Error creating file");
+			}
+		}, "Give File name");
+	}
+
 
 	public void PromptCreateWorld(string atPath)
 	{

--- a/Polytoria/scripts/creator/CreatorSession.cs
+++ b/Polytoria/scripts/creator/CreatorSession.cs
@@ -523,6 +523,21 @@ return module";
 		RescanFolder();
 	}
 
+	public async Task CreateFile(string atPath)
+	{
+		atPath = atPath.SanitizePath();
+		string globalized = GlobalizePath(atPath);
+
+		if (File.Exists(globalized))
+		{
+			throw new Exception("File already exists");
+		}
+
+		await File.WriteAllBytesAsync(globalized, []);
+		FileBrowserTab.AutoSelects.Add(atPath);
+		RescanFolder();
+	}
+
 	public void RemoveFile(string src, bool toRecycleBin = false)
 	{
 		if (src == Globals.ProjectMetaFileName) throw new InvalidOperationException("Cannot delete the project metadata file");

--- a/Polytoria/scripts/creator/ui/Tabs.cs
+++ b/Polytoria/scripts/creator/ui/Tabs.cs
@@ -153,7 +153,8 @@ public sealed partial class Tabs : Control
 				CurrentControl = existing;
 				return;
 			}
-			TextEditorContainer tec = new(txt.TargetPath, fullPath, txt.Session) { OriginTabName = txt.Title ?? "" };
+
+			TextEditorContainer tec = new(txt.TargetPath, fullPath, txt.CodeCompletion, txt.Session) { OriginTabName = txt.Title ?? "" };
 			container = tec;
 			ScriptTypeEnum st = CreatorService.GetScriptTypeFromPath(txt.TargetPath);
 			icon = st switch
@@ -250,6 +251,7 @@ public sealed partial class Tabs : Control
 	{
 		public string TargetPath = null!;
 		public CreatorSession Session = null!;
+		public FileTypeEnum CodeCompletion = FileTypeEnum.Lua;
 	}
 
 	public class GameTab : TabData

--- a/Polytoria/scripts/creator/ui/ctxmenus/FileItemContextMenu.cs
+++ b/Polytoria/scripts/creator/ui/ctxmenus/FileItemContextMenu.cs
@@ -54,8 +54,9 @@ public partial class FileItemContextMenu : ContextMenu
 			{
 				_newMenu = new();
 				SetIconItem(_newMenu, "folder", "Folder", 1);
-				SetIconItem(_newMenu, "script", "Script", 2);
-				SetIconItem(_newMenu, "planet", "World", 3);
+				SetIconItem(_newMenu, "script", "File", 2);
+				SetIconItem(_newMenu, "script", "Script", 3);
+				SetIconItem(_newMenu, "planet", "World", 4);
 				_newMenu.IdPressed += OnNewMenuIdPressed;
 
 				AddSubmenuNodeItem("New", _newMenu, 1);
@@ -99,10 +100,13 @@ public partial class FileItemContextMenu : ContextMenu
 			case 1: // New Folder
 				CreatorService.Interface.PromptCreateFolder(Target!);
 				break;
-			case 2: // New Script
+			case 2: // New File
+				CreatorService.Interface.PromptCreateFile(atPath: Target);
+				break;
+			case 3: // New Script
 				CreatorService.Interface.PromptCreateScript(atPath: Target);
 				break;
-			case 3: // New World
+			case 4: // New World
 				CreatorService.Interface.PromptCreateWorld(Target!);
 				break;
 		}

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorContainer.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorContainer.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using Godot;
+using Polytoria.Datamodel.Creator;
 
 namespace Polytoria.Creator.UI.TextEditor;
 
@@ -14,13 +15,15 @@ public sealed partial class TextEditorContainer : Control
 	public string TargetFilePath = "";
 	public string TargetFilePathAbsolute = "";
 	public string OriginTabName = "";
+	public FileTypeEnum CodeCompletion = FileTypeEnum.Plaintext;
 	public CreatorSession TargetSession;
 
-	public TextEditorContainer(string path, string fpath, CreatorSession session)
+	public TextEditorContainer(string path, string fpath, FileTypeEnum codeCompletion, CreatorSession session)
 	{
 		TargetFilePath = path;
 		TargetFilePathAbsolute = fpath;
 		TargetSession = session;
+		CodeCompletion = codeCompletion;
 		EditorRoot = _textEditorPacked.Instantiate<TextEditorRoot>();
 		EditorRoot.Container = this;
 	}

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -229,13 +229,13 @@ public partial class TextEditorRoot : Node
 		_highlighter = new();
 		CodeEditor.SyntaxHighlighter = _highlighter;
 
-		_highlighter.FunctionColor = ColorWarn;
-		_highlighter.MemberVariableColor = ColorWhite;
-		_highlighter.NumberColor = ColorSuccess;
-		_highlighter.SymbolColor = ColorWhite;
-
 		if (fileType == FileTypeEnum.Lua)
 		{
+			_highlighter.FunctionColor = ColorWarn;
+			_highlighter.MemberVariableColor = ColorWhite;
+			_highlighter.NumberColor = ColorSuccess;
+			_highlighter.SymbolColor = ColorWhite;
+
 			foreach (string item in LuaCompletionService.LuaKeywords)
 			{
 				_highlighter.AddKeywordColor(item, ColorDanger);
@@ -251,6 +251,13 @@ public partial class TextEditorRoot : Node
 			CodeEditor.AddStringDelimiter("\"", "\"", true);
 			CodeEditor.AddStringDelimiter("'", "'", true);
 			CodeEditor.AddStringDelimiter("[[", "]]", false);
+		}
+		else
+		{
+			_highlighter.FunctionColor = ColorWhite;
+			_highlighter.MemberVariableColor = ColorWhite;
+			_highlighter.NumberColor = ColorWhite;
+			_highlighter.SymbolColor = ColorWhite;
 		}
 	}
 

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -70,20 +70,24 @@ public partial class TextEditorRoot : Node
 		_autoCompleteTimer.OneShot = true;
 		_autoCompleteTimer.Timeout += OnCompletionRequest;
 
-		_completion = Container.TargetSession.LuaCompletion;
-		_completion?.PublishDiagnostics += OnPublishDiagnostics;
+		if (Container.CodeCompletion == FileTypeEnum.Lua)
+		{
+			_completion = Container.TargetSession.LuaCompletion;
+			_completion?.PublishDiagnostics += OnPublishDiagnostics;
+
+			CodeEditor.CodeCompletionPrefixes = [".", ":", "\n", ",", " ", "("];
+			CodeEditor.CodeCompletionEnabled = true;
+			CodeEditor.CodeCompletionRequested += OnCompletionRequest;
+		}
 
 		CodeEditor.Text = File.ReadAllText(Container.TargetFilePathAbsolute);
 		CodeEditor.ClearUndoHistory();
 		CodeEditor.TextChanged += OnCodeEditTextChanged;
-		InitSyntaxHighlighter();
+		InitSyntaxHighlighter(Container.CodeCompletion);
 
 		CreatorSettingsService.Instance.Changed += OnCreatorSettingChanged;
 		ApplyIndentSettings();
 
-		CodeEditor.CodeCompletionPrefixes = [".", ":", "\n", ",", " ", "("];
-		CodeEditor.CodeCompletionEnabled = true;
-		CodeEditor.CodeCompletionRequested += OnCompletionRequest;
 		CodeEditor.GuiInput += OnCodeEditGUIInput;
 
 		CodeEditor.GuttersDrawLineNumbers = true;
@@ -220,30 +224,33 @@ public partial class TextEditorRoot : Node
 		}
 	}
 
-	private void InitSyntaxHighlighter()
+	private void InitSyntaxHighlighter(FileTypeEnum fileType)
 	{
 		_highlighter = new();
 		CodeEditor.SyntaxHighlighter = _highlighter;
 
-		foreach (string item in LuaCompletionService.LuaKeywords)
+		if (fileType == FileTypeEnum.Lua)
 		{
-			_highlighter.AddKeywordColor(item, ColorDanger);
+			foreach (string item in LuaCompletionService.LuaKeywords)
+			{
+				_highlighter.AddKeywordColor(item, ColorDanger);
+			}
+
+			_highlighter.AddColorRegion("\"", "\"", ColorWarn);
+			_highlighter.AddColorRegion("'", "'", ColorWarn);
+			_highlighter.AddColorRegion("`", "`", ColorWarn);
+			_highlighter.AddColorRegion("[[", "]]", ColorWarn);
+			_highlighter.AddColorRegion("--[[", "]]", ColorGrey);
+			_highlighter.AddColorRegion("--", "", ColorGrey);
+			_highlighter.FunctionColor = ColorWarn;
+			_highlighter.MemberVariableColor = ColorWhite;
+			_highlighter.NumberColor = ColorSuccess;
+			_highlighter.SymbolColor = ColorWhite;
+
+			CodeEditor.AddStringDelimiter("\"", "\"", true);
+			CodeEditor.AddStringDelimiter("'", "'", true);
+			CodeEditor.AddStringDelimiter("[[", "]]", false);
 		}
-
-		_highlighter.AddColorRegion("\"", "\"", ColorWarn);
-		_highlighter.AddColorRegion("'", "'", ColorWarn);
-		_highlighter.AddColorRegion("`", "`", ColorWarn);
-		_highlighter.AddColorRegion("[[", "]]", ColorWarn);
-		_highlighter.AddColorRegion("--[[", "]]", ColorGrey);
-		_highlighter.AddColorRegion("--", "", ColorGrey);
-		_highlighter.FunctionColor = ColorWarn;
-		_highlighter.MemberVariableColor = ColorWhite;
-		_highlighter.NumberColor = ColorSuccess;
-		_highlighter.SymbolColor = ColorWhite;
-
-		CodeEditor.AddStringDelimiter("\"", "\"", true);
-		CodeEditor.AddStringDelimiter("'", "'", true);
-		CodeEditor.AddStringDelimiter("[[", "]]", false);
 	}
 
 	public void Save()

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -229,6 +229,11 @@ public partial class TextEditorRoot : Node
 		_highlighter = new();
 		CodeEditor.SyntaxHighlighter = _highlighter;
 
+		_highlighter.FunctionColor = ColorWarn;
+		_highlighter.MemberVariableColor = ColorWhite;
+		_highlighter.NumberColor = ColorSuccess;
+		_highlighter.SymbolColor = ColorWhite;
+
 		if (fileType == FileTypeEnum.Lua)
 		{
 			foreach (string item in LuaCompletionService.LuaKeywords)
@@ -242,10 +247,6 @@ public partial class TextEditorRoot : Node
 			_highlighter.AddColorRegion("[[", "]]", ColorWarn);
 			_highlighter.AddColorRegion("--[[", "]]", ColorGrey);
 			_highlighter.AddColorRegion("--", "", ColorGrey);
-			_highlighter.FunctionColor = ColorWarn;
-			_highlighter.MemberVariableColor = ColorWhite;
-			_highlighter.NumberColor = ColorSuccess;
-			_highlighter.SymbolColor = ColorWhite;
 
 			CodeEditor.AddStringDelimiter("\"", "\"", true);
 			CodeEditor.AddStringDelimiter("'", "'", true);

--- a/Polytoria/scripts/datamodel/creator/CreatorService.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorService.cs
@@ -381,8 +381,9 @@ public sealed partial class CreatorService : Node, IScriptObject
 			{
 				codeCompletion = FileTypeEnum.Lua;
 			}
-	
-			Tabs.Singleton.Insert(new Tabs.TextEditorTab() {
+
+			Tabs.Singleton.Insert(new Tabs.TextEditorTab()
+			{
 				Session = CurrentSession,
 				TargetPath = pathRelative,
 				CodeCompletion = codeCompletion,

--- a/Polytoria/scripts/datamodel/creator/CreatorService.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorService.cs
@@ -374,16 +374,23 @@ public sealed partial class CreatorService : Node, IScriptObject
 
 		PreferredEditorEnum userPref = CreatorSettingsService.Instance.Get<PreferredEditorEnum>(CreatorSettingKeys.CodeEditor.PreferredEditor);
 
-		if (Globals.ScriptFileExtensions.Contains(path.GetExtension()))
+		if (userPref == PreferredEditorEnum.BuiltIn)
 		{
-			if (userPref == PreferredEditorEnum.BuiltIn)
+			FileTypeEnum codeCompletion = FileTypeEnum.Plaintext;
+			if (Globals.ScriptFileExtensions.Contains(path.GetExtension()))
 			{
-				Tabs.Singleton.Insert(new Tabs.TextEditorTab() { Session = CurrentSession, TargetPath = pathRelative, Title = pathRelative.GetFile() });
-				return;
+				codeCompletion = FileTypeEnum.Lua;
 			}
+	
+			Tabs.Singleton.Insert(new Tabs.TextEditorTab() {
+				Session = CurrentSession,
+				TargetPath = pathRelative,
+				CodeCompletion = codeCompletion,
+				Title = pathRelative.GetFile()
+			});
+			return;
 		}
-
-		if (userPref == PreferredEditorEnum.VSCode)
+		else if (userPref == PreferredEditorEnum.VSCode)
 		{
 			CurrentSession.CreateVSCodeConfig();
 			// open in vscode
@@ -643,4 +650,10 @@ public enum ScriptTypeEnum
 	Client,
 	Module,
 	Unknown
+}
+
+public enum FileTypeEnum
+{
+	Plaintext,
+	Lua
 }


### PR DESCRIPTION
## Summary

This pull request implements the ability to edit plaintext files within the built-in code editor without having to use an external editor. This also includes markdown files as well.

## Related issue or discussion

Fixes #318

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Not sure how much needs to be shown here.

## AI/LLM use

No AI/LLMs were used in the making of this pull request.