### PR TITLE
Fix luau userdata cache v2

### DIFF
--- a/Polytoria/Polytoria.csproj
+++ b/Polytoria/Polytoria.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Godot.NET.Sdk/4.6.2">
+﻿<Project Sdk="Godot.NET.Sdk/4.6.3">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
@@ -47,8 +47,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Polytoria.SourceGen\Polytoria.SourceGen.csproj"
-			OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\Polytoria.SourceGen\Polytoria.SourceGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 	<!-- ExportRelease configuration -->

--- a/Polytoria/Polytoria.csproj
+++ b/Polytoria/Polytoria.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Godot.NET.Sdk/4.6.3">
+<Project Sdk="Godot.NET.Sdk/4.6.2">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
@@ -125,7 +125,7 @@
 	<PropertyGroup Condition="'$(PT_PRIVATE_API)' == 'TRUE'">
 		<DefineConstants>$(DefineConstants);PT_PRIVATE_API</DefineConstants>
 	</PropertyGroup>
-	
+
 	<!-- Delete PDB files after publish, we don't want leaks happening TヮT -->
 	<Target Name="DeleteFiles" AfterTargets="Publish">
 		<ItemGroup>

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -41,7 +41,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 	private const string WeakUserdataCache = "__UDCACHE";
 	private static readonly int ThreadDataKey = 0x1247;
 
-	private static readonly ConditionalWeakTable<object, string> _objectIDS= new();
+	private static readonly ConditionalWeakTable<object, string> _objectIDS = new();
 	private static long _nextObjectID;
 
 	private static int _allocsSinceLastGC = 0;

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -23,6 +23,8 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Script = Polytoria.Datamodel.Script;
 
 namespace Polytoria.Scripting.Luau;
@@ -38,6 +40,9 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 	private static readonly Dictionary<IntPtr, object> _ptrToObject = [];
 	private const string WeakUserdataCache = "__UDCACHE";
 	private static readonly int ThreadDataKey = 0x1247;
+
+	private static readonly ConditionalWeakTable<object, string> _objectIDS= new();
+	private static long _nextObjectID;
 
 	private static int _allocsSinceLastGC = 0;
 
@@ -1604,7 +1609,10 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 
 	private static string GetRegKeyFromObj(object obj)
 	{
-		return "__userdata_" + obj.GetType().Name + obj.GetHashCode();
+		return _objectIDS.GetValue(
+			obj,
+			_ => "__userdata_" + Interlocked.Increment(ref _nextObjectID)
+		);
 	}
 
 	private void PushCSClassInternal(LuaState lua, IScriptObject? obj, [DynamicallyAccessedMembers(DynamicallyAccessedTypes)] Type? specifyType = null)


### PR DESCRIPTION
## Summary

Previously creation large quantities of userdata objects would cause hash collisions resulting in incorrect data being returned.
This fixes the issue by giving each object its own unique cache identifier.

## Related issue or discussion

Fixes #699 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [X] Server
- [ ] Networking / replication
- [ ] Scripting API
- [X] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None