### PR TITLE
Fix vscode and zed not opening on macOS

### DIFF
--- a/Polytoria/scripts/datamodel/creator/CreatorService.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorService.cs
@@ -396,8 +396,18 @@ public sealed partial class CreatorService : Node, IScriptObject
 			CurrentSession.CreateVSCodeConfig();
 			// open in vscode
 			System.Diagnostics.Process p = new();
-			p.StartInfo.FileName = "code";
-			p.StartInfo.Arguments = $"\"{path}\" \"{CurrentSession.ProjectFolderPath}\"";
+
+			if (OS.HasFeature("macos"))
+			{
+				p.StartInfo.FileName = "open";
+				p.StartInfo.Arguments = $"-a \"Visual Studio Code\" \"{path}\" \"{CurrentSession.ProjectFolderPath}\"";
+			}
+			else
+			{
+				p.StartInfo.FileName = "code";
+				p.StartInfo.Arguments = $"\"{path}\" \"{CurrentSession.ProjectFolderPath}\"";
+			}
+
 			p.StartInfo.UseShellExecute = true;
 			p.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
 			p.Start();
@@ -407,8 +417,18 @@ public sealed partial class CreatorService : Node, IScriptObject
 		{
 			// open in zed
 			System.Diagnostics.Process p = new();
-			p.StartInfo.FileName = "zed";
-			p.StartInfo.Arguments = $"\"{path}\" \"{CurrentSession.ProjectFolderPath}\"";
+
+			if (OS.HasFeature("macos"))
+			{
+				p.StartInfo.FileName = "open";
+				p.StartInfo.Arguments = $"-a Zed \"{path}\" \"{CurrentSession.ProjectFolderPath}\"";
+			}
+			else
+			{
+				p.StartInfo.FileName = "zed";
+				p.StartInfo.Arguments = $"\"{path}\" \"{CurrentSession.ProjectFolderPath}\"";
+			}
+
 			p.StartInfo.UseShellExecute = true;
 			p.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
 			p.Start();


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Fixed Visual Studio Code and Zed not opening on macOS by adding an OS check before opening a script

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
None
<!-- Describe AI use, or write "None" if not applicable -->