### PR TITLE
Player.KeepInventory + PlayerDefaults.KeepInventory

### DIFF
--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -201,7 +201,7 @@ public sealed partial class Player : NPC
 			OnPropertyChanged();
 		}
 	}
-	
+
 	[Editable, ScriptProperty]
 	public bool KeepInventory
 	{

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -46,6 +46,7 @@ public sealed partial class Player : NPC
 	private bool _useStamina = true;
 	private float _staminaRegen = 1.2f;
 	private float _staminaBurn = 1.2f;
+	private bool _keepInventory = false;
 	private bool _useHeadTurning = false;
 	private int _userID;
 	private bool _useBubbleChat = true;
@@ -197,6 +198,17 @@ public sealed partial class Player : NPC
 		set
 		{
 			_respawnTime = value;
+			OnPropertyChanged();
+		}
+	}
+	
+	[Editable, ScriptProperty]
+	public bool KeepInventory
+	{
+		get => _keepInventory;
+		set
+		{
+			_keepInventory = value;
 			OnPropertyChanged();
 		}
 	}
@@ -1018,6 +1030,7 @@ public sealed partial class Player : NPC
 		StaminaBurn = Root.PlayerDefaults.StaminaBurn;
 		JumpPower = Root.PlayerDefaults.JumpPower;
 		RespawnTime = Root.PlayerDefaults.RespawnTime;
+		KeepInventory = Root.PlayerDefaults.KeepInventory;
 		UseHeadTurning = Root.PlayerDefaults.UseHeadTurning;
 		UseBubbleChat = Root.PlayerDefaults.UseBubbleChat;
 		AutoLoadAppearance = Root.PlayerDefaults.AutoLoadAppearance;
@@ -1043,9 +1056,12 @@ public sealed partial class Player : NPC
 		// Only allow this operation in server
 		if (!Root.Network.IsServer) return;
 
-		foreach (Instance item in Inventory.GetChildren())
+		if (!KeepInventory)
 		{
-			item.Delete();
+			foreach (Instance item in Inventory.GetChildren())
+			{
+				item.Delete();
+			}
 		}
 
 		if (Root.PlayerDefaults.Inventory != null)

--- a/Polytoria/scripts/datamodel/PlayerDefaults.cs
+++ b/Polytoria/scripts/datamodel/PlayerDefaults.cs
@@ -23,6 +23,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 	private bool _useStamina;
 	private float _staminaRegen;
 	private float _staminaBurn;
+	private bool _keepInventory;
 	private bool _useHeadTurning;
 	private bool _useBubbleChat;
 	private bool _autoLoadAppearance;
@@ -175,6 +176,18 @@ public sealed partial class PlayerDefaults : HiddenBase
 		set
 		{
 			_staminaRegen = value;
+			OnPropertyChanged();
+		}
+	}
+
+
+	[Editable, ScriptProperty]
+	public bool KeepInventory
+	{
+		get => _keepInventory;
+		set
+		{
+			_keepInventory = value;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

adds a property to Player and PlayerDefaults that when enabled does not clear out your inventory upon respawning.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

none!