### PR TITLE
Fix BodyRotation.TargetRotation + Add BodyRotation.TargetQuaternion

### DIFF
--- a/Polytoria/scripts/datamodel/BodyRotation.cs
+++ b/Polytoria/scripts/datamodel/BodyRotation.cs
@@ -4,23 +4,24 @@
 
 using Godot;
 using Polytoria.Attributes;
+using Polytoria.Utils;
 
 namespace Polytoria.Datamodel;
 
 [Instantiable]
 public partial class BodyRotation : Instance
 {
-	private Vector3 _targetRotation = new(0, 0, 0);
+	private Quaternion _targetQuaternion = Quaternion.Identity;
 	private float _force = 0;
 	private float _acceptanceAngle = 5;
 
 	[Editable, ScriptProperty]
 	public Vector3 TargetRotation
 	{
-		get => _targetRotation;
+		get => _targetQuaternion.GetEuler().RadToDeg();
 		set
 		{
-			_targetRotation = value;
+			_targetQuaternion = Quaternion.FromEuler(value.DegToRad());
 			OnPropertyChanged();
 		}
 	}
@@ -55,27 +56,20 @@ public partial class BodyRotation : Instance
 
 	public override void PhysicsProcess(double delta)
 	{
-		Quaternion gdRot = Quaternion.FromEuler(_targetRotation);
-
 		if (Parent != null && Parent.GDNode is RigidBody3D rigid3D)
 		{
-			Vector3 currentPos = rigid3D.GlobalPosition;
-			Quaternion currentRot = rigid3D.GlobalBasis.GetRotationQuaternion();
-			Quaternion error = gdRot * currentRot.Inverse();
+			Quaternion error = _targetQuaternion * rigid3D.GlobalBasis.GetRotationQuaternion().Inverse();
 
 			if (error.W < 0)
 			{
 				error = -error;
 			}
 
-			error = error.Normalized();
-			Vector3 axis = error.GetAxis();
 			float angle = error.GetAngle();
-			float speed = Mathf.Min(angle * Force, Force);
 
 			if (angle > Mathf.DegToRad(AcceptanceAngle))
 			{
-				rigid3D.AngularVelocity = axis * speed;
+				rigid3D.AngularVelocity = error.GetAxis() * Mathf.Min(angle * Force, Force);
 			}
 			else
 			{
@@ -88,6 +82,6 @@ public partial class BodyRotation : Instance
 	[ScriptMethod]
 	public void SetQuaternion(Quaternion quaternion)
 	{
-		_targetRotation = quaternion.GetEuler();
+		_targetQuaternion = quaternion;
 	}
 }


### PR DESCRIPTION
## Summary

`BodyRotation` now holds a quaternion internally to avoid repeatedly converting from euler angles, and adds `BodyRotation.TargetQuaternion` to access that quaternion (supersedes `BodyRotation:SetQuaternion`). `BodyRotation.TargetRotation` is now a wrapper over `BodyRotation.TargetQuaternion` and uses degrees instead of radians (I think this was a mistake? almost everything else uses degrees).

## Related issue or discussion

Fixes #868

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None