### PR TITLE
fix: robust type conversion for array types

### DIFF
--- a/Polytoria/scripts/datamodel/services/ScriptService.cs
+++ b/Polytoria/scripts/datamodel/services/ScriptService.cs
@@ -349,10 +349,7 @@ public sealed partial class ScriptService : Instance
 		{
 			Type? elemType = targetType.GetElementType();
 			if (elemType == null) return false;
-			foreach (object? elem in objArr)
-				if (elem != null && !elemType.IsAssignableFrom(elem.GetType()))
-					return false;
-			return true;
+			return objArr.All((element) => IsObjectConvertible(element, elemType));
 		}
 
 		// Empty array to dictionary
@@ -476,20 +473,8 @@ public sealed partial class ScriptService : Instance
 			if (targetElementType == null)
 				return null;
 
-			// Check if all elements are assignable to target element type
-			bool allCompatible = true;
-
-			for (int i = 0; i < objectArray.Length; i++)
-			{
-				if (objectArray[i] != null && !targetElementType.IsAssignableFrom(objectArray[i].GetType()))
-				{
-					allCompatible = false;
-					break;
-				}
-			}
-
 			// If all elements are compatible, create a typed array
-			if (allCompatible)
+			if (objectArray.All((element) => IsObjectConvertible(element, targetElementType)))
 			{
 				List<object> convertedList = [];
 				for (int i = 0; i < objectArray.Length; i++)


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Array type values are being checked for compatibility strictly by `Type.IsAssignableFrom` during conversion. This causes arrays of enum values to be considered incompatible and likely imposes similar limitations.

Type compatibility via `IsObjectConvertible` already handles special cases on top of general cases like `Type.IsAssignableFrom`. This change switches to `IsObjectConvertible` recursion when considering array compatibility.

## Related issue or discussion

Fixes #834 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None