### PR TITLE
Fixed PartDestroyHeight

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -749,9 +749,9 @@ public partial class Dynamic : Instance
 		}
 
 		// Destroy entity/rigidbodies under part destroy height
-		if (Root != null && Root.Environment != null && this is Entity or RigidBody)
+		if (Root != null && Root.Environment != null && this is Physical physical)
 		{
-			if (Position.Y <= Root.Environment.PartDestroyHeight)
+			if (Position.Y <= Root.Environment.PartDestroyHeight && !physical.Anchored)
 			{
 				// If not client, ignore PartDestroyHeight rule
 				if (Root.SessionType != World.SessionTypeEnum.Client) return;


### PR DESCRIPTION
## Summary

Make sure that the part is physical and unanchored to be destroyed.

## Related issue or discussion

Fixes #823 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [X] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None