### PR TITLE
Fix Creator text editor find

### DIFF
--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorFind.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorFind.cs
@@ -179,9 +179,7 @@ public sealed partial class TextEditorFind : Control
 		int line = result.X;
 		int column = result.Y;
 
-		Root.CodeEditor.SetCaretLine(line);
-		Root.CodeEditor.SetCaretColumn(column);
-		Root.CodeEditor.SelectWordUnderCaret();
+		Root.CodeEditor.Select(line, column, line, column + _searchField.Text.Length);
 		Root.CodeEditor.CenterViewportToCaret();
 	}
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Text editor find used to jump to every even-numbered match correctly but didn't highlight correctly. This pull request fixes this so it always highlights correctly.

## Related issue or discussion

Fixes -
Related to -

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

**Before:**

https://github.com/user-attachments/assets/8c18c980-a580-4c82-af15-3e4244ade7ec

**After:**

https://github.com/user-attachments/assets/3c69f3aa-418d-4a0f-aaf3-809059b175f4

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None