### PR TITLE
Add RigidBody.GravityScale

### DIFF
--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -15,7 +15,7 @@ public partial class RigidBody : Physical
 	internal RigidBody3D GDRigidBody = null!;
 	internal PhysicsMaterial PhysicsMat = null!;
 
-	private bool _useGravity = true;
+	private float _gravityScale;
 	private bool _lockRotation = false;
 	private float _mass;
 	private float _friction;
@@ -51,20 +51,37 @@ public partial class RigidBody : Physical
 		}
 	}
 
-	[Editable, ScriptProperty, DefaultValue(true)]
-	public bool UseGravity
+	[Editable, ScriptProperty, DefaultValue(1f)]
+	public float GravityScale
 	{
-		get => _useGravity;
+		get => _gravityScale;
 		set
 		{
-			if (_useGravity == value)
+			if (_gravityScale == value)
 			{
 				return;
 			}
 
-			_useGravity = value;
+			_gravityScale = value;
 
-			GDRigidBody.GravityScale = value ? 2 : 0;
+			GDRigidBody.GravityScale = value * 2f;
+
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use GravityScale instead"), CloneIgnore, SaveIgnore]
+	public bool UseGravity
+	{
+		get => GravityScale != 0f;
+		set
+		{
+			if (UseGravity == value)
+			{
+				return;
+			}
+
+			GravityScale = value ? 1f : 0f;
 
 			OnPropertyChanged();
 		}


### PR DESCRIPTION
## Summary

adds `RigidBody.GravityScale`, which allows setting [`RigidBody3D.gravity_scale`](https://docs.godotengine.org/en/stable/classes/class_rigidbody3d.html#class-rigidbody3d-property-gravity-scale) to any number, instead of the binary 0 or 2 that `RigidBody.UseGravity` provides (Polytoria doubles the gravity scale of everything, no idea why). `RigidBody.UseGravity` has been marked obsolete and is now just a wrapper over `RigidBody.GravityScale` (if `RigidBody.UseGravity` then `RigidBody.GravityScale` = 1 else `RigidBody.GravityScale` = 0)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None