### PR TITLE
Fix Bounds methods with incorrect behaviors

### DIFF
--- a/Polytoria/scripts/scripting/datatypes/PTBounds.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTBounds.cs
@@ -56,7 +56,7 @@ public class PTBounds : IScriptGDObject
 		return $"<Bounds:({v.Start}, {v.End}, {v.Size})>";
 	}
 
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static Vector3 ClosestPoint(PTBounds bounds, PTVector3 point) => bounds.aabb.GetSupport(point.vector);
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static Vector3 ClosestPoint(PTBounds bounds, PTVector3 point) => point.vector.Clamp(bounds.aabb.Position, bounds.aabb.End);
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static bool Contains(PTBounds bounds, PTVector3 point) => bounds.aabb.HasPoint(point.vector);
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Encapsulate(PTBounds bounds, PTVector3 point) => FromGDClass(bounds.aabb.Expand(point.vector));
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Expand(PTBounds bounds, float amount) => FromGDClass(bounds.aabb.Grow(amount));
@@ -73,20 +73,8 @@ public class PTBounds : IScriptGDObject
 	}
 
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)]
-	public static float Distance(PTBounds bounds, PTVector3 point)
-	{
-		Vector3 closest = bounds.aabb.GetCenter().Clamp(bounds.aabb.Position, bounds.aabb.End);
-		return point.vector.DistanceSquaredTo(closest);
-	}
+	public static float Distance(PTBounds bounds, PTVector3 point) => point.vector.DistanceTo(ClosestPoint(bounds, point));
 
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)]
-	public static float SqrDistance(PTBounds bounds, PTVector3 point)
-	{
-		Vector3 closest = Vector3.Zero;
-		closest.X = Mathf.Clamp(point.vector.X, bounds.aabb.Position.X, bounds.aabb.End.X);
-		closest.Y = Mathf.Clamp(point.vector.Y, bounds.aabb.Position.Y, bounds.aabb.End.Y);
-		closest.Z = Mathf.Clamp(point.vector.Z, bounds.aabb.Position.Z, bounds.aabb.End.Z);
-
-		return point.vector.DistanceSquaredTo(closest);
-	}
+	public static float SqrDistance(PTBounds bounds, PTVector3 point) => point.vector.DistanceSquaredTo(ClosestPoint(bounds, point));
 }

--- a/Polytoria/scripts/scripting/datatypes/PTBounds.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTBounds.cs
@@ -56,7 +56,7 @@ public class PTBounds : IScriptGDObject
 		return $"<Bounds:({v.Start}, {v.End}, {v.Size})>";
 	}
 
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTVector3 ClosestPoint(PTBounds bounds, PTVector3 point) => PTVector3.FromGDClass(point.vector.Clamp(bounds.aabb.Position, bounds.aabb.End));
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static Vector3 ClosestPoint(PTBounds bounds, PTVector3 point) => point.vector.Clamp(bounds.aabb.Position, bounds.aabb.End);
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static bool Contains(PTBounds bounds, PTVector3 point) => bounds.aabb.HasPoint(point.vector);
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Encapsulate(PTBounds bounds, PTVector3 point) => FromGDClass(bounds.aabb.Expand(point.vector));
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Expand(PTBounds bounds, float amount) => FromGDClass(bounds.aabb.Grow(amount));
@@ -72,6 +72,6 @@ public class PTBounds : IScriptGDObject
 		return FromGDClass(aabb);
 	}
 
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float Distance(PTBounds bounds, PTVector3 point) => point.vector.DistanceTo(ClosestPoint(bounds, point).vector);
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float SqrDistance(PTBounds bounds, PTVector3 point) => point.vector.DistanceSquaredTo(ClosestPoint(bounds, point).vector);
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float Distance(PTBounds bounds, PTVector3 point) => point.vector.DistanceTo(ClosestPoint(bounds, point));
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float SqrDistance(PTBounds bounds, PTVector3 point) => point.vector.DistanceSquaredTo(ClosestPoint(bounds, point));
 }

--- a/Polytoria/scripts/scripting/datatypes/PTBounds.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTBounds.cs
@@ -34,13 +34,13 @@ public class PTBounds : IScriptGDObject
 	[ScriptMethod]
 	public static PTBounds New()
 	{
-		return FromGDClass(new Aabb(Vector3.Zero, Vector3.Zero));
+		return FromGDClass(new());
 	}
 
 	[ScriptMethod]
 	public static PTBounds New(Vector3 position, Vector3 size)
 	{
-		return FromGDClass(new Aabb(position, size));
+		return FromGDClass(new(position, size));
 	}
 
 	[ScriptMetamethod(ScriptObjectMetamethod.Eq)]

--- a/Polytoria/scripts/scripting/datatypes/PTBounds.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTBounds.cs
@@ -62,8 +62,6 @@ public class PTBounds : IScriptGDObject
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Expand(PTBounds bounds, float amount) => FromGDClass(bounds.aabb.Grow(amount));
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static bool Intersects(PTBounds bounds, PTBounds other) => bounds.aabb.Intersects(other.aabb);
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Intersection(PTBounds bounds, PTBounds other) => FromGDClass(bounds.aabb.Intersection(other.aabb));
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float Distance(PTBounds bounds, PTVector3 point) => point.vector.DistanceTo(ClosestPoint(bounds, point).vector);
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float SqrDistance(PTBounds bounds, PTVector3 point) => point.vector.DistanceSquaredTo(ClosestPoint(bounds, point).vector);
 
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)]
 	public static PTBounds SetMinMax(PTBounds bounds, PTVector3 min, PTVector3 max)
@@ -73,4 +71,7 @@ public class PTBounds : IScriptGDObject
 		aabb.Size = max.vector - min.vector;
 		return FromGDClass(aabb);
 	}
+
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float Distance(PTBounds bounds, PTVector3 point) => point.vector.DistanceTo(ClosestPoint(bounds, point).vector);
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float SqrDistance(PTBounds bounds, PTVector3 point) => point.vector.DistanceSquaredTo(ClosestPoint(bounds, point).vector);
 }

--- a/Polytoria/scripts/scripting/datatypes/PTBounds.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTBounds.cs
@@ -56,12 +56,14 @@ public class PTBounds : IScriptGDObject
 		return $"<Bounds:({v.Start}, {v.End}, {v.Size})>";
 	}
 
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static Vector3 ClosestPoint(PTBounds bounds, PTVector3 point) => point.vector.Clamp(bounds.aabb.Position, bounds.aabb.End);
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTVector3 ClosestPoint(PTBounds bounds, PTVector3 point) => PTVector3.FromGDClass(point.vector.Clamp(bounds.aabb.Position, bounds.aabb.End));
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static bool Contains(PTBounds bounds, PTVector3 point) => bounds.aabb.HasPoint(point.vector);
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Encapsulate(PTBounds bounds, PTVector3 point) => FromGDClass(bounds.aabb.Expand(point.vector));
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Expand(PTBounds bounds, float amount) => FromGDClass(bounds.aabb.Grow(amount));
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static bool Intersects(PTBounds bounds, PTBounds other) => bounds.aabb.Intersects(other.aabb);
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static PTBounds Intersection(PTBounds bounds, PTBounds other) => FromGDClass(bounds.aabb.Intersection(other.aabb));
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float Distance(PTBounds bounds, PTVector3 point) => point.vector.DistanceTo(ClosestPoint(bounds, point).vector);
+	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)] public static float SqrDistance(PTBounds bounds, PTVector3 point) => point.vector.DistanceSquaredTo(ClosestPoint(bounds, point).vector);
 
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)]
 	public static PTBounds SetMinMax(PTBounds bounds, PTVector3 min, PTVector3 max)
@@ -71,10 +73,4 @@ public class PTBounds : IScriptGDObject
 		aabb.Size = max.vector - min.vector;
 		return FromGDClass(aabb);
 	}
-
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)]
-	public static float Distance(PTBounds bounds, PTVector3 point) => point.vector.DistanceTo(ClosestPoint(bounds, point));
-
-	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)]
-	public static float SqrDistance(PTBounds bounds, PTVector3 point) => point.vector.DistanceSquaredTo(ClosestPoint(bounds, point));
 }


### PR DESCRIPTION
## Summary

`Bounds:ClosestPoint(point)` now actually returns the closest point on the `Bounds`, and `Bounds:Distance(point)` returns the distance between the closest point on the `Bounds` and the given `point` (similar to `Bounds:SqrDistance(point)`)

## Related issue or discussion

Fixes #871

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None