### PR TITLE
fix NPCs not walking down stairs properly

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -17,7 +17,7 @@ namespace Polytoria.Datamodel;
 public partial class NPC : Physical
 {
 	private const float CoyoteTime = 0.15f;
-	private const float NavigationDistance = 1f;
+	private const float NavigationDistance = 2f;
 	public const float BodyRotateLerp = 10f;
 	private const float StepHeight = 1.5f;
 	private Tool? _holdingTool;
@@ -1077,7 +1077,7 @@ public partial class NPC : Physical
 				PathDesiredDistance = NavigationDistance,
 				TargetDesiredDistance = 0.5f,
 				PathHeightOffset = -(CalculateBounds().Size.Y / 2),
-				PathMaxDistance = 3f,
+				PathMaxDistance = 3f
 			};
 
 			_navAgentContainer.AddChild(_navAgent);


### PR DESCRIPTION
## Summary

allows NPCs to go down stairs with 1-stud tall steps, before it would kinda just glitch out and get stuck walking sideways or something

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

none!