### PR TITLE
Adds `PhysicalRootStop` attribute to `Tool`.

### DIFF
--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace Polytoria.Datamodel;
 
-[Instantiable]
+[Instantiable, PhysicalRootStop]
 public sealed partial class Tool : RigidBody
 {
 	private bool _droppable = true;


### PR DESCRIPTION
## Summary

This change adds the `PhysicalRootStop` attribute to `Tool`, such that it's collision logic [is decoupled from the `NPC` instance's `Physical`](https://github.com/Psykatte/polytoria-game/blob/61d18996ab75876765f6086f0dd4db5178fae4e3/Polytoria/scripts/datamodel/Physical.cs#L376), as coupling the two was causing a lot of undefined behavior.

This results in:
- The `Tool`'s collision now correctly positions itself over the `Tool` itself, instead of it's last position.
- The `Tool`'s collision now follows the `Tool` instead of being anchored to the `NPC`.
- `Touched` events now register to the `Tool` instead of the `NPC` (e.g. this will prevent the `Tool` from triggering kill-bricks).

Note: Doesn't resolve behavior with dropped `Tool`s stretching, firing `Touched` events on the `NPC` holding them, or picking `Tool`s up positioning in the hand incorrectly.

## Related issue or discussion

Fixes #753
Fixes #750

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

None