### PR TITLE
fix position when sitting on a Seat + adjust default SeatOffset property

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -29,7 +29,7 @@ public partial class NPC : Physical
 	public const float ForwardRaycastRange = 1;
 	public const float StairForwardRaycastRange = 4;
 	public const float NameTagHeightMinus = 3f;
-	private Vector3 _seatOffset = new(0, 1.5f, 0);
+	private Vector3 _seatOffset = new(0, 1.7f, 0);
 	private float _health = 100;
 	private RemoteTransform3D? _toolRemoteTransform;
 	private float _maxHealth = 100;
@@ -587,7 +587,7 @@ public partial class NPC : Physical
 			if (!Root.Network.IsServer && SittingIn != null)
 			{
 				Velocity = Vector3.Zero;
-				Position = SittingIn.Position + SeatOffset * Up;
+				Position = SittingIn.Position + SeatOffset.Y * Up;
 				if (!SittingIn.SitDirectionLocked)
 				{
 					Rotation = new Vector3(SittingIn.Rotation.X, Rotation.Y, SittingIn.Rotation.Z);


### PR DESCRIPTION
## Summary

changed the calculation for the NPC.Position for when it is sitting on a chair sideways + changed the SeatOffset property to raise up the NPC slightly

## Related issue or discussion

Fixes the remaining problems from #657

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
before:
<img width="725" height="424" alt="11" src="https://github.com/user-attachments/assets/f2c6e6a8-0cda-4458-8f31-68cf5598c1cc" />

after:
<img width="390" height="269" alt="22" src="https://github.com/user-attachments/assets/f87a29d8-6620-4e3f-9de0-bd3abd40088d" />

## AI/LLM use

None