### PR TITLE
Fix ungrouping rigidbody and undo not working with group types

### DIFF
--- a/Polytoria/scripts/creator/ui/ctxmenus/ExplorerItemContextMenu.cs
+++ b/Polytoria/scripts/creator/ui/ctxmenus/ExplorerItemContextMenu.cs
@@ -55,7 +55,7 @@ public partial class ExplorerItemContextMenu : ContextMenu
 		AddIconItem("select-all", "Select Children", 25);
 		AddSeparator();
 		AddIconItem("group", "Group", 31);
-		if (Target is IGroup)
+		if (Target is IGroup or RigidBody)
 		{
 			AddIconItem("ungroup", "Ungroup", 32);
 		}

--- a/Polytoria/scripts/datamodel/creator/CreatorHistory.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorHistory.cs
@@ -159,6 +159,8 @@ public sealed partial class CreatorHistory : Instance
 		Instance[] originalModels = instances;
 		Instance[]? ungroupedChildren = null;
 
+		GroupAsEnum ungroupType = instances.Length > 0 ? GetGroupAsEnum(instances[0]) : GroupAsEnum.Model;
+
 		NewAction("Ungroup instances");
 
 		AddDoCallback(new((_) =>
@@ -170,12 +172,19 @@ public sealed partial class CreatorHistory : Instance
 		{
 			if (ungroupedChildren != null)
 			{
-				originalModels = [Root.CreatorContext.Selections.GroupInstances(ungroupedChildren)];
+				originalModels = [Root.CreatorContext.Selections.GroupInstances(ungroupedChildren, ungroupType)];
 			}
 		}));
 
 		CommitAction();
 	}
+
+	private static GroupAsEnum GetGroupAsEnum(Instance instance) => instance switch
+	{
+		RigidBody => GroupAsEnum.RigidBody,
+		Folder => GroupAsEnum.Folder,
+		_ => GroupAsEnum.Model,
+	};
 
 	public void ToggleLockedDynamics(Dynamic[] dyns)
 	{

--- a/Polytoria/scripts/datamodel/creator/CreatorSelections.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorSelections.cs
@@ -248,7 +248,7 @@ public sealed partial class CreatorSelections : Instance
 
 		foreach (Instance item in models)
 		{
-			if (item is not IGroup and RigidBody) continue;
+			if (item is not IGroup and not RigidBody) continue;
 			foreach (Instance modelItem in item.GetChildren())
 			{
 				modelItem.Reparent(item.Parent!);


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
fixed ungrouping rigidbody also fixed undo not working with group types
## Related issue or discussion

Fixes #668

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
none