### PR TITLE
Fix PlayOneShot with looped sounds

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -133,17 +133,7 @@ public sealed partial class Sound : Dynamic
 		{
 			_loop = value;
 
-			switch (_currentStream)
-			{
-				case AudioStreamMP3 aStream:
-					aStream.Loop = value;
-					break;
-				case AudioStreamOggVorbis aStream:
-					aStream.Loop = value;
-					break;
-					// unused in Polytoria
-					//case AudioStreamWav aStream:
-			}
+			SetStreamLoop(_currentStream, value);
 			OnPropertyChanged();
 		}
 	}
@@ -162,17 +152,7 @@ public sealed partial class Sound : Dynamic
 
 			_loopStart = value;
 
-			switch (_currentStream)
-			{
-				case AudioStreamMP3 aStream:
-					aStream.LoopOffset = value;
-					break;
-				case AudioStreamOggVorbis aStream:
-					aStream.LoopOffset = value;
-					break;
-					// unused in Polytoria
-					//case AudioStreamWav aStream:
-			}
+			SetStreamLoopStart(_currentStream, value);
 			OnPropertyChanged();
 		}
 	}
@@ -500,6 +480,7 @@ public sealed partial class Sound : Dynamic
 
 			clone.Finished += f;
 
+			SetStreamLoop(clone.Stream, false);
 			clone.Play();
 		}
 
@@ -519,6 +500,7 @@ public sealed partial class Sound : Dynamic
 
 			clone3D.Finished += f;
 
+			SetStreamLoop(clone3D.Stream, false);
 			clone3D.Play();
 		}
 	}
@@ -559,6 +541,36 @@ public sealed partial class Sound : Dynamic
 		{
 			_playAfterLoad = false;
 			InternalPlay();
+		}
+	}
+
+	private static void SetStreamLoop(AudioStream? stream, bool val)
+	{
+		switch (stream)
+		{
+			case AudioStreamMP3 aStream:
+				aStream.Loop = val;
+				break;
+			case AudioStreamOggVorbis aStream:
+				aStream.Loop = val;
+				break;
+				// unused in Polytoria
+				//case AudioStreamWav aStream:
+		}
+	}
+
+	private static void SetStreamLoopStart(AudioStream? stream, float val)
+	{
+		switch (stream)
+		{
+			case AudioStreamMP3 aStream:
+				aStream.LoopOffset = val;
+				break;
+			case AudioStreamOggVorbis aStream:
+				aStream.LoopOffset = val;
+				break;
+				// unused in Polytoria
+				//case AudioStreamWav aStream:
 		}
 	}
 }


### PR DESCRIPTION
Oops! PlayOneShot should never, ever loop.

## Summary

I forgot to disable Loop property of cloned PlayOneShot sounds.

## Related issue or discussion

Related to #406

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

## AI/LLM use

None.