### PR TITLE
Fixed ChildAdded

### DIFF
--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -87,14 +87,6 @@ public partial class NetworkedObject : IScriptObject
 			{
 				_networkParent.NonInstanceChildren.Add(this);
 			}
-			if (_networkParent is Instance postI && this is Instance selfpostI)
-			{
-				selfpostI.AddNameToParent();
-				selfpostI.AddLegacyNameToParent();
-				postI.Children.Add(selfpostI);
-				selfpostI.Index = postI.Children.Count - 1;
-				postI.ChildAdded.Invoke(selfpostI);
-			}
 
 			if (_networkParent != null)
 			{
@@ -117,6 +109,15 @@ public partial class NetworkedObject : IScriptObject
 				}
 
 				TreeEntered.Invoke();
+			}
+
+			if (_networkParent is Instance postI && this is Instance selfpostI)
+			{
+				selfpostI.AddNameToParent();
+				selfpostI.AddLegacyNameToParent();
+				postI.Children.Add(selfpostI);
+				selfpostI.Index = postI.Children.Count - 1;
+				postI.ChildAdded.Invoke(selfpostI);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Moved ``ChildAdded`` call so that it fires after the object has entered the scene preventing object reference issues.

## Related issue or discussion

Fixes #847 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [X] Server
- [X] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None