### PR TITLE
Fixed interaction prompt validation

### DIFF
--- a/Polytoria/scripts/datamodel/InteractionPrompt.cs
+++ b/Polytoria/scripts/datamodel/InteractionPrompt.cs
@@ -343,20 +343,21 @@ public sealed partial class InteractionPrompt : Physical
 					_animPlayer.Play("InputStart");
 				}
 				_timeSpentActivating += (float)delta;
-			}
-			if (_timeSpentActivating >= _activationTime)
-			{
-				_timeSpentActivating = 0.0f;
-				_animPlayer.Play("InputEnd");
-				Interacted.Invoke(Root.Players.LocalPlayer);
-				RpcId(1, nameof(TriggerInteracted));
-				if (_activationTime <= 0.1)
+
+				if (_timeSpentActivating >= _activationTime)
 				{
-					// Kind-of weird, silly solution, but this prevents the server from being spammed with requests from a client if the activation time is instant
-					// Hate it? Blame JewelEyed <3
-					if (Root.Players.LocalPlayer != null)
+					_timeSpentActivating = 0.0f;
+					_animPlayer.Play("InputEnd");
+					Interacted.Invoke(Root.Players.LocalPlayer);
+					RpcId(1, nameof(TriggerInteracted));
+					if (_activationTime <= 0.1)
 					{
-						_timeSpentActivating = -Math.Max((Root.Players.LocalPlayer.NetworkPing / 1000f), 0.1f);
+						// Kind-of weird, silly solution, but this prevents the server from being spammed with requests from a client if the activation time is instant
+						// Hate it? Blame JewelEyed <3
+						if (Root.Players.LocalPlayer != null)
+						{
+							_timeSpentActivating = -Math.Max((Root.Players.LocalPlayer.NetworkPing / 1000f), 0.1f);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Only the part of the code that incremented ``_timeSpentActivating`` was checking if you could actually interact using ``CheckCanInteract``. The part check if the time spent activating was larger than activation time was being called reguardless if you could interact or not and it was using a >= sign meaning that if activation time was zero then it would fire reguardless if you could activate it or not.

## Related issue or discussion

Fixes #783 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [X] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None