### PR TITLE
fix positioning of chat bubble when a part is parented to the player

### DIFF
--- a/Polytoria/scripts/client/spatial/chat/BubbleChat.cs
+++ b/Polytoria/scripts/client/spatial/chat/BubbleChat.cs
@@ -13,7 +13,7 @@ public partial class BubbleChat : Node3D
 {
 	public string BubbleItemPath = "res://scenes/client/spatial/chat/bubble_item.tscn";
 	private const int BubbleCountLimit = 5;
-	public const float BubbleHeightMinus = 2f;
+	public const float BubbleHeightPlus = 4f;
 	private readonly List<BubbleItem> _activeBubbles = [];
 
 	[Export] private Control _itemContainer = null!;
@@ -33,16 +33,16 @@ public partial class BubbleChat : Node3D
 
 	private void OnPlayerChatted(string msg)
 	{
-		Aabb? bounds = TargetPlayer.CalculateBounds();
+		Aabb? bounds = TargetPlayer.Character.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).CalculateBounds();
 
 		if (bounds.HasValue)
 		{
-			int additional = 0;
+			int decrease = 0;
 			if (TargetPlayer.IsLocal)
 			{
-				additional = 1;
+				decrease = 1;
 			}
-			Position = new Vector3(0, bounds.Value.Size.Y - BubbleHeightMinus - additional, 0);
+			Position = new Vector3(0, bounds.Value.Size.Y + BubbleHeightPlus - decrease, 0);
 		}
 
 		BubbleItem item = Globals.CreateInstanceFromScene<BubbleItem>(BubbleItemPath);

--- a/Polytoria/scripts/client/spatial/chat/BubbleChat.cs
+++ b/Polytoria/scripts/client/spatial/chat/BubbleChat.cs
@@ -33,18 +33,19 @@ public partial class BubbleChat : Node3D
 
 	private void OnPlayerChatted(string msg)
 	{
-		Aabb? bounds = TargetPlayer.Character.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).CalculateBounds();
-
-		if (bounds.HasValue)
+		if (TargetPlayer.Character != null)
 		{
-			int decrease = 0;
-			if (TargetPlayer.IsLocal)
+			Aabb? bounds = TargetPlayer.Character.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).CalculateBounds();
+			if (bounds.HasValue)
 			{
-				decrease = 1;
+				int decrease = 0;
+				if (TargetPlayer.IsLocal)
+				{
+					decrease = 1;
+				}
+				Position = new Vector3(0, bounds.Value.Size.Y + BubbleHeightPlus - decrease, 0);
 			}
-			Position = new Vector3(0, bounds.Value.Size.Y + BubbleHeightPlus - decrease, 0);
 		}
-
 		BubbleItem item = Globals.CreateInstanceFromScene<BubbleItem>(BubbleItemPath);
 		item.Content = msg;
 		_itemContainer.AddChild(item);


### PR DESCRIPTION
## Summary

Made the position of the chat bubble based off of the head's position

## Related issue or discussion

Fixes #247

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
before
<img width="1020" height="989" alt="test1" src="https://github.com/user-attachments/assets/89c8ff6e-a9a8-48ca-988b-30ad09bcf30e" />

after
<img width="984" height="907" alt="test2" src="https://github.com/user-attachments/assets/abd9dee9-afe7-4101-bded-6b9f4e9c0ecb" />

## AI/LLM use
None