### PR TITLE
Allow modification of chat bubble render distance

### DIFF
--- a/Polytoria/scripts/client/spatial/SpatialUIBase.cs
+++ b/Polytoria/scripts/client/spatial/SpatialUIBase.cs
@@ -18,7 +18,7 @@ public partial class SpatialUIBase : Sprite3D
 
 		if (cam != null)
 		{
-			Visible = (cam.Position - GlobalPosition).Length() < SpatialVisibleRange;
+			Visible = (cam.Position - GlobalPosition).Length() < World.Current.CoreUI.ChatBubbleRenderDistance;
 		}
 	}
 }

--- a/Polytoria/scripts/client/spatial/SpatialUIBase.cs
+++ b/Polytoria/scripts/client/spatial/SpatialUIBase.cs
@@ -9,8 +9,6 @@ namespace Polytoria.Client.UI;
 
 public partial class SpatialUIBase : Sprite3D
 {
-	public const float SpatialVisibleRange = 40;
-
 	public override void _Process(double delta)
 	{
 		if (World.Current == null) { Visible = false; return; }

--- a/Polytoria/scripts/datamodel/services/CoreUIService.cs
+++ b/Polytoria/scripts/datamodel/services/CoreUIService.cs
@@ -16,6 +16,7 @@ public sealed partial class CoreUIService : Instance
 {
 	private const string CoreUIPath = "res://scenes/client/ui/core_ui.tscn";
 
+	private int _chatBubbleRenderDistance = 40;
 	private bool _useUserCard = true;
 	private bool _useChat = true;
 	private bool _useHealthBar = true;
@@ -44,6 +45,13 @@ public sealed partial class CoreUIService : Instance
 			OnPropertyChanged();
 			CtrlLockCursorChanged.Invoke();
 		}
+	}
+
+	[Editable, ScriptProperty]
+	public int ChatBubbleRenderDistance
+	{
+		get => _chatBubbleRenderDistance;
+		set { _chatBubbleRenderDistance = value; }
 	}
 
 	[Editable, ScriptProperty, ScriptLegacyProperty("UserCardEnabled")]


### PR DESCRIPTION
## Summary

Added property under CoreUI for changing the chat bubble render distance.

## Related issue or discussion

Related to #704 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None