### PR TITLE
Do not overwrite luaurc file if it already exists

### DIFF
--- a/Polytoria/scripts/creator/CreatorSession.cs
+++ b/Polytoria/scripts/creator/CreatorSession.cs
@@ -214,7 +214,11 @@ public partial class CreatorSession : Node, IDisposable
 
 			PT.Print("Writing doc...");
 			File.WriteAllText(versionPath, Globals.AppVersion);
-			File.WriteAllText(luauRcPath, LuauRCContent);
+
+			if (!File.Exists(luauRcPath))
+			{
+				File.WriteAllText(luauRcPath, LuauRCContent);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

When writing my tool polysync it auto generates a luaurc file however when opening a new polytoria project in the same directory it would overwrite the file.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None