### PR TITLE
Fixed Dynamic:RotateAround not working properly after assigning to Dynamic.Rotation

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -90,7 +90,9 @@ public partial class Dynamic : Instance
 		}
 		set
 		{
-			GDNode3D.GlobalRotationDegrees = value.SanitizeNaN();
+			Vector3 sanitizedValue = value.SanitizeNaN();
+			GDNode3D.GlobalRotationDegrees = sanitizedValue;
+			_oldGlobalTransformApplied.Basis = Basis.FromEuler(sanitizedValue);
 			if (AutoUpdateNetTransform)
 			{
 				UpdateNetTransformReliable();

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -92,7 +92,9 @@ public partial class Dynamic : Instance
 		{
 			Vector3 sanitizedValue = value.SanitizeNaN();
 			GDNode3D.GlobalRotationDegrees = sanitizedValue;
-			_oldGlobalTransformApplied.Basis = Basis.FromEuler(sanitizedValue);
+			ForceUpdateTransform();
+			_oldGlobalTransformApplied = GetGlobalTransform();
+
 			if (AutoUpdateNetTransform)
 			{
 				UpdateNetTransformReliable();


### PR DESCRIPTION
## Summary

Fixed calling `Dynamic:RotateAround` twice not updating rotation for the second time, even after assigning to `Dynamic.Rotation` between calls

## Related issue or discussion

Fixes https://github.com/Polytoria/polytoria-game/issues/89

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video



## AI/LLM use

None