### PR TITLE
[New Feature] Add MaxAutoSize, AutoSize properties to UITextInput

### DIFF
--- a/Polytoria/scripts/datamodel/UILabel.cs
+++ b/Polytoria/scripts/datamodel/UILabel.cs
@@ -6,6 +6,7 @@ using Godot;
 using Polytoria.Attributes;
 using Polytoria.Datamodel.Resources;
 using Polytoria.Enums;
+using Polytoria.Utils;
 
 namespace Polytoria.Datamodel;
 
@@ -19,6 +20,7 @@ public partial class UILabel : UIView
 	private Color _textColor;
 	private float _fontSize;
 	private bool _autoSize;
+	private float _maxAutoSize;
 	private bool _useRichText;
 	private TextHorizontalAlignmentEnum _justify;
 	private TextVerticalAlignmentEnum _verticalAlign;
@@ -40,7 +42,7 @@ public partial class UILabel : UIView
 			_text = value;
 			_richLabel.Text = _text;
 			_label.Text = _text;
-			if (_autoSize) UpdateAutosize();
+			UpdateText();
 			OnPropertyChanged();
 		}
 	}
@@ -144,7 +146,7 @@ public partial class UILabel : UIView
 		set
 		{
 			_fontSize = value;
-			if (!_autoSize) SetTextSize(_fontSize);
+			UpdateText();
 			OnPropertyChanged();
 		}
 	}
@@ -156,16 +158,21 @@ public partial class UILabel : UIView
 		set
 		{
 			_autoSize = value;
-			if (_autoSize)
-			{
-				NodeControl.Resized += UpdateAutosize;
-				UpdateAutosize();
-			}
-			else
-			{
-				NodeControl.Resized -= UpdateAutosize;
-				SetTextSize(_fontSize);
-			}
+			if (_autoSize) NodeControl.Resized += UpdateText;
+			else NodeControl.Resized -= UpdateText;
+			UpdateText();
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float MaxAutoSize
+	{
+		get => _maxAutoSize;
+		set
+		{
+			_maxAutoSize = value;
+			UpdateText();
 			OnPropertyChanged();
 		}
 	}
@@ -257,42 +264,20 @@ public partial class UILabel : UIView
 
 			_label.AutowrapMode = _richLabel.AutowrapMode = _textWrapped ? TextServer.AutowrapMode.WordSmart : TextServer.AutowrapMode.Off;
 
-			if (_autoSize) UpdateAutosize();
+			UpdateText();
 			OnPropertyChanged();
 		}
 	}
 
-	private void UpdateAutosize()
+	private void UpdateText()
 	{
-		Font font = _label.GetThemeFont("font");
-		Vector2 bounds = NodeControl.Size;
-		int lo = 1, hi = 512, result = 0;
-
-		while (lo <= hi)
+		if (_autoSize)
 		{
-			int mid = (lo + hi) / 2;
-			int scaled = (int)(mid * FontScaleConversion);
-			Vector2 textBounds;
-			if (_textWrapped)
-			{
-				textBounds = font.GetMultilineStringSize(
-					text: _text,
-					alignment: _label.HorizontalAlignment,
-					width: bounds.X,
-					fontSize: scaled
-				);
-			}
-			else textBounds = font.GetStringSize(_text, _label.HorizontalAlignment, -1, scaled);
-
-			if (textBounds.X <= bounds.X && textBounds.Y <= bounds.Y)
-			{
-				result = mid;
-				lo = mid + 1;
-			}
-			else hi = mid - 1;
+			float autoSize = TextUtils.BoundsToTextSize(_label.GetThemeFont("font"), _text, NodeControl.Size, _textWrapped) / FontScaleConversion;
+			if (_maxAutoSize > 0 && autoSize > _maxAutoSize) SetTextSize(_maxAutoSize);
+			else SetTextSize(autoSize);
 		}
-
-		SetTextSize(result);
+		else SetTextSize(_fontSize);
 	}
 
 	private void SetTextSize(float size)
@@ -314,7 +299,7 @@ public partial class UILabel : UIView
 		_richLabel.AddThemeFontOverride("bold_italics_font", (Font)resource);
 		_richLabel.AddThemeFontOverride("italics_font", (Font)resource);
 		_richLabel.AddThemeFontOverride("mono_font", (Font)resource);
-		if (_autoSize) UpdateAutosize();
+		UpdateText();
 	}
 
 	public override void Init()
@@ -336,6 +321,8 @@ public partial class UILabel : UIView
 		Text = "Text";
 		TextColor = new(0, 0, 0);
 		FontSize = 16;
+		AutoSize = false;
+		MaxAutoSize = 0;
 		HorizontalAlignment = TextHorizontalAlignmentEnum.Center;
 		VerticalAlignment = TextVerticalAlignmentEnum.Middle;
 		UseRichText = false;

--- a/Polytoria/scripts/datamodel/UITextInput.cs
+++ b/Polytoria/scripts/datamodel/UITextInput.cs
@@ -21,6 +21,7 @@ public partial class UITextInput : UIView
 	private Color _textColor;
 	private float _fontSize;
 	private bool _autoSize;
+	private float _maxAutoSize;
 	private TextHorizontalAlignmentEnum _justify;
 	private bool _multiLine;
 	private string _placeholder = "";
@@ -170,18 +171,17 @@ public partial class UITextInput : UIView
 		}
 	}
 
-	/*
 	[Editable, ScriptProperty]
-	public float MaxFontSize
+	public float MaxAutoSize
 	{
-		get => maxFontSize;
+		get => _maxAutoSize;
 		set
 		{
-			maxFontSize = Mathf.Max(value, fontSize);
-			tmp.fontSizeMax = maxFontSize * FONT_SCALE;
-			tmp.fontSizeMin = fontSize * FONT_SCALE;
+			_maxAutoSize = value;
+			UpdateTextSize();
+			OnPropertyChanged();
 		}
-	}*/
+	}
 
 	[Editable, ScriptProperty]
 	public bool AutoSize
@@ -259,7 +259,8 @@ public partial class UITextInput : UIView
 		{
 			string textDisplayed = !string.IsNullOrEmpty(Text) ? Text : _placeholder;
 			float autoSize = TextUtils.BoundsToTextSize(_textEdit.GetThemeFont("font"), textDisplayed, NodeControl.Size, _multiLine) / UILabel.FontScaleConversion;
-			SetTextSize(autoSize);
+			if (_maxAutoSize > 0 && autoSize > _maxAutoSize) SetTextSize(_maxAutoSize);
+			else SetTextSize(autoSize);
 		}
 		else SetTextSize(_fontSize);
 	}

--- a/Polytoria/scripts/datamodel/UITextInput.cs
+++ b/Polytoria/scripts/datamodel/UITextInput.cs
@@ -7,6 +7,7 @@ using Polytoria.Attributes;
 using Polytoria.Datamodel.Resources;
 using Polytoria.Enums;
 using Polytoria.Scripting;
+using Polytoria.Utils;
 using System;
 
 namespace Polytoria.Datamodel;
@@ -19,6 +20,7 @@ public partial class UITextInput : UIView
 
 	private Color _textColor;
 	private float _fontSize;
+	private bool _autoSize;
 	private TextHorizontalAlignmentEnum _justify;
 	private bool _multiLine;
 	private string _placeholder = "";
@@ -47,6 +49,7 @@ public partial class UITextInput : UIView
 		{
 			_lineEdit.Text = value;
 			_textEdit.Text = value;
+			UpdateTextSize();
 			OnPropertyChanged();
 		}
 	}
@@ -95,8 +98,7 @@ public partial class UITextInput : UIView
 		set
 		{
 			_fontSize = value;
-			_textEdit.AddThemeFontSizeOverride("font_size", Convert.ToInt32(_fontSize * UILabel.FontScaleConversion));
-			_lineEdit.AddThemeFontSizeOverride("font_size", Convert.ToInt32(_fontSize * UILabel.FontScaleConversion));
+			UpdateTextSize();
 			OnPropertyChanged();
 		}
 	}
@@ -110,6 +112,7 @@ public partial class UITextInput : UIView
 			_multiLine = value;
 			_textEdit.Visible = _multiLine;
 			_lineEdit.Visible = !_multiLine;
+			UpdateTextSize();
 			OnPropertyChanged();
 		}
 	}
@@ -123,6 +126,7 @@ public partial class UITextInput : UIView
 			_placeholder = value;
 			_textEdit.PlaceholderText = _placeholder;
 			_lineEdit.PlaceholderText = _placeholder;
+			UpdateTextSize();
 			OnPropertyChanged();
 		}
 	}
@@ -177,19 +181,21 @@ public partial class UITextInput : UIView
 			tmp.fontSizeMax = maxFontSize * FONT_SCALE;
 			tmp.fontSizeMin = fontSize * FONT_SCALE;
 		}
-	}
+	}*/
 
 	[Editable, ScriptProperty]
 	public bool AutoSize
 	{
-		get => autoSize;
+		get => _autoSize;
 		set
 		{
-			autoSize = value;
-			tmp.enableAutoSizing = autoSize;
+			_autoSize = value;
+			if (_autoSize) NodeControl.Resized += UpdateTextSize;
+			else NodeControl.Resized -= UpdateTextSize;
+			UpdateTextSize();
+			OnPropertyChanged();
 		}
 	}
-	*/
 
 	[Editable, ScriptProperty]
 	public FontAsset? FontAsset
@@ -244,8 +250,26 @@ public partial class UITextInput : UIView
 	{
 		_textEdit.AddThemeFontOverride("font", (Font)resource);
 		_lineEdit.AddThemeFontOverride("font", (Font)resource);
+		UpdateTextSize();
 	}
 
+	private void UpdateTextSize()
+	{
+		if (_autoSize)
+		{
+			string textDisplayed = !string.IsNullOrEmpty(Text) ? Text : _placeholder;
+			float autoSize = TextUtils.BoundsToTextSize(_textEdit.GetThemeFont("font"), textDisplayed, NodeControl.Size, _multiLine) / UILabel.FontScaleConversion;
+			SetTextSize(autoSize);
+		}
+		else SetTextSize(_fontSize);
+	}
+
+	private void SetTextSize(float size)
+	{
+		int setto = Convert.ToInt32(size * UILabel.FontScaleConversion);
+		_textEdit.AddThemeFontSizeOverride("font_size", setto);
+		_lineEdit.AddThemeFontSizeOverride("font_size", setto);
+	}
 
 	public override void Init()
 	{
@@ -266,6 +290,7 @@ public partial class UITextInput : UIView
 		_lineEdit.AddThemeStyleboxOverride("read_only", empty);
 		_lineEdit.AddThemeStyleboxOverride("focus", empty);
 		_textEdit.MouseDefaultCursorShape = _lineEdit.MouseDefaultCursorShape = Control.CursorShape.Ibeam;
+		_textEdit.AddThemeConstantOverride("line_spacing", 0);
 
 		// Set pass
 		_textEdit.MouseFilter = Control.MouseFilterEnum.Pass;
@@ -289,6 +314,7 @@ public partial class UITextInput : UIView
 		ReadOnlyColor = new(0, 0, 0, 0.2f);
 		MultiLine = false;
 		FontSize = 16;
+		AutoSize = false;
 		ReadOnly = false;
 
 		base.Init();
@@ -338,11 +364,13 @@ public partial class UITextInput : UIView
 	private void OnTextEditTextChanged()
 	{
 		Changed.Invoke(_textEdit.Text);
+		UpdateTextSize();
 	}
 
 	private void OnLineEditTextChanged(string txt)
 	{
 		Changed.Invoke(txt);
+		UpdateTextSize();
 	}
 
 	private void OnLineEditTextSubmitted(string str)

--- a/Polytoria/scripts/datamodel/UITextInput.cs
+++ b/Polytoria/scripts/datamodel/UITextInput.cs
@@ -105,6 +105,32 @@ public partial class UITextInput : UIView
 	}
 
 	[Editable, ScriptProperty]
+	public bool AutoSize
+	{
+		get => _autoSize;
+		set
+		{
+			_autoSize = value;
+			if (_autoSize) NodeControl.Resized += UpdateTextSize;
+			else NodeControl.Resized -= UpdateTextSize;
+			UpdateTextSize();
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float MaxAutoSize
+	{
+		get => _maxAutoSize;
+		set
+		{
+			_maxAutoSize = value;
+			UpdateTextSize();
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
 	public bool MultiLine
 	{
 		get => _multiLine;
@@ -167,32 +193,6 @@ public partial class UITextInput : UIView
 			_readOnly = value;
 			_textEdit.Editable = !_readOnly;
 			_lineEdit.Editable = !_readOnly;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float MaxAutoSize
-	{
-		get => _maxAutoSize;
-		set
-		{
-			_maxAutoSize = value;
-			UpdateTextSize();
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public bool AutoSize
-	{
-		get => _autoSize;
-		set
-		{
-			_autoSize = value;
-			if (_autoSize) NodeControl.Resized += UpdateTextSize;
-			else NodeControl.Resized -= UpdateTextSize;
-			UpdateTextSize();
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/utils/TextUtils.cs
+++ b/Polytoria/scripts/utils/TextUtils.cs
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Godot;
+
+namespace Polytoria.Utils;
+
+public static class TextUtils
+{
+	public static int BoundsToTextSize(Font font, string text, Vector2 bounds, bool isWrapped)
+	{
+		int lo = 1, hi = 512, result = 0;
+
+		while (lo <= hi)
+		{
+			int mid = (lo + hi) / 2;
+			Vector2 textBounds;
+			if (isWrapped)
+			{
+				textBounds = font.GetMultilineStringSize(
+					text: text,
+					alignment: HorizontalAlignment.Center,
+					width: bounds.X,
+					fontSize: mid
+				);
+			}
+			else textBounds = font.GetStringSize(text, HorizontalAlignment.Center, -1, mid);
+
+			if (textBounds.X <= bounds.X && textBounds.Y <= bounds.Y)
+			{
+				result = mid;
+				lo = mid + 1;
+			}
+			else hi = mid - 1;
+		}
+
+		return result;
+	}
+}

--- a/Polytoria/scripts/utils/TextUtils.cs.uid
+++ b/Polytoria/scripts/utils/TextUtils.cs.uid
@@ -1,0 +1,1 @@
+uid://b1d8dovrcwdv0


### PR DESCRIPTION
## Summary

This PR: 
- Adds a new `MaxAutoSize` property that sets a maximum for the font size when `AutoSize` is enabled. Value must be over 0 to be active.
- Moves AutoSize code into a static `TextUtils` class (`Polytoria/scripts/utils` seemed like the right place for this). Now it can be reused in other places.
- Adds text auto-sizing to `UITextInput`. It's pretty much identical to the one in `UILabel`.

## Related issue or discussion

No related issue or discussion opened, but was suggested on discord.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [X] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Empty UITextInput with placeholder text and `MaxAutoSize` set to 32:
<img width="531" height="256" alt="placeholder" src="https://github.com/user-attachments/assets/665efb90-cdef-4108-a834-696f9b58b16a" />

UITextInput with `MultiLine` enabled:
<img width="609" height="224" alt="multiline" src="https://github.com/user-attachments/assets/970c469f-f823-4fc4-8f5c-86096028367b" />
Last line is "horizontal scrolling is permitted for longer lines". `AutoSize` will try to fit all lines vertically, but extremely long lines may also cause the text to shrink because `MultiLine` is used as an equivalent for `TextWrapped`.

## AI/LLM use

None.