### PR TITLE
Expose Character default animation related methods to scripts

### DIFF
--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -103,36 +103,43 @@ public partial class CharacterModel : Dynamic
 		}
 	}
 
+	[ScriptMethod]
 	public void PlayIdle()
 	{
 		SetState(CharacterModelStateEnum.Idle);
 	}
 
+	[ScriptMethod]
 	public void PlayWalk()
 	{
 		SetState(CharacterModelStateEnum.Walking);
 	}
 
+	[ScriptMethod]
 	public void PlayRun()
 	{
 		SetState(CharacterModelStateEnum.Running);
 	}
 
+	[ScriptMethod]
 	public void PlayJump()
 	{
 		SetState(CharacterModelStateEnum.Jumping);
 	}
 
+	[ScriptMethod]
 	public void PlayClimb()
 	{
 		SetState(CharacterModelStateEnum.Climbing);
 	}
 
+	[ScriptMethod]
 	public void SetAnimSpeed(float speed)
 	{
 		CurrentSpeed = speed;
 	}
 
+	[ScriptMethod]
 	public void SetState(CharacterModelStateEnum newState)
 	{
 		if (newState != CurrentState)


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Used these in Gravity Controller luau module for playing default animations while in `Scripted` movement mode.

## Related issue or discussion

<!-- Fixes # -->
<!-- Related to # -->
None

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->
<img width="445" height="476" alt="{D8EC5A08-AAA7-4D78-B2C0-68554A3104FE}" src="https://github.com/user-attachments/assets/bd6eaad6-5393-44ff-9b5d-d596e7f2230f" />


## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None