### PR TITLE
Exposed GetNetworkedObject for world

### DIFF
--- a/Polytoria/scripts/datamodel/World.cs
+++ b/Polytoria/scripts/datamodel/World.cs
@@ -216,6 +216,12 @@ public sealed partial class World : Instance
 	[ScriptProperty, Attributes.Obsolete("Use InstanceCount instead")]
 	public int LocalInstanceCount => InstanceCount;
 
+	[ScriptMethod]
+	public async Task<NetworkedObject?> GetNetworkedObject(string networkID)
+	{
+		return await WaitForNetObjectAsync(networkID);
+	}
+
 	[SyncVar]
 	public bool ServerUnderLoad
 	{


### PR DESCRIPTION
## Summary

Was working on a networking library and the API has access to NetworkedObjectID but no way to resolve it.
This allows you to get any NetworkedObject by its ID.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None