### PR TITLE
`InvalidateBoundCache` on `SelectionBox.Target` setter.

### DIFF
--- a/Polytoria/scripts/creator/spatial/gizmos/SelectionBox.cs
+++ b/Polytoria/scripts/creator/spatial/gizmos/SelectionBox.cs
@@ -24,6 +24,8 @@ public partial class SelectionBox : Node
 			{
 				_target?.TransformChanged -= UpdateBox;
 				_target = value;
+				// When the target changes drop the cache so the new target recalculates it's bounds.
+				InvalidateBoundCache();
 				UpdateBox();
 				_target?.TransformChanged += UpdateBox;
 			}


### PR DESCRIPTION
## Summary

Resets the `SelectionBox` bound cache when the target changes, allowing it to be recalculated while dragging.

## Related issue or discussion

Fixes #692

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

None