### PR TITLE
Fix Stat:Set(Player, <string>) and similar methods that have <string> and <double> overloads

### DIFF
--- a/Polytoria/scripts/datamodel/services/ScriptService.cs
+++ b/Polytoria/scripts/datamodel/services/ScriptService.cs
@@ -380,14 +380,14 @@ public sealed partial class ScriptService : Instance
 			return true;
 		}
 
-		// IConvertible fallback
-		if (arg is IConvertible && typeof(IConvertible).IsAssignableFrom(underlying))
-			return true;
-
 		// string to double
 		if (arg is string s && (underlying == typeof(int) || underlying == typeof(long)
 			|| underlying == typeof(short) || underlying == typeof(float) || underlying == typeof(double)))
 			return double.TryParse(s, out _);
+
+		// IConvertible fallback
+		if (arg is IConvertible && typeof(IConvertible).IsAssignableFrom(underlying))
+			return true;
 
 		return false;
 	}


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Changed order of "string to double" and "arg to IConvertible" validations inside of `ScriptService.IsObjectConvertible`

Both conditions are true and its bad because of logic finds function with wrong overload when using `ScriptService.IsObjectConvertible` for test if parameters are eligible

## Related issue or discussion

None

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->
None

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None