### PR TITLE
Add SitDirectionLocked property to Seats

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -590,7 +590,7 @@ public partial class NPC : Physical
 				Position = SittingIn.Position + SeatOffset * Up;
 				if (SittingIn.CanRotate)
 				{
-					Rotation = new Vector3(SittingIn.Rotation.X, Rotation.Y, SittingIn.Rotation.X);
+					Rotation = new Vector3(SittingIn.Rotation.X, Rotation.Y, SittingIn.Rotation.Z);
 				}
 				else
 				{

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -588,7 +588,13 @@ public partial class NPC : Physical
 			{
 				Velocity = Vector3.Zero;
 				Position = SittingIn.Position + SeatOffset * Up;
-				Rotation = SittingIn.Rotation;
+				if(SittingIn.CanRotate)
+				{
+					Rotation = new Vector3(SittingIn.Rotation.X , Rotation.Y, SittingIn.Rotation.X);
+				}else
+				{
+					Rotation = SittingIn.Rotation;
+				}
 				Character?.PlayIdle();
 			}
 			return;

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -588,7 +588,7 @@ public partial class NPC : Physical
 			{
 				Velocity = Vector3.Zero;
 				Position = SittingIn.Position + SeatOffset * Up;
-				if (SittingIn.CanRotate)
+				if (!SittingIn.SitDirectionLocked)
 				{
 					Rotation = new Vector3(SittingIn.Rotation.X, Rotation.Y, SittingIn.Rotation.Z);
 				}

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -588,10 +588,11 @@ public partial class NPC : Physical
 			{
 				Velocity = Vector3.Zero;
 				Position = SittingIn.Position + SeatOffset * Up;
-				if(SittingIn.CanRotate)
+				if (SittingIn.CanRotate)
 				{
-					Rotation = new Vector3(SittingIn.Rotation.X , Rotation.Y, SittingIn.Rotation.X);
-				}else
+					Rotation = new Vector3(SittingIn.Rotation.X, Rotation.Y, SittingIn.Rotation.X);
+				}
+				else
 				{
 					Rotation = SittingIn.Rotation;
 				}

--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -12,7 +12,7 @@ public partial class Seat : Part
 {
 	private bool _canPlayerSit;
 	private bool _canNPCSit;
-	private bool _canRotate;
+	private bool _sitDirectionLocked;
 
 	private NPC? _occupant = null;
 
@@ -51,13 +51,13 @@ public partial class Seat : Part
 			OnPropertyChanged();
 		}
 	}
-	[Editable, ScriptProperty, DefaultValue(false)]
-	public bool CanRotate
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool SitDirectionLocked
 	{
-		get => _canRotate;
+		get => _sitDirectionLocked;
 		set
 		{
-			_canRotate = value;
+			_sitDirectionLocked = value;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -12,6 +12,7 @@ public partial class Seat : Part
 {
 	private bool _canPlayerSit;
 	private bool _canNPCSit;
+	private bool _canRotate;
 
 	private NPC? _occupant = null;
 
@@ -47,6 +48,16 @@ public partial class Seat : Part
 		set
 		{
 			_canNPCSit = value;
+			OnPropertyChanged();
+		}
+	}
+	[Editable, ScriptProperty, DefaultValue(false)]
+	public bool CanRotate
+	{
+		get => _canRotate;
+		set
+		{
+			_canRotate = value;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

This property when true allows players to sit without having their Rotaion.Y value be set to the Seat's Rotation.Y value

## Related issue or discussion

Feature requested in #675

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/c6da41f0-edc7-4b3d-88aa-9dbb956134f2

## AI/LLM use

None