### PR TITLE
Apply UI scale to popup windows in Creator

### DIFF
--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -632,6 +632,11 @@ public partial class CreatorInterface : Control, IScriptObject
 		window.Visible = false;
 		window.ForceNative = true;
 		window.Theme = _creatorTheme;
+
+		float uiScale = GetWindow().ContentScaleFactor;
+		window.ContentScaleFactor = uiScale;
+		window.Size = (Vector2I)((Vector2)window.Size * uiScale);
+
 		AddChild(window);
 		window.PopupCentered();
 	}


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
PopupWindow() used to ignore UI scale. This pull request makes it apply the main window's scale to popups.

## Related issue or discussion

Fixes #636 
Related to -

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
**Before (UI Scale at 1.5 on 1440p):**
<img width="879" height="644" alt="Ekran görüntüsü 2026-06-12 114608" src="https://github.com/user-attachments/assets/14ffed42-959a-485f-b94e-a97a8f82b254" />

**After (UI Scale at 1.5 on 1440p):**
<img width="948" height="675" alt="Ekran görüntüsü 2026-06-12 113528" src="https://github.com/user-attachments/assets/0cc1d343-82d2-4ba1-9f07-09f2125ea3b7" />

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->

None