### PR TITLE
Added GetPeakVolume sound method

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -446,6 +446,19 @@ public sealed partial class Sound : Dynamic
 		}
 	}
 
+	[ScriptMethod]
+	public float GetPeakVolume()
+	{
+		int bus = AudioServer.GetBusIndex(_audioBusName);
+		if (bus < 0)
+			return 0f;
+
+		float left = AudioServer.GetBusPeakVolumeLeftDb(bus, 0);
+		float right = AudioServer.GetBusPeakVolumeRightDb(bus, 0);
+
+		return Mathf.DbToLinear(Mathf.Max(left, right));
+	}
+
 	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable)]
 	private void NetPlayOneshot(float volume)
 	{


### PR DESCRIPTION
## Summary

Exposed get peak volume from the current sound audio bus.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [X] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/1f691f6e-fe5a-442d-b543-49d93d901bb5

## AI/LLM use

None