### PR TITLE
Fixed scale gizmo incorrect math

### DIFF
--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -130,7 +130,8 @@ public sealed partial class Gizmos : Node
 		Vector3 currentAxisVector = oldScaleVector * globalDirection;
 		int localDirection = rawMotion.Dot(currentAxisVector) > 0 ? 1 : -1;
 
-		float snappedDelta = rawMotion.Snap(moveSnap).Length() * localDirection;
+		Vector3 axisDir = currentAxisVector.Normalized();
+		float snappedDelta = Mathf.Snapped(rawMotion.Dot(axisDir), moveSnap);
 		Vector3 resizeDirection = oldScaleVector.Normalized();
 		Vector3 newScaleVector = oldScaleVector + resizeDirection * snappedDelta * scaleFactor;
 


### PR DESCRIPTION
## Summary

Scale gizmo was scaling by length of drag vector which is incorrect when rotated. Instead scale by projected drag vector onto scale axis.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None