### PR TITLE
add missing brackets to stringified data types

### DIFF
--- a/Polytoria/scripts/scripting/datatypes/PTBounds.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTBounds.cs
@@ -53,7 +53,7 @@ public class PTBounds : IScriptGDObject
 	public static string ToString(PTBounds? v)
 	{
 		if (v == null) return "<Bounds>";
-		return $"<Bounds:({v.Start}, {v.End}, {v.Size}>";
+		return $"<Bounds:({v.Start}, {v.End}, {v.Size})>";
 	}
 
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static Vector3 ClosestPoint(PTBounds bounds, PTVector3 point) => bounds.aabb.GetSupport(point.vector);

--- a/Polytoria/scripts/scripting/datatypes/PTColor.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTColor.cs
@@ -107,7 +107,7 @@ public class PTColor : IScriptGDObject
 	public static string ToString(PTColor? v)
 	{
 		if (v == null) return "<Color>";
-		return $"<Color:({v.color.R}, {v.color.G}, {v.color.B}, {v.color.A}>";
+		return $"<Color:({v.color.R}, {v.color.G}, {v.color.B}, {v.color.A})>";
 	}
 
 	[ScriptMethod]

--- a/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
@@ -86,7 +86,7 @@ public class PTQuaternion : IScriptGDObject
 	public static string ToString(PTQuaternion? v)
 	{
 		if (v == null) return "<Quaternion>";
-		return $"<Quaternion:({v.quat.X}, {v.quat.Y}, {v.quat.Z}, {v.quat.W}>";
+		return $"<Quaternion:({v.quat.X}, {v.quat.Y}, {v.quat.Z}, {v.quat.W})>";
 	}
 
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)]


### PR DESCRIPTION
## Summary

brackets were missing from the end of `Bounds`, `Color` and `Quaternion` (visible in console)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

none!