### PR TITLE
Reorganize when ChildAdded is fired

### DIFF
--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -650,7 +650,7 @@ public partial class NetworkedObject : IScriptObject
 		if (_netObjToProxy.Remove(this, out var gdn))
 		{
 			// Delete Valid Root node only
-			if (Node.IsInstanceValid(gdn) && !DeletedAsChild)
+			if (GodotObject.IsInstanceValid(gdn) && !DeletedAsChild)
 			{
 				gdn.QueueFree();
 				gdn.Dispose();
@@ -913,7 +913,7 @@ public partial class NetworkedObject : IScriptObject
 
 		if (GDNode != null && NetworkParent != null)
 		{
-			if (!Node.IsInstanceValid(NetworkParent.SlotNode)) return;
+			if (!GodotObject.IsInstanceValid(NetworkParent.SlotNode)) return;
 			Node? parent = GDNode.GetParentOrNull<Node>();
 			if (parent == null)
 			{
@@ -1239,7 +1239,7 @@ public partial class NetworkedObject : IScriptObject
 		NetPropReplicateData[] props = data.Props;
 		//PT.Print(Root.Network.LocalPeerID, " ", data.nodePath, " on the way");
 
-		NetworkedObject? existingObj = null;
+		NetworkedObject? existingObj;
 
 
 		if (this is Instance i3)
@@ -1569,7 +1569,7 @@ public partial class NetworkedObject : IScriptObject
 
 	internal NetworkedObject CloneInternal(NetworkedObject? parent = null, bool isRoot = false)
 	{
-		NetworkedObject clonedRoot = NewInternal(ClassName, null, Root)!;
+		NetworkedObject clonedRoot = NewInternal(ClassName, null, Root);
 
 		// Disable auto replicate on instances
 		// NOTE: This could be reworked so it sends a chunk of networked objects.

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -83,19 +83,6 @@ public partial class NetworkedObject : IScriptObject
 			_networkParent = value;
 			ReenforceName();
 
-			if (_networkParent != null && this is not Instance)
-			{
-				_networkParent.NonInstanceChildren.Add(this);
-			}
-			if (_networkParent is Instance postI && this is Instance selfpostI)
-			{
-				selfpostI.AddNameToParent();
-				selfpostI.AddLegacyNameToParent();
-				postI.Children.Add(selfpostI);
-				selfpostI.Index = postI.Children.Count - 1;
-				postI.ChildAdded.Invoke(selfpostI);
-			}
-
 			if (_networkParent != null)
 			{
 				if (!InvokedEntry)
@@ -105,6 +92,23 @@ public partial class NetworkedObject : IScriptObject
 				else
 				{
 					InvokeEnterTree();
+				}
+
+				if (this is Instance selfpostI)
+				{
+					if (_networkParent is Instance postI)
+					{
+						selfpostI.AddNameToParent();
+						selfpostI.AddLegacyNameToParent();
+						int index = postI.Children.Count;
+						postI.Children.Add(selfpostI);
+						selfpostI.Index = index;
+						postI.ChildAdded.Invoke(selfpostI);
+					}
+				}
+				else
+				{
+					_networkParent.NonInstanceChildren.Add(this);
 				}
 
 				try

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -4,7 +4,6 @@
 
 using Godot;
 using Polytoria.Attributes;
-using Polytoria.Datamodel.Data;
 using Polytoria.Networking;
 using Polytoria.Scripting;
 using Polytoria.Shared;
@@ -273,7 +272,7 @@ public partial class Physical : Dynamic
 	{
 		foreach (CollisionShape3D c in CollisionShapes.ToArray())
 		{
-			if (!Node.IsInstanceValid(c)) continue;
+			if (!GodotObject.IsInstanceValid(c)) continue;
 			c.Disabled = disabled;
 		}
 	}
@@ -339,7 +338,7 @@ public partial class Physical : Dynamic
 			// create pending shapes
 			foreach (var shape in _pendingAreaShapes.ToArray())
 			{
-				if (Node.IsInstanceValid(shape))
+				if (GodotObject.IsInstanceValid(shape))
 					CreateAreaShape(shape);
 			}
 
@@ -442,7 +441,7 @@ public partial class Physical : Dynamic
 			PhysicalArea.BodyShapeEntered -= BodyShapeEntered;
 			PhysicalArea.BodyShapeExited -= BodyShapeExited;
 
-			if (Node.IsInstanceValid(PhysicalArea))
+			if (GodotObject.IsInstanceValid(PhysicalArea))
 			{
 				PhysicalArea.QueueFree();
 			}
@@ -679,7 +678,7 @@ public partial class Physical : Dynamic
 		List<Node> createdNodes = selector(state);
 		foreach (Node node in createdNodes)
 		{
-			if (node != null && Node.IsInstanceValid(node))
+			if (node != null && GodotObject.IsInstanceValid(node))
 			{
 				if (removeAreaShapes && node is CollisionShape3D shape)
 				{
@@ -709,7 +708,7 @@ public partial class Physical : Dynamic
 
 	private void CreateAreaShape(CollisionShape3D origin)
 	{
-		if (!Node.IsInstanceValid(origin)) return;
+		if (!GodotObject.IsInstanceValid(origin)) return;
 
 		// If is hidden, don't create area shape yet
 		if (IsHidden && PhysicalRoot == null)
@@ -724,7 +723,7 @@ public partial class Physical : Dynamic
 	internal static void SetRemoteLinkTarget(CollisionShape3D collisionShape, Node? target)
 	{
 		RemoteLinkConfig config = _remoteLinkConfigs.GetOrCreateValue(collisionShape);
-		config.Target = target != null && Node.IsInstanceValid(target) ? target : null;
+		config.Target = target != null && GodotObject.IsInstanceValid(target) ? target : null;
 	}
 
 	internal static void SetRemoteLinkOffset(CollisionShape3D collisionShape, Vector3 offset)
@@ -760,7 +759,7 @@ public partial class Physical : Dynamic
 		for (int i = trackedNodes.Count - 1; i >= 0; i--)
 		{
 			Node node = trackedNodes[i];
-			if (node != null && Node.IsInstanceValid(node))
+			if (node != null && GodotObject.IsInstanceValid(node))
 			{
 				return true;
 			}
@@ -789,7 +788,7 @@ public partial class Physical : Dynamic
 		RemoteLinkConfig? config = GetRemoteLinkConfig(origin);
 		Node? target = config?.Target;
 
-		if (target != null && Node.IsInstanceValid(target))
+		if (target != null && GodotObject.IsInstanceValid(target))
 		{
 			target.AddChild(scaleNode, @internal: Node.InternalMode.Back);
 		}
@@ -818,7 +817,7 @@ public partial class Physical : Dynamic
 
 	private void EnsureRemoteTransform(CollisionShape3D origin)
 	{
-		if (!Node.IsInstanceValid(origin)) return;
+		if (!GodotObject.IsInstanceValid(origin)) return;
 
 		if (HasValidTrackedNodes(origin, static state => state.CollisionSyncNodes))
 		{
@@ -831,7 +830,7 @@ public partial class Physical : Dynamic
 
 	private void CreateAreaShapeInternal(CollisionShape3D origin)
 	{
-		if (!Node.IsInstanceValid(origin) || origin.Shape == null) return;
+		if (!GodotObject.IsInstanceValid(origin) || origin.Shape == null) return;
 
 		Shape3D sharedShape = origin.Shape;
 		List<Node> createdNodes = [];
@@ -914,10 +913,10 @@ public partial class Physical : Dynamic
 
 	private void AttachCollisionShape(CollisionShape3D origin)
 	{
-		if (!Node.IsInstanceValid(origin)) return;
+		if (!GodotObject.IsInstanceValid(origin)) return;
 
 		Node targetRoot = GetCollisionShapeRoot();
-		if (!Node.IsInstanceValid(targetRoot)) return;
+		if (!GodotObject.IsInstanceValid(targetRoot)) return;
 
 		if (origin.GetParent() == targetRoot)
 		{
@@ -939,7 +938,7 @@ public partial class Physical : Dynamic
 
 	private void RevertCollisionShape(CollisionShape3D origin)
 	{
-		if (!Node.IsInstanceValid(origin)) return;
+		if (!GodotObject.IsInstanceValid(origin)) return;
 
 		if (origin.GetParent() == GDNode)
 		{
@@ -1139,7 +1138,7 @@ public partial class Physical : Dynamic
 	protected void EnsureTouchArea()
 	{
 		if (PhysicalArea != null) return;
-		if (!Node.IsInstanceValid(GDNode3D)) return;
+		if (!GodotObject.IsInstanceValid(GDNode3D)) return;
 
 		PhysicalArea = new()
 		{


### PR DESCRIPTION
## Summary

moves `Instance.ChildAdded` to be fired AFTER the instance is initialized (with `NetworkedObject.InitEntry()`). also shuts up some warnings

## Related issue or discussion

Fixes #847

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None