### PR TITLE
Fix typo in UILabel.cs

### DIFF
--- a/Polytoria/scripts/datamodel/UILabel.cs
+++ b/Polytoria/scripts/datamodel/UILabel.cs
@@ -295,7 +295,7 @@ public partial class UILabel : UIView
 	{
 		_label.AddThemeFontOverride("font", (Font)resource);
 		_richLabel.AddThemeFontOverride("normal_font", (Font)resource);
-		_richLabel.AddThemeFontOverride("bold_fonte", (Font)resource);
+		_richLabel.AddThemeFontOverride("bold_font", (Font)resource);
 		_richLabel.AddThemeFontOverride("bold_italics_font", (Font)resource);
 		_richLabel.AddThemeFontOverride("italics_font", (Font)resource);
 		_richLabel.AddThemeFontOverride("mono_font", (Font)resource);


### PR DESCRIPTION
## Summary

Fixed typo in UILabel.cs

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion

Fixes -
Related to -

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [ ] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None

<!-- Describe AI use, or write "None" if not applicable -->