### PR TITLE
Add Visible property to stat to hide it from the leaderboard

### DIFF
--- a/Polytoria/scripts/client/ui/playerlist/UILeaderboard.cs
+++ b/Polytoria/scripts/client/ui/playerlist/UILeaderboard.cs
@@ -176,7 +176,7 @@ public partial class UILeaderboard : TouchScrollContainer
 
 		_layout.AddChild(card);
 
-		foreach (var st in Stats.GetStats())
+		foreach (var st in Stats.GetVisibleStats())
 			card.AddStat(st);
 
 		player.StatChanged.Connect(OnPlayerStatChanged);
@@ -195,7 +195,7 @@ public partial class UILeaderboard : TouchScrollContainer
 
 		_layout.AddChild(card);
 
-		foreach (var st in Stats.GetStats())
+		foreach (var st in Stats.GetVisibleStats())
 		{
 			card.AddStat(st);
 		}
@@ -225,7 +225,7 @@ public partial class UILeaderboard : TouchScrollContainer
 			_neutralTeamItem = null;
 		}
 
-		foreach (var st in Stats.GetStats())
+		foreach (var st in Stats.GetVisibleStats())
 		{
 			if (st is Stat stat)
 			{
@@ -319,7 +319,7 @@ public partial class UILeaderboard : TouchScrollContainer
 		card.SetNeutral("Neutral Team", new Color(0.56f, 0.61f, 0.66f));
 		_layout.AddChild(card);
 		_neutralTeamItem = card;
-		foreach (var st in Stats.GetStats())
+		foreach (var st in Stats.GetVisibleStats())
 			card.AddStat(st);
 	}
 
@@ -352,7 +352,7 @@ public partial class UILeaderboard : TouchScrollContainer
 			_neutralTeamItem = null;
 		}
 
-		foreach (var st in Stats.GetStats())
+		foreach (var st in Stats.GetVisibleStats())
 		{
 			if (st is Stat stat)
 			{
@@ -368,6 +368,8 @@ public partial class UILeaderboard : TouchScrollContainer
 
 	private void OnPlayerStatChanged(Stat stat, object? _)
 	{
+		if (!stat.Visible) return;
+
 		foreach (var item in _teamToItem.Values)
 			item.UpdateStat(stat);
 		_neutralTeamItem?.UpdateStat(stat);
@@ -384,7 +386,7 @@ public partial class UILeaderboard : TouchScrollContainer
 			node.QueueFree();
 		}
 
-		foreach (var stat in Stats.GetStats())
+		foreach (var stat in Stats.GetVisibleStats())
 		{
 			if (stat.IsDeleted) continue;
 			Label headerLabel = new()

--- a/Polytoria/scripts/client/ui/playerlist/UIUserCard.cs
+++ b/Polytoria/scripts/client/ui/playerlist/UIUserCard.cs
@@ -70,6 +70,18 @@ public partial class UIUserCard : Control
 	private void AddStat(Stat stat)
 	{
 		if (_statToUserCardStat.ContainsKey(stat)) return;
+
+		stat.PropertyChanged.Connect(_ => OnStatVisibilityChanged(stat));
+
+		if (!stat.Visible) return;
+
+		CreateStatRow(stat);
+	}
+
+	private void CreateStatRow(Stat stat)
+	{
+		if (_statToUserCardStat.ContainsKey(stat)) return;
+
 		var s = Globals.CreateInstanceFromScene<UIUserCardStat>(UserCardStat);
 		s.TargetStat = stat;
 		s.Root = this;
@@ -84,6 +96,22 @@ public partial class UIUserCard : Control
 
 		stat.Deleted += OnStatDeleted;
 		RefreshBox();
+	}
+
+	private void OnStatVisibilityChanged(Stat stat)
+	{
+		bool hasRow = _statToUserCardStat.ContainsKey(stat);
+
+		if (stat.Visible && !hasRow)
+		{
+			CreateStatRow(stat);
+		}
+		else if (!stat.Visible && hasRow)
+		{
+			_statToUserCardStat[stat].QueueFree();
+			_statToUserCardStat.Remove(stat);
+			RefreshBox();
+		}
 	}
 
 	private void RemoveStat(Stat stat)

--- a/Polytoria/scripts/client/ui/playerlist/UIUserCard.cs
+++ b/Polytoria/scripts/client/ui/playerlist/UIUserCard.cs
@@ -8,6 +8,7 @@ using Polytoria.Datamodel;
 using Polytoria.Datamodel.Resources;
 using Polytoria.Schemas.API;
 using Polytoria.Shared;
+using System;
 using System.Collections.Generic;
 
 namespace Polytoria.Client.UI.Playerlist;
@@ -85,7 +86,10 @@ public partial class UIUserCard : Control
 		var s = Globals.CreateInstanceFromScene<UIUserCardStat>(UserCardStat);
 		s.TargetStat = stat;
 		s.Root = this;
+
 		_statsContainer.AddChild(s);
+		_statsContainer.MoveChild(s, GetInsertIndex(stat));
+
 		_statToUserCardStat.Add(stat, s);
 
 		void OnStatDeleted()
@@ -96,6 +100,12 @@ public partial class UIUserCard : Control
 
 		stat.Deleted += OnStatDeleted;
 		RefreshBox();
+	}
+
+	private int GetInsertIndex(Stat stat)
+	{
+		Stat[] visibleStats = Root.Stats.GetVisibleStats();
+		return Array.IndexOf(visibleStats, stat);
 	}
 
 	private void OnStatVisibilityChanged(Stat stat)

--- a/Polytoria/scripts/datamodel/Stat.cs
+++ b/Polytoria/scripts/datamodel/Stat.cs
@@ -15,6 +15,7 @@ namespace Polytoria.Datamodel;
 public partial class Stat : Instance
 {
 	private string _displayName = "";
+	private bool _visible = true;
 
 	internal Dictionary<Player, object?> PlayerToStat = [];
 	public PTSignal<Player, object?> PlayerStatChanged = new();
@@ -29,6 +30,22 @@ public partial class Stat : Instance
 		set
 		{
 			_displayName = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool Visible
+	{
+		get => _visible;
+		set
+		{
+			if (_visible == value)
+			{
+				return;
+			}
+
+			_visible = value;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/Stats.cs
+++ b/Polytoria/scripts/datamodel/Stats.cs
@@ -38,6 +38,22 @@ public sealed partial class Stats : Instance
 		return [.. stats];
 	}
 
+	[ScriptMethod]
+	public Stat[] GetVisibleStats()
+	{
+		List<Stat> stats = [];
+
+		foreach (Instance item in GetChildren())
+		{
+			if (item is Stat { Visible: true } s)
+			{
+				stats.Add(s);
+			}
+		}
+
+		return [.. stats];
+	}
+
 	private void OnChildAdded(Instance instance)
 	{
 		if (instance is Stat stat)


### PR DESCRIPTION
## Summary
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Added the ability to hide certain stats from the leaderboard because not all stats should be visible to the player

## Related issue or discussion

Fixes #631 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

https://github.com/user-attachments/assets/202411bf-32d8-4f51-977d-e64efd9183a8


## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None