### PR TITLE
Customisation for Player Character Rotation Modes

### DIFF
--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -1137,7 +1137,7 @@ public sealed partial class Player : NPC
 	{
 		Automatic, // Default value (works how it did before), automatically switches between rotating to movement or facing camera when Ctrl Locked or in First Person
 		CameraLocked,
-		RotateToMovement,
-		RotateToMovementCtrlLockOnly // separate version that still locks in First Person, will only rotate to movement when Ctrl Locked
+		Movement,
+		MovementCtrlLockOnly // separate version that still locks in First Person, will only rotate to movement when Ctrl Locked
 	}
 }

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -52,6 +52,7 @@ public sealed partial class Player : NPC
 	private bool _autoLoadAppearance = true;
 	private bool _allowAnimationWhileMoving = false;
 	private PlayerMovementModeEnum _movementMode = PlayerMovementModeEnum.Default;
+	private PlayerRotationModeEnum _rotationMode = PlayerRotationModeEnum.Automatic;
 	private Team? _team;
 	private Color _chatColorBeforeTeam;
 
@@ -284,6 +285,17 @@ public sealed partial class Player : NPC
 				_ => null,
 			};
 
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public PlayerRotationModeEnum RotationMode
+	{
+		get => _rotationMode;
+		set
+		{
+			_rotationMode = value;
 			OnPropertyChanged();
 		}
 	}
@@ -1118,5 +1130,14 @@ public sealed partial class Player : NPC
 	{
 		Default,
 		Scripted
+	}
+
+	[ScriptEnum]
+	public enum PlayerRotationModeEnum
+	{
+		Automatic, // Default value (works how it did before), automatically switches between rotating to movement or facing camera when Ctrl Locked or in First Person
+		CameraLocked,
+		RotateToMovement,
+		RotateToMovementCtrlLockOnly // separate version that still locks in First Person, will only rotate to movement when Ctrl Locked
 	}
 }

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -46,7 +46,21 @@ public class DefaultMovement : IPlayerMovement
 				}
 			}
 
-			camLocked = cam.IsFirstPerson || cam.CtrlLocked;
+			switch (Target.RotationMode)
+			{
+				case Player.PlayerRotationModeEnum.Automatic:
+					camLocked = cam.IsFirstPerson || cam.CtrlLocked;
+					break;
+				case Player.PlayerRotationModeEnum.CameraLocked:
+					camLocked = true;
+					break;
+				case Player.PlayerRotationModeEnum.RotateToMovement:
+					camLocked = false;
+					break;
+				case Player.PlayerRotationModeEnum.RotateToMovementCtrlLockOnly:
+					camLocked = cam.IsFirstPerson;
+					break;
+			}
 		}
 
 		return new()

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -54,10 +54,10 @@ public class DefaultMovement : IPlayerMovement
 				case Player.PlayerRotationModeEnum.CameraLocked:
 					camLocked = true;
 					break;
-				case Player.PlayerRotationModeEnum.RotateToMovement:
+				case Player.PlayerRotationModeEnum.Movement:
 					camLocked = false;
 					break;
-				case Player.PlayerRotationModeEnum.RotateToMovementCtrlLockOnly:
+				case Player.PlayerRotationModeEnum.MovementCtrlLockOnly:
 					camLocked = cam.IsFirstPerson;
 					break;
 			}


### PR DESCRIPTION
## Note

Repost of #768. I'm really sorry about that, I don't understand git at all (fingers crossed it works this time)

## Summary

Adds a new enum to the Player: "PlayerRotationMode", which overrides how the character rotates, detaching modes like face camera off of CtrlLock. For example, a game could have "Always Ctrl Lock" enabled so users don't have to break RMB, but the character could still rotate to face movement

PlayerRotationMode has 4 items:
- "Automatic", the default which works exactly how it did before. Rotate character to movement normally, rotate character with camera in CtrlLock or First Person
- "CameraLocked", always rotates character with the camera, like Ctrl Lock or First Person, even when you aren't in either
- "RotateToMovement", always makes the character rotate in the direction you are moving, even when Ctrl Locked or in First Person
- "RotateToMovementCtrlLockOnly", same as "RotateToMovement" except it doesn't rotate to movement in First Person, it still rotates with the camera (ik it's a wordy name, but i wanted it to be clear what it does)

## Related issue or discussion

never made a feature request, just made it

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Networking / replication
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

CameraLocked:

https://github.com/user-attachments/assets/3507c5b5-d0c0-4633-af22-368791f0df37

RotateToMovement:

https://github.com/user-attachments/assets/653326e6-cc95-4bdf-84bf-c9f1946347c6

RotateToMovementCtrlLockOnly:

https://github.com/user-attachments/assets/5a2d5908-eac9-4860-95ad-732e7b90392c

## AI/LLM use

None