### PR TITLE
Add CanPlayerSit property to Seats

### DIFF
--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System.Numerics;
+using System.Runtime.Intrinsics.X86;
 using Polytoria.Attributes;
 using Polytoria.Scripting;
 
@@ -10,7 +12,9 @@ namespace Polytoria.Datamodel;
 [Instantiable]
 public partial class Seat : Part
 {
+	private bool _canSit;
 	private bool _canNPCSit;
+	private float HeightOffset = 1.1f;
 
 	private NPC? _occupant = null;
 
@@ -26,6 +30,17 @@ public partial class Seat : Part
 			return _occupant;
 		}
 		set => _occupant = value;
+	}
+
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool CanSit
+	{
+		get => _canSit;
+		set
+		{
+			_canSit = value;
+			OnPropertyChanged();
+		}
 	}
 
 	[Editable, ScriptProperty, DefaultValue(false)]
@@ -69,11 +84,12 @@ public partial class Seat : Part
 		}
 		if (hit is Player plr)
 		{
+			if (!CanSit) { return; }
 			plr.Sit(this);
 		}
 		else if (hit is NPC npc)
 		{
-			if (!CanNPCSit) { return; }
+			if (!CanNPCSit || !CanSit) { return; }
 			npc.Sit(this);
 		}
 	}

--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -12,7 +12,7 @@ namespace Polytoria.Datamodel;
 [Instantiable]
 public partial class Seat : Part
 {
-	private bool _canSit;
+	private bool _canPlayerSit;
 	private bool _canNPCSit;
 
 	private NPC? _occupant = null;
@@ -32,12 +32,12 @@ public partial class Seat : Part
 	}
 
 	[Editable, ScriptProperty, DefaultValue(true)]
-	public bool CanSit
+	public bool CanPlayerSit
 	{
-		get => _canSit;
+		get => _canPlayerSit;
 		set
 		{
-			_canSit = value;
+			_canPlayerSit = value;
 			OnPropertyChanged();
 		}
 	}
@@ -83,12 +83,12 @@ public partial class Seat : Part
 		}
 		if (hit is Player plr)
 		{
-			if (!CanSit) { return; }
+			if (!CanPlayerSit) { return; }
 			plr.Sit(this);
 		}
 		else if (hit is NPC npc)
 		{
-			if (!CanNPCSit || !CanSit) { return; }
+			if (!CanNPCSit) { return; }
 			npc.Sit(this);
 		}
 	}

--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using System.Numerics;
-using System.Runtime.Intrinsics.X86;
 using Polytoria.Attributes;
 using Polytoria.Scripting;
 

--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -14,7 +14,6 @@ public partial class Seat : Part
 {
 	private bool _canSit;
 	private bool _canNPCSit;
-	private float HeightOffset = 1.1f;
 
 	private NPC? _occupant = null;
 


### PR DESCRIPTION
## Summary

Add CanPlayerSit property to Seats. default true. when false  players cant sit on the Seat.

## Related issue or discussion

Suggested in #640

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="302" height="92" alt="1" src="https://github.com/user-attachments/assets/6a56b6da-a1f5-40b1-a332-22140b1d4a1e" />

<img width="126" height="220" alt="2" src="https://github.com/user-attachments/assets/fb0ad477-f8a5-42fd-b3f6-a7a35c87dfd0" />

## AI/LLM use

None