### PR TITLE
Fix part colors on mobile OpenGL

### DIFF
--- a/Polytoria/resources/shaders/part/part.gdshader
+++ b/Polytoria/resources/shaders/part/part.gdshader
@@ -1,7 +1,7 @@
 shader_type spatial;
 render_mode cull_back, diffuse_burley, specular_schlick_ggx;
 
-instance uniform vec4 color : source_color = vec4(1.0);
+uniform vec4 color : source_color = vec4(1.0);
 
 uniform sampler2D albedo : source_color;
 uniform bool use_albedo_texture = true;

--- a/Polytoria/resources/shaders/part/part_transparent.gdshader
+++ b/Polytoria/resources/shaders/part/part_transparent.gdshader
@@ -1,7 +1,7 @@
 shader_type spatial;
 render_mode blend_mix, depth_prepass_alpha, cull_back, diffuse_burley, specular_schlick_ggx;
 
-instance uniform vec4 color : source_color = vec4(1.0);
+uniform vec4 color : source_color = vec4(1.0);
 
 uniform sampler2D albedo : source_color;
 uniform bool use_albedo_texture = true;

--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -75,6 +75,9 @@ public partial class DatamodelBridge : Node3D
 		base._ExitTree();
 	}
 
+	// opengl on mobile needs sRGB instead of linear, otherwise material colors will be dark.
+	private static Color ToInstanceColor(Color color) => Globals.UsesGLCompatibility ? color : color.SrgbToLinear();
+
 	private Material GetMaterial(Part.PartMaterialEnum partMaterial, bool isTransparent)
 	{
 		if (_materials.TryGetValue((partMaterial, isTransparent), out Material? mat))
@@ -136,7 +139,7 @@ public partial class DatamodelBridge : Node3D
 				{
 					ChunkBatch batch = _batches[handle.Key];
 					batch.MultiMesh.SetInstanceTransform(handle.Index, part.GetGlobalTransform());
-					batch.MultiMesh.SetInstanceColor(handle.Index, part.Color.SrgbToLinear());
+					batch.MultiMesh.SetInstanceColor(handle.Index, ToInstanceColor(part.Color));
 				}
 			}
 			else
@@ -252,7 +255,7 @@ public partial class DatamodelBridge : Node3D
 		batch.MultiMesh.VisibleInstanceCount = batch.Count;
 
 		batch.MultiMesh.SetInstanceTransform(index, part.GetGlobalTransform());
-		batch.MultiMesh.SetInstanceColor(index, part.Color.SrgbToLinear());
+		batch.MultiMesh.SetInstanceColor(index, ToInstanceColor(part.Color));
 
 		_handles[part] = new PartHandle { Key = key, Index = index };
 	}
@@ -280,7 +283,7 @@ public partial class DatamodelBridge : Node3D
 			{
 				batch.MultiMesh.SetInstanceTransform(index, lastPart.GetGlobalTransform());
 			}
-			batch.MultiMesh.SetInstanceColor(index, lastPart.Color.SrgbToLinear());
+			batch.MultiMesh.SetInstanceColor(index, ToInstanceColor(lastPart.Color));
 		}
 
 		batch.Parts.RemoveAt(lastIndex);
@@ -315,7 +318,7 @@ public partial class DatamodelBridge : Node3D
 		{
 			var p = batch.Parts[i];
 			batch.MultiMesh.SetInstanceTransform(i, p.GetGlobalTransform());
-			batch.MultiMesh.SetInstanceColor(i, p.Color.SrgbToLinear());
+			batch.MultiMesh.SetInstanceColor(i, ToInstanceColor(p.Color));
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -234,14 +234,14 @@ public partial class Part : Entity
 	{
 		if (_isSeparateMesh && _mesh != null)
 		{
-			Material targetMat = Globals.LoadMaterial(_material, Color.A);
+			Material baseMat = Globals.LoadMaterial(_material, Color.A);
+			Material targetMat = Globals.LoadColorMaterial(baseMat, _color);
+
 			if (!ReferenceEquals(_meshMaterial, targetMat))
 			{
 				_meshMaterial = targetMat;
 				_mesh.MaterialOverride = _meshMaterial;
 			}
-
-			_mesh.SetInstanceShaderParameter("color", _color);
 		}
 
 		UpdateCamLayer();

--- a/Polytoria/scripts/shared/Globals.cs
+++ b/Polytoria/scripts/shared/Globals.cs
@@ -67,6 +67,11 @@ public sealed partial class Globals : Node
 
 	private static readonly Dictionary<(Part.PartMaterialEnum, bool), Material> _materialCache = [];
 
+	private static readonly Dictionary<(Material, Color), ShaderMaterial> _colorMaterialCache = [];
+
+	private static bool? _usesGLCompatibility;
+	public static bool UsesGLCompatibility => _usesGLCompatibility ??= RenderingServer.GetCurrentRenderingMethod() == "gl_compatibility";
+
 	private static bool _isExiting = false;
 
 	public static bool IsExiting => _isExiting;
@@ -357,6 +362,24 @@ public sealed partial class Globals : Node
 		return mat;
 	}
 
+	public static Material LoadColorMaterial(Material baseMaterial, Color color)
+	{
+		if (baseMaterial is not ShaderMaterial baseShaderMat)
+		{
+			return baseMaterial;
+		}
+
+		if (_colorMaterialCache.TryGetValue((baseMaterial, color), out ShaderMaterial? mat))
+		{
+			return mat;
+		}
+
+		mat = (ShaderMaterial)baseShaderMat.Duplicate();
+		mat.SetShaderParameter("color", color);
+		_colorMaterialCache[(baseMaterial, color)] = mat;
+		return mat;
+	}
+
 	public static void SetNormalMapsEnabled(bool enabled)
 	{
 		foreach (var mat in _materialCache.Values)
@@ -365,6 +388,10 @@ public sealed partial class Globals : Node
 			{
 				shaderMat.SetShaderParameter("use_normal_texture", enabled);
 			}
+		}
+		foreach (var mat in _colorMaterialCache.Values)
+		{
+			mat.SetShaderParameter("use_normal_texture", enabled);
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Fixed part colors dark on mobile with gl_compability, along with colors being broken on older Android devices on gl_compability aswell.

## Related issue or discussion

Fixes -
Related to -

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

### Before:

<img width="3120" height="1440" alt="Screenshot_20260618_142620_PolyDroid 3" src="https://github.com/user-attachments/assets/980a5469-f1a8-4576-8f28-e26538086914" />

### After:

<img width="3120" height="1440" alt="Screenshot_20260618_151537_PolyDroid 3" src="https://github.com/user-attachments/assets/1eedf0a1-32d2-4ab8-9dbf-1817feef4ac2" />

dont mind the sprint buttons, they're on my seperate fork i tested on
<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
Claude helped with debugging the broken colors.