### PR TITLE
Ignore RotationUInt64 from serialization

### DIFF
--- a/Polytoria/scripts/utils/dto/TransformPayload.cs
+++ b/Polytoria/scripts/utils/dto/TransformPayload.cs
@@ -55,6 +55,8 @@ public partial class TransformPayloadDto
 	// UnitQuaternionDto has a ~0.137 degree step and uses 4 bytes,
 	// UnitQuaternionUInt64Dto has a ~0.003 497 degree step and uses 8 bytes.
 	// This is the the unimplemented TransformPayload logic for higher precision network replication of rotations.
+	[MemoryPackIgnore]
+	[JsonIgnore]
 	public ulong RawRotationUInt64
 	{
 		get => BitConverter.ToUInt64(Data, 12);
@@ -65,6 +67,8 @@ public partial class TransformPayloadDto
 		}
 	}
 
+	[MemoryPackIgnore]
+	[JsonIgnore]
 	public Quaternion RotationUInt64
 	{
 		get => UnitQuaternionUInt64Dto.FromCompressed(RawRotationUInt64);


### PR DESCRIPTION
## Summary

TransformPayloadDto still serializes transform payloads using the 16-byte layout, but PR #805 adds RawRotationUInt64/RotationUInt64 which get included by memorypack serialization which throws an error. This PR excludes the unused rotation properties from serialization

## Related issue or discussion
Related to #805

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [x] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Behavior before the fix:

https://github.com/user-attachments/assets/6a3f1c9c-7ba7-47f7-805a-58fcc0f3444a

## AI/LLM use

None