### PR TITLE
Prevent the player from sitting on a seat if they are already sitting on a seat

### DIFF
--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -93,13 +93,13 @@ public partial class Seat : Part
 		if (hit is Player plr)
 		{
 			if (!CanPlayerSit) { return; }
-			if(plr.IsSitting) { return; }
+			if (plr.IsSitting) { return; }
 			plr.Sit(this);
 		}
 		else if (hit is NPC npc)
 		{
 			if (!CanNPCSit) { return; }
-			if(npc.IsSitting) { return; }
+			if (npc.IsSitting) { return; }
 			npc.Sit(this);
 		}
 	}

--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -93,11 +93,13 @@ public partial class Seat : Part
 		if (hit is Player plr)
 		{
 			if (!CanPlayerSit) { return; }
+			if(plr.IsSitting) { return; }
 			plr.Sit(this);
 		}
 		else if (hit is NPC npc)
 		{
 			if (!CanNPCSit) { return; }
+			if(npc.IsSitting) { return; }
 			npc.Sit(this);
 		}
 	}


### PR DESCRIPTION
## Summary

added a check to prevent NPCs and Players from sitting on another Seat if they already are sitting. this prevents Seats from having a fake occupant as the occupant must unsit properly in order to sit on the other Seat

## Related issue or discussion

Fixes #787 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
here the player managed to sit on the left Seat while sitting on the right first breaking the right
<img width="889" height="836" alt="1" src="https://github.com/user-attachments/assets/b544629f-cc06-4081-8bc2-82c656529117" />
here the player didnt sit on the left Seat as the Seat now checks if the Player is already sitting before trying to sit them
<img width="903" height="685" alt="i" src="https://github.com/user-attachments/assets/79bb83bf-da0b-4ca4-8198-fa52e8511ae0" />


## AI/LLM use

None