### PR TITLE
Creator fix freeze double sided boolean property Image3D

### DIFF
--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -168,13 +168,13 @@ public sealed partial class Image3D : Dynamic
 		get => _doubleSided;
 		set
 		{
+			_doubleSided = value;
 			// Fixes freeze or at least lowers chance on freeze
 			if (_material != null)
 			{
-				_doubleSided = value;
 				_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
-				OnPropertyChanged();
 			}
+			OnPropertyChanged();
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Image3D.cs
+++ b/Polytoria/scripts/datamodel/Image3D.cs
@@ -168,9 +168,13 @@ public sealed partial class Image3D : Dynamic
 		get => _doubleSided;
 		set
 		{
-			_doubleSided = value;
-			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
-			OnPropertyChanged();
+			// Fixes freeze or at least lowers chance on freeze
+			if (_material != null)
+			{
+				_doubleSided = value;
+				_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
+				OnPropertyChanged();
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
*Fixes freeze bug while setting up double sided boolean property in Creator (Image3D class)
## Related issue or discussion

None

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
None

## AI/LLM use
None