### PR TITLE
Fix inventory button not being hidden when CoreUI.UseBackpack is disabled

### DIFF
--- a/Polytoria/scenes/client/ui/core_ui.tscn
+++ b/Polytoria/scenes/client/ui/core_ui.tscn
@@ -274,7 +274,7 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[node name="CoreUI" type="CanvasLayer" unique_id=520186302 node_paths=PackedStringArray("GameMenu", "MenuButton", "UserCard", "Chat", "ChatButton", "HealthBar", "Leaderboard", "Inventory", "EmoteWheel", "NotificationCenter", "CapturePreview", "PurchasePrompt", "CtrlLockCursor", "DevWindow")]
+[node name="CoreUI" type="CanvasLayer" unique_id=520186302 node_paths=PackedStringArray("GameMenu", "MenuButton", "UserCard", "Chat", "ChatButton", "HealthBar", "Leaderboard", "Inventory", "InventoryButton", "EmoteWheel", "NotificationCenter", "CapturePreview", "PurchasePrompt", "CtrlLockCursor", "DevWindow")]
 layer = 100
 script = ExtResource("1_aji3h")
 GameMenu = NodePath("Control/GameMenu")
@@ -285,6 +285,7 @@ ChatButton = NodePath("Control/MenuButton/Chat")
 HealthBar = NodePath("Control/HealthBar")
 Leaderboard = NodePath("Control/Playerlist/Pivot/Pivot/Pivot/PlayerlistPivot/Container/Leaderboard")
 Inventory = NodePath("Control/Inventory")
+InventoryButton = NodePath("Control/MenuButton/Backpack")
 EmoteWheel = NodePath("Control/EmoteWheel")
 NotificationCenter = NodePath("Control/Notification")
 CapturePreview = NodePath("Control/Capture")

--- a/Polytoria/scripts/client/ui/CoreUIRoot.cs
+++ b/Polytoria/scripts/client/ui/CoreUIRoot.cs
@@ -33,6 +33,7 @@ public partial class CoreUIRoot : CanvasLayer
 	[Export] public UIHealthbar HealthBar = null!;
 	[Export] public UILeaderboard Leaderboard = null!;
 	[Export] public UIInventory Inventory = null!;
+	[Export] public UIInventoryButton InventoryButton = null!;
 	[Export] public UIEmoteWheel EmoteWheel = null!;
 	[Export] public UINotification NotificationCenter = null!;
 	[Export] public UICapturePreview CapturePreview = null!;
@@ -58,6 +59,7 @@ public partial class CoreUIRoot : CanvasLayer
 		NotificationCenter.CoreUI = this;
 		CapturePreview.CoreUI = this;
 		Inventory.CoreUI = this;
+		InventoryButton.CoreUI = this;
 		Leaderboard.CoreUI = this;
 		Chat.CoreUI = this;
 		ChatButton.CoreUI = this;
@@ -91,10 +93,7 @@ public partial class CoreUIRoot : CanvasLayer
 
 	private void SyncCtrlLockCursor()
 	{
-		if (CtrlLockCursor != null)
-		{
-			CtrlLockCursor.Visible = Root?.Environment?.CurrentCamera?.CtrlLocked == true;
-		}
+		CtrlLockCursor?.Visible = Root?.Environment?.CurrentCamera?.CtrlLocked == true;
 	}
 
 	private void OnCtrlLockCursorChanged()

--- a/Polytoria/scripts/client/ui/inventory/UIInventory.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIInventory.cs
@@ -64,7 +64,7 @@ public partial class UIInventory : Control
 
 	public void OpenBackpack()
 	{
-		if (!CoreUI.Service.UseBackpack) return;
+		if (IsBackpackOpened || !CoreUI.Service.UseBackpack) return;
 		IsBackpackOpened = true;
 		_backpackAnim.Stop();
 		_backpackAnim.Play("appear");
@@ -72,7 +72,7 @@ public partial class UIInventory : Control
 
 	public void CloseBackpack()
 	{
-		if (!CoreUI.Service.UseBackpack) return;
+		if (!IsBackpackOpened) return;
 		IsBackpackOpened = false;
 		_backpackAnim.Stop();
 		_backpackAnim.Play("disappear");

--- a/Polytoria/scripts/client/ui/inventory/UIInventoryButton.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIInventoryButton.cs
@@ -10,6 +10,8 @@ public partial class UIInventoryButton : Button
 {
 	[Export] public UIInventory InventoryUI { get; set; } = null!;
 
+	public CoreUIRoot CoreUI = null!;
+
 	public override void _Ready()
 	{
 		Toggled += OnToggled;
@@ -17,6 +19,7 @@ public partial class UIInventoryButton : Button
 
 	internal void OnToggled(bool toggleOn)
 	{
+		if (!CoreUI.Service.UseBackpack) return;
 		if (toggleOn)
 		{
 			InventoryUI.OpenBackpack();
@@ -29,7 +32,7 @@ public partial class UIInventoryButton : Button
 
 	public override void _UnhandledInput(InputEvent @event)
 	{
-		if (@event.IsActionPressed("toggle_backpack"))
+		if (@event.IsActionPressed("toggle_backpack") && CoreUI.Service.UseBackpack)
 		{
 			SetPressedNoSignal(!ButtonPressed);
 		}

--- a/Polytoria/scripts/datamodel/services/CoreUIService.cs
+++ b/Polytoria/scripts/datamodel/services/CoreUIService.cs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-using Godot;
 using Polytoria.Attributes;
 using Polytoria.Client.UI;
 using Polytoria.Scripting;
@@ -31,8 +30,6 @@ public sealed partial class CoreUIService : Instance
 	public CoreUIRoot CoreUI = null!;
 
 	public PTSignal CtrlLockCursorChanged { get; private set; } = new();
-
-
 
 	[Editable, ScriptProperty]
 	public CtrlLockCursorEnum CtrlLockCursor
@@ -134,6 +131,12 @@ public sealed partial class CoreUIService : Instance
 			CoreUI.HealthBar.Visible = UseHealthBar;
 			CoreUI.Leaderboard.Visible = UseLeaderboard;
 			CoreUI.Inventory.Visible = UseHotbar;
+			CoreUI.InventoryButton.Visible = UseBackpack;
+			if (!UseBackpack)
+			{
+				CoreUI.Inventory.CloseBackpack();
+				CoreUI.InventoryButton.SetPressedNoSignal(false);
+			}
 			CoreUI.MenuButton.Visible = UseMenuButton;
 			CoreUI.EmoteWheel.UseEmoteWheel = UseEmoteWheel;
 		}


### PR DESCRIPTION
## Summary

hides the inventory button and closes the inventory when `CoreUI.UseBackpack` is set to false. also ensures the inventory button cannot be toggled using the keybind when `CoreUI.UseBackpack` is false

## Related issue or discussion

Fixes #825

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width=640 height=360 src=https://github.com/user-attachments/assets/9e94bd6d-939e-4b37-9b89-b55fe34917a2>

## AI/LLM use

None