### PR TITLE
Fix IgnoreMouse Reset After Reparenting

### DIFF
--- a/Polytoria/scripts/datamodel/UIField.cs
+++ b/Polytoria/scripts/datamodel/UIField.cs
@@ -231,7 +231,7 @@ public partial class UIField : Instance
 		IsParentedToCreatorGUI = IsDescendantOfClass<CreatorGUI>();
 		if (!IsParentedToCreatorGUI)
 		{
-			NodeControl.MouseFilter = Control.MouseFilterEnum.Pass;
+			NodeControl.MouseFilter = IgnoreMouse ? Control.MouseFilterEnum.Ignore : Control.MouseFilterEnum.Pass;
 			NodeControl.FocusMode = Control.FocusModeEnum.Click;
 		}
 #endif


### PR DESCRIPTION
## Summary

Fixes #166. Bug was caused by a line in EnterTree which would override the internal Enum IgnoreMouse changes

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None