### PR TITLE
add suffix Enum to AspectRatioScaleType

### DIFF
--- a/Polytoria/scripts/datamodel/UIAspectRatioRestraint.cs
+++ b/Polytoria/scripts/datamodel/UIAspectRatioRestraint.cs
@@ -6,7 +6,7 @@ namespace Polytoria.Datamodel;
 public partial class UIAspectRatioRestraint : Instance
 {
 	private DominantAxisEnum _dominantAxis = default;
-	private AspectRatioScaleType _scaleType = default;
+	private AspectRatioScaleTypeEnum _scaleType = default;
 	private float _aspectRatio = 1;
 	private UIField? oldParent = null;
 
@@ -22,7 +22,7 @@ public partial class UIAspectRatioRestraint : Instance
 		}
 	}
 	[Editable, ScriptProperty]
-	public AspectRatioScaleType ScaleType
+	public AspectRatioScaleTypeEnum ScaleType
 	{
 		get => _scaleType;
 		set
@@ -82,7 +82,7 @@ public enum DominantAxisEnum
 	Height = 1
 }
 [ScriptEnum]
-public enum AspectRatioScaleType
+public enum AspectRatioScaleTypeEnum
 {
 	FitContainer = 0,
 	FitMaxSize = 1,

--- a/Polytoria/scripts/datamodel/UIField.cs
+++ b/Polytoria/scripts/datamodel/UIField.cs
@@ -521,10 +521,10 @@ public partial class UIField : Instance
 			Vector2? maxSize;
 			switch (aspectRatioConstraint.ScaleType)
 			{
-				case AspectRatioScaleType.FitContainer:
+				case AspectRatioScaleTypeEnum.FitContainer:
 					maxSize = parentSize;
 					break;
-				case AspectRatioScaleType.FitMaxSize:
+				case AspectRatioScaleTypeEnum.FitMaxSize:
 					maxSize = size;
 					break;
 				default:


### PR DESCRIPTION
## Summary
Fixed the ommision of `Enum` suffix in the scriptenum AspectRatioScaleTypeEnum.

## Related issue or discussion

Fixes #707
Related to #707

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [x] Other
(can somebody please explain to what extent "affected" means?)

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None