### PR TITLE
Fix memory leak when deselecting creator instances

### DIFF
--- a/Polytoria/scripts/creator/spatial/gizmos/SelectionBox.cs
+++ b/Polytoria/scripts/creator/spatial/gizmos/SelectionBox.cs
@@ -59,6 +59,11 @@ public partial class SelectionBox : Node
 	{
 		_selectionBoxMesh?.QueueFree();
 		_selectionBoxXrayMesh?.QueueFree();
+
+		_selectionBox?.Dispose();
+		_selectionBoxXray?.Dispose();
+		_mat?.Dispose();
+		_matXray?.Dispose();
 		base._ExitTree();
 	}
 
@@ -105,6 +110,9 @@ public partial class SelectionBox : Node
 		};
 		stXray.SetMaterial(_matXray);
 		_selectionBoxXray = stXray.Commit();
+
+		st.Dispose();
+		stXray.Dispose();
 
 		_selectionBoxMesh = new MeshInstance3D { Mesh = _selectionBox };
 		Root.GDNode.AddChild(_selectionBoxMesh, @internal: Node.InternalMode.Back);


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Fixed memory leaking when selecting and deselecting a large amount of objects. It also seems this fixed lag spikes when selecting large amounts of objects, but I'm not sure.

## Related issue or discussion

Fixes #752 
Related to -

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

### Before:
<img width="419" height="41" alt="Screenshot 2026-06-21 142756" src="https://github.com/user-attachments/assets/8529c23b-16f6-4e77-86a4-fa4b7a88035f" />

### After:
<img width="420" height="42" alt="Screenshot 2026-06-21 142616" src="https://github.com/user-attachments/assets/8502a8ae-192f-4a16-a64e-8086fd08b3f7" />

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None