### PR TITLE
Use _turnStartPos properly

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -685,6 +685,8 @@ public sealed partial class Camera : Dynamic
 		if (Mode != CameraModeEnum.Follow) return;
 		_turning = true;
 
+		_turnStartPos = GDNode.GetViewport().GetMousePosition();
+
 		if (!Root.Input.CursorLocked)
 		{
 			Root.Input.CursorLocked = true;
@@ -693,7 +695,6 @@ public sealed partial class Camera : Dynamic
 		}
 
 		Vector2 screenCenter = GDNode.GetViewport().GetVisibleRect().GetCenter();
-		_turnStartPos = GDNode.GetViewport().GetMousePosition();
 		GDNode.GetViewport().WarpMouse(screenCenter);
 
 		Root.Input.OverrideMousePosTo = Root.Input.MousePosition;
@@ -709,10 +710,6 @@ public sealed partial class Camera : Dynamic
 		{
 			Root.Input.CursorVisible = true;
 			Root.Input.OverrideMousePos = false;
-			GDNode.GetViewport().WarpMouse(_turnStartPos);
-#if GODOT_WINDOWS
-			GDNode.GetViewport().WarpMouse(_turnStartPos); // Workaround for godotengine/godot#119205
-#endif
 		}
 		else
 		{
@@ -720,6 +717,10 @@ public sealed partial class Camera : Dynamic
 			Root.Input.CursorLocked = false;
 			Root.Input.OverrideMousePos = false;
 		}
+		GDNode.GetViewport().WarpMouse(_turnStartPos);
+#if GODOT_WINDOWS
+			GDNode.GetViewport().WarpMouse(_turnStartPos); // Workaround for godotengine/godot#119205
+#endif
 	}
 
 	private void OnInput(InputEvent @event)

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -719,7 +719,7 @@ public sealed partial class Camera : Dynamic
 		}
 		GDNode.GetViewport().WarpMouse(_turnStartPos);
 #if GODOT_WINDOWS
-			GDNode.GetViewport().WarpMouse(_turnStartPos); // Workaround for godotengine/godot#119205
+		GDNode.GetViewport().WarpMouse(_turnStartPos); // Workaround for godotengine/godot#119205
 #endif
 	}
 


### PR DESCRIPTION
## Summary
Fixes mouse position warping when stopping camera turn
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion

Fixes #647

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
None.
<!-- Describe AI use, or write "None" if not applicable -->