### PR TITLE
[Small fix] Correct the size of ctrl lock cursor SVGs

### DIFF
--- a/Polytoria/assets/textures/client/cursor/ctrl-lock/chevron.svg
+++ b/Polytoria/assets/textures/client/cursor/ctrl-lock/chevron.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
@@ -53,7 +53,8 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="scale(1.5)">
     <g
        id="g2">
       <rect

--- a/Polytoria/assets/textures/client/cursor/ctrl-lock/dot.svg
+++ b/Polytoria/assets/textures/client/cursor/ctrl-lock/dot.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
@@ -53,7 +53,8 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="scale(1.5)">
     <circle
        style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
        id="path5"

--- a/Polytoria/assets/textures/client/cursor/ctrl-lock/plus.svg
+++ b/Polytoria/assets/textures/client/cursor/ctrl-lock/plus.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
@@ -53,7 +53,8 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="scale(1.5)">
     <g
        id="g2-3-7">
       <rect

--- a/Polytoria/assets/textures/client/cursor/ctrl-lock/stereotypical-dot.svg
+++ b/Polytoria/assets/textures/client/cursor/ctrl-lock/stereotypical-dot.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
@@ -53,7 +53,8 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="scale(1.5)">
     <g
        id="g2-3-2-6-2">
       <rect

--- a/Polytoria/assets/textures/client/cursor/ctrl-lock/stereotypical.svg
+++ b/Polytoria/assets/textures/client/cursor/ctrl-lock/stereotypical.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
@@ -53,7 +53,8 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="scale(1.5)">
     <g
        id="g2-3-2-6">
       <rect

--- a/Polytoria/assets/textures/client/cursor/ctrl-lock/tactical-dot.svg
+++ b/Polytoria/assets/textures/client/cursor/ctrl-lock/tactical-dot.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
@@ -53,7 +53,8 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="scale(1.5)">
     <g
        id="g2-3-2-3"
        transform="translate(0,-24)">

--- a/Polytoria/assets/textures/client/cursor/ctrl-lock/tactical.svg
+++ b/Polytoria/assets/textures/client/cursor/ctrl-lock/tactical.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
@@ -53,7 +53,8 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="scale(1.5)">
     <g
        id="g2-3-2">
       <rect

--- a/Polytoria/assets/textures/client/cursor/ctrl-lock/x.svg
+++ b/Polytoria/assets/textures/client/cursor/ctrl-lock/x.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="24"
-   height="24"
-   viewBox="0 0 24 24"
+   width="36"
+   height="36"
+   viewBox="0 0 36 36"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
@@ -53,7 +53,8 @@
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1">
+     id="layer1"
+     transform="scale(1.5)">
     <g
        id="g2-3">
       <rect


### PR DESCRIPTION
## Summary

This PR simply changes the size of all ctrl lock cursor SVG files from 24x24 to 36x36 to match the texture size displayed on screen. This drastically reduces the blurriness of the cursors (see examples below).

## Related issue or discussion

No related issue or discussion.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Comparisons for 3 cursors with the correct size (right) and the downscaled size (left):
<img width="1920" height="957" alt="comparison0" src="https://github.com/user-attachments/assets/7ffeef64-00a9-43b4-9ee7-59e9d79b9cc2" />
<img width="1920" height="952" alt="comparison1" src="https://github.com/user-attachments/assets/8a149d70-79b0-4895-a018-e5ac3dcbe549" />
<img width="1920" height="952" alt="comparison2" src="https://github.com/user-attachments/assets/8eb9607f-2bb3-4b03-9ac4-4089f3171a90" />


## AI/LLM use

None.