### PR TITLE
Fix Player scripted movement mode

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -607,6 +607,10 @@ public partial class NPC : Physical
 			{
 				return;
 			}
+			if (plr.MovementMode == Player.PlayerMovementModeEnum.Scripted)
+			{
+				return;
+			}
 		}
 
 		if (Root.Network.LocalPeerID != NetworkAuthority && ExistInNetwork) return;


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
### What changed
When `MovementMode.Scripted`
Stop `NPC.PhysicsProcess` from updating everything that related to `CharBody3D` existance:
states, velocity, animations, landed, IsOnFloor, IsOnCeiling, ...

### Why changed
Its messing with velocity that people try to apply when manipulate character's movement
If anything of that is needed for scripted mode - its best to expose related methods
So creators decide on their own what they need in this mode

### Current alternative
Current approach i use to avoid this bug:
Create client-side NPC and trigger :Move on it instead of Player
Its stops on this line `Root.Network.LocalPeerID != NetworkAuthority && ExistInNetwork` unlike of scripted player
Then i do Player.Position = NPC.Position

## Related issue or discussion

<!-- Fixes # -->
<!-- Related to # -->
None

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->
None

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None