### PR TITLE
Scripting: Prevent wait() from resuming dead coroutines

### DIFF
--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -1064,7 +1064,19 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 
 	private static async Task HandleYieldTaskAsync(LuaState thread, LuaState from, Task<int> initialTask)
 	{
-		await ResumeThread(thread, from, await initialTask, false);
+		int narg = await initialTask;
+		LuaCoStatus costatus;
+		lock (thread)
+		{
+			costatus = thread.CoStatus(from);
+		}
+
+		// Luau will throw an error if you attempt to resume a dead coroutine.
+		// If the coroutine is finished, don't resume.
+		if (costatus == LuaCoStatus.CoFin)
+			return;
+
+		await ResumeThread(thread, from, narg, false);
 	}
 
 #if DEBUG

--- a/Polytoria/scripts/scripting/languages/luau/native/LuaCoStatus.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/LuaCoStatus.cs
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+namespace Polytoria.Scripting.Luau;
+/// <summary>
+/// Lua Coroutine status return
+/// </summary>
+public enum LuaCoStatus
+{
+	/// <summary>
+	/// Running
+	/// </summary>
+	CoRun = 0,
+	/// <summary>
+	/// Suspended
+	/// </summary>
+	CoSus = 1,
+	/// <summary>
+	/// 'Normal' (Resumed another coroutine...)
+	/// </summary>
+	CoNor = 2,
+	/// <summary>
+	/// Finished
+	/// </summary>
+	CoFin = 3,
+	/// <summary>
+	/// Finished with Error
+	/// </summary>
+	CoErr = 4,
+}

--- a/Polytoria/scripts/scripting/languages/luau/native/LuaCoStatus.cs.uid
+++ b/Polytoria/scripts/scripting/languages/luau/native/LuaCoStatus.cs.uid
@@ -1,0 +1,1 @@
+uid://c2fkgv85teq8f

--- a/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
@@ -663,6 +663,12 @@ public partial class LuaState : IDisposable
 			return (LuaStatus)NativeBindings.lua_status(_state);
 	}
 
+	public LuaCoStatus CoStatus(LuaState co)
+	{
+		lock (_lock)
+			return (LuaCoStatus)NativeBindings.lua_costatus(_state, co.State);
+	}
+
 	public int Yield(int nresults)
 	{
 		lock (_lock)

--- a/Polytoria/scripts/scripting/languages/luau/native/NativeBindings.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/NativeBindings.cs
@@ -232,6 +232,10 @@ internal partial class NativeBindings
 	internal static partial int lua_status(IntPtr L);
 
 	[LibraryImport(LuaLibraryName)]
+	[UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+	internal static partial int lua_costatus(IntPtr L, IntPtr co);
+
+	[LibraryImport(LuaLibraryName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	internal static partial void lua_setmetatable(IntPtr luaState, int objIndex);
 


### PR DESCRIPTION
## Summary

This pull request introduces an additional check in `HandleYieldTaskAsync()` that prevents a coroutine from being resumed if it's already dead. In addition, new native bindings were added to make this feature a reality. (e.g. bindings to `lua_costatus`)

## Related issue or discussion

Fixes #748

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Don't think this is necessary here. However, **testing will need to be done before this is merged.**

## AI/LLM use

No AI/LLMs were used in the making of this pull request.