### PR TITLE
Show game/core ui toggles on capture

### DIFF
--- a/Polytoria/scenes/client/ui/capture/capture.tscn
+++ b/Polytoria/scenes/client/ui/capture/capture.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Script" uid="uid://413x81bcug4h" path="res://scripts/client/ui/capture/UICapturePreview.cs" id="1_pv180"]
 [ext_resource type="Texture2D" uid="uid://b4v43t5eftodu" path="res://assets/textures/client/placeholder/place_thumbnail.png" id="2_eeble"]
+[ext_resource type="Texture2D" uid="uid://cj3q8kltscs14" path="res://assets/textures/datamodel/BoolValue.svg" id="3_eeble"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_02uox"]
 bg_color = Color(0, 0, 0, 0.54901963)
@@ -339,7 +340,7 @@ _data = {
 &"disappear": SubResource("Animation_ns0ro")
 }
 
-[node name="Capture" type="Panel" unique_id=1148407156 node_paths=PackedStringArray("_pictureRect", "_firstShareBtn", "_saveBtn", "_firstCloseBtn", "_shareBtn", "_cancelBtn", "_captionWritePage", "_firstMenuPage", "_captionTextEdit", "_animPlay", "_shareAnimPlay")]
+[node name="Capture" type="Panel" unique_id=1148407156 node_paths=PackedStringArray("_pictureRect", "_firstShareBtn", "_saveBtn", "_firstCloseBtn", "_shareBtn", "_cancelBtn", "_captionWritePage", "_firstMenuPage", "_captionTextEdit", "_animPlay", "_shareAnimPlay", "_coreUiToggle", "_gameUiToggle", "_layerLayout")]
 visible = false
 z_index = 5
 anchors_preset = 15
@@ -350,9 +351,9 @@ grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_02uox")
 script = ExtResource("1_pv180")
 _pictureRect = NodePath("Control/Panel/Control/Aspect/Pivot/TextureRect3/Picture")
-_firstShareBtn = NodePath("Control/Panel/Menu/FirstMenu/Layout/Share")
-_saveBtn = NodePath("Control/Panel/Menu/FirstMenu/Layout/Save")
-_firstCloseBtn = NodePath("Control/Panel/Menu/FirstMenu/Layout/Close")
+_firstShareBtn = NodePath("Control/Panel/Menu/FirstMenu/Layout2/Share")
+_saveBtn = NodePath("Control/Panel/Menu/FirstMenu/Layout2/Save")
+_firstCloseBtn = NodePath("Control/Panel/Menu/FirstMenu/Layout2/Close")
 _shareBtn = NodePath("Control/Panel/Menu/CaptionWrite/CaptionWrite/HBoxContainer/Share")
 _cancelBtn = NodePath("Control/Panel/Menu/CaptionWrite/CaptionWrite/HBoxContainer/Cancel")
 _captionWritePage = NodePath("Control/Panel/Menu/CaptionWrite")
@@ -360,6 +361,9 @@ _firstMenuPage = NodePath("Control/Panel/Menu/FirstMenu")
 _captionTextEdit = NodePath("Control/Panel/Menu/CaptionWrite/CaptionWrite/EditContainer/TextEdit")
 _animPlay = NodePath("AnimPlay")
 _shareAnimPlay = NodePath("Control/Panel/Menu/ShareAnim")
+_coreUiToggle = NodePath("Control/Panel/Menu/FirstMenu/Layout/LayerLayout/CoreUI")
+_gameUiToggle = NodePath("Control/Panel/Menu/FirstMenu/Layout/LayerLayout/GameUI")
+_layerLayout = NodePath("Control/Panel/Menu/FirstMenu/Layout/LayerLayout")
 
 [node name="Control" type="Control" parent="." unique_id=876182044]
 layout_mode = 1
@@ -478,29 +482,103 @@ offset_bottom = 145.0
 size_flags_vertical = 3
 theme_override_constants/separation = 8
 
-[node name="Layout2" type="VBoxContainer" parent="Control/Panel/Menu/FirstMenu" unique_id=581129892]
+[node name="Layout" type="HBoxContainer" parent="Control/Panel/Menu/FirstMenu" unique_id=1791370820]
 layout_mode = 2
 size_flags_vertical = 3
+theme_override_constants/separation = 200
 alignment = 1
 
-[node name="Label" type="Label" parent="Control/Panel/Menu/FirstMenu/Layout2" unique_id=41714090]
+[node name="InfoLayout" type="VBoxContainer" parent="Control/Panel/Menu/FirstMenu/Layout" unique_id=1159238899]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Control/Panel/Menu/FirstMenu/Layout/InfoLayout" unique_id=41714090]
 layout_mode = 2
 theme_override_font_sizes/font_size = 24
 text = "Photo Taken!"
 horizontal_alignment = 1
 
-[node name="Label2" type="Label" parent="Control/Panel/Menu/FirstMenu/Layout2" unique_id=1679371006]
+[node name="Label2" type="Label" parent="Control/Panel/Menu/FirstMenu/Layout/InfoLayout" unique_id=1679371006]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.6, 0.6, 0.6, 1)
 text = "Memory: Captured"
 horizontal_alignment = 1
 
-[node name="Layout" type="HBoxContainer" parent="Control/Panel/Menu/FirstMenu" unique_id=843048881]
+[node name="LayerLayout" type="VBoxContainer" parent="Control/Panel/Menu/FirstMenu/Layout" unique_id=948221168]
+custom_minimum_size = Vector2(150, 0)
+layout_mode = 2
+
+[node name="CoreUI" type="Button" parent="Control/Panel/Menu/FirstMenu/Layout/LayerLayout" unique_id=227853216]
+custom_minimum_size = Vector2(0, 30)
+custom_maximum_size = Vector2(200, -1)
+layout_mode = 2
+toggle_mode = true
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/Panel/Menu/FirstMenu/Layout/LayerLayout/CoreUI" unique_id=962588791]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -5.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_constants/separation = 12
+
+[node name="TextureRect" type="TextureRect" parent="Control/Panel/Menu/FirstMenu/Layout/LayerLayout/CoreUI/HBoxContainer" unique_id=2117687651]
+custom_minimum_size = Vector2(28, 0)
+layout_mode = 2
+mouse_filter = 2
+texture = ExtResource("3_eeble")
+expand_mode = 2
+stretch_mode = 5
+
+[node name="Label" type="Label" parent="Control/Panel/Menu/FirstMenu/Layout/LayerLayout/CoreUI/HBoxContainer" unique_id=302137327]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Show Core UI"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="GameUI" type="Button" parent="Control/Panel/Menu/FirstMenu/Layout/LayerLayout" unique_id=1941438685]
+custom_minimum_size = Vector2(0, 30)
+custom_maximum_size = Vector2(200, -1)
+propagate_maximum_size = true
+layout_mode = 2
+toggle_mode = true
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/Panel/Menu/FirstMenu/Layout/LayerLayout/GameUI" unique_id=1376362937]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = 5.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_constants/separation = 12
+
+[node name="TextureRect" type="TextureRect" parent="Control/Panel/Menu/FirstMenu/Layout/LayerLayout/GameUI/HBoxContainer" unique_id=1026439778]
+custom_minimum_size = Vector2(28, 0)
+layout_mode = 2
+mouse_filter = 2
+texture = ExtResource("3_eeble")
+expand_mode = 2
+stretch_mode = 5
+
+[node name="Label" type="Label" parent="Control/Panel/Menu/FirstMenu/Layout/LayerLayout/GameUI/HBoxContainer" unique_id=1027267477]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Show Game UI"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Layout2" type="HBoxContainer" parent="Control/Panel/Menu/FirstMenu" unique_id=843048881]
 custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="Share" type="Button" parent="Control/Panel/Menu/FirstMenu/Layout" unique_id=837719853]
+[node name="Share" type="Button" parent="Control/Panel/Menu/FirstMenu/Layout2" unique_id=837719853]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_default_cursor_shape = 2
@@ -515,7 +593,7 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_gbck0")
 theme_override_styles/hover = SubResource("StyleBoxFlat_ns0ro")
 text = "Share"
 
-[node name="Save" type="Button" parent="Control/Panel/Menu/FirstMenu/Layout" unique_id=1381379384]
+[node name="Save" type="Button" parent="Control/Panel/Menu/FirstMenu/Layout2" unique_id=1381379384]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_default_cursor_shape = 2
@@ -531,7 +609,7 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_dsnfc")
 theme_override_styles/disabled = SubResource("StyleBoxFlat_dsnfc")
 text = "Save"
 
-[node name="Close" type="Button" parent="Control/Panel/Menu/FirstMenu/Layout" unique_id=227682114]
+[node name="Close" type="Button" parent="Control/Panel/Menu/FirstMenu/Layout2" unique_id=227682114]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_default_cursor_shape = 2

--- a/Polytoria/scripts/client/ui/capture/UICapturePreview.cs
+++ b/Polytoria/scripts/client/ui/capture/UICapturePreview.cs
@@ -22,8 +22,14 @@ public partial class UICapturePreview : Control
 	[Export] private TextEdit _captionTextEdit = null!;
 	[Export] private AnimationPlayer _animPlay = null!;
 	[Export] private AnimationPlayer _shareAnimPlay = null!;
+	[Export] private Button _coreUiToggle = null!;
+	[Export] private Button _gameUiToggle = null!;
+	[Export] private VBoxContainer _layerLayout = null!;
 
 	private CaptureService _capture = null!;
+	private CaptureService.LayerSelection _selection;
+	private ImageTexture? _previewTexture;
+	private bool _finalized;
 
 	public override void _Ready()
 	{
@@ -34,13 +40,52 @@ public partial class UICapturePreview : Control
 		_saveBtn.Pressed += OnSaveBtnPressed;
 		_firstShareBtn.Pressed += OnFirstShareBtnPressed;
 		_shareBtn.Pressed += OnShareBtnPressed;
+		_coreUiToggle.Toggled += OnCoreUiToggled;
+		_gameUiToggle.Toggled += OnGameUiToggled;
 		base._Ready();
+	}
+
+	public override void _UnhandledInput(InputEvent @event)
+	{
+		if (Visible && @event.IsActionPressed("toggle_menu"))
+		{
+			Close();
+			GetViewport().SetInputAsHandled();
+		}
+		base._UnhandledInput(@event);
+	}
+
+	private void OnCoreUiToggled(bool pressed)
+	{
+		_selection = _selection with { CoreUi = pressed };
+		UpdatePreview();
+	}
+
+	private void OnGameUiToggled(bool pressed)
+	{
+		_selection = _selection with { GameUi = pressed };
+		UpdatePreview();
+	}
+
+	private void UpdatePreview()
+	{
+		_previewTexture?.Dispose();
+		_previewTexture = _capture.ComposePreview(_selection);
+		_pictureRect.Texture = _previewTexture;
+	}
+
+	private void FinalizeSave()
+	{
+		_finalized = true;
+		_capture.SaveCurrentPhoto(_selection);
+		_capture.PersistLayerPreferences(_selection);
 	}
 
 	private void OnShareBtnPressed()
 	{
+		FinalizeSave();
 		Close();
-		_capture.UploadCurrentPhoto(_captionTextEdit.Text);
+		_capture.UploadCurrentPhoto(_captionTextEdit.Text, _selection);
 	}
 
 	private void OnFirstShareBtnPressed()
@@ -52,8 +97,8 @@ public partial class UICapturePreview : Control
 
 	private void OnSaveBtnPressed()
 	{
-		_capture.SaveCurrentPhoto();
-		_capture.OpenCurrentPhotoFile();
+		FinalizeSave();
+		Close();
 	}
 
 	public void Open()
@@ -63,13 +108,34 @@ public partial class UICapturePreview : Control
 		_firstMenuPage.Visible = true;
 		_captionWritePage.Visible = false;
 		_shareBtn.GrabFocus();
-		_pictureRect.Texture = _capture.CurrentPhoto;
-		_saveBtn.Visible = _capture.CurrentPhotoPath == null;
+
+		_finalized = false;
+
+		bool coreAvailable = _capture.CoreUiLayer != null;
+		bool gameAvailable = _capture.GameUiLayer != null;
+		bool notYetSaved = _capture.CurrentPhotoPath == null;
+
+		_selection = new() { CoreUi = coreAvailable, GameUi = gameAvailable };
+		_coreUiToggle.ButtonPressed = _selection.CoreUi;
+		_gameUiToggle.ButtonPressed = _selection.GameUi;
+		_layerLayout.Visible = (coreAvailable || gameAvailable) && notYetSaved;
+
+		UpdatePreview();
+
+		_saveBtn.Visible = notYetSaved;
 		_animPlay.Play("appear");
 	}
 
 	public void Close()
 	{
+		if (!_finalized)
+		{
+			_capture.DiscardCurrentPhoto();
+		}
+
+		_previewTexture?.Dispose();
+		_previewTexture = null;
+
 		CoreUI.CoreUIActive = false;
 		_animPlay.Play("disappear");
 	}

--- a/Polytoria/scripts/datamodel/services/CaptureService.cs
+++ b/Polytoria/scripts/datamodel/services/CaptureService.cs
@@ -6,6 +6,7 @@ using Godot;
 using Polytoria.Attributes;
 using Polytoria.Client.UI;
 using Polytoria.Client.UI.Notification;
+using Polytoria.Enums;
 using Polytoria.Providers.CapturePublish;
 using Polytoria.Shared;
 using Polytoria.Utils;
@@ -17,19 +18,33 @@ namespace Polytoria.Datamodel.Services;
 [Static("Capture")]
 public sealed partial class CaptureService : Instance
 {
+	//Which optional UI layers the player chose to include into the final image
+	public readonly struct LayerSelection
+	{
+		public bool CoreUi { get; init; }
+		public bool GameUi { get; init; }
+
+		public static readonly LayerSelection All = new() { CoreUi = true, GameUi = true };
+	}
+
 	private const int CaptureCooldownSec = 3;
 	private const string CaptureSoundPath = "res://assets/audio/built-in/capture.ogg";
 
 	private Vector2 _photoSizeLimit = new(2000, 2000);
 	private bool _debounce = false;
+	private bool _isQuickScreenshot = false;
+	private LayerSelection? _layerPreferences = null;
 
 	public ImageTexture? CurrentPhoto = null;
 	public string? CurrentPhotoPath = null;
+	public ImageTexture? CoreUiLayer { get; private set; }
+	public ImageTexture? GameUiLayer { get; private set; }
 
 	[ScriptProperty] public bool OnCooldown => _debounce;
 	[Editable, ScriptProperty] public bool CanCapture { get; set; } = true;
 	[ScriptProperty] public UIField? DefaultCaptureOverlay { get; set; } = null;
 	[ScriptProperty] public Dynamic? SpectatorAttach { get; set; } = null;
+	[Editable, ScriptProperty] public CaptureLayersEnum DefaultCaptureLayers { get; set; } = CaptureLayersEnum.All;
 	internal static ICapturePublisher? CapturePublisher { get; set; }
 
 	private AudioStreamPlayer _shutterSound = null!;
@@ -64,7 +79,20 @@ public sealed partial class CaptureService : Instance
 		await TakePhotoAtDynamic(Root.Environment.CurrentCamera);
 		// Override debounce
 		_debounce = false;
-		SaveCurrentPhoto();
+
+		bool wasQuick = _isQuickScreenshot;
+		_isQuickScreenshot = false;
+
+		//Save on the spot if this is a quick screenshot, otheriwse trigger preview
+		if (wasQuick)
+		{
+			SaveCurrentPhoto(CurrentLayerPreferences);
+			PostPhotoTaken();
+		}
+		else
+		{
+			Root.CoreUI.CoreUI.CapturePreview.Open();
+		}
 	}
 
 	public override void Process(double delta)
@@ -119,9 +147,59 @@ public sealed partial class CaptureService : Instance
 		SetProcess(false);
 	}
 
-	public void SaveCurrentPhoto()
+	// Remembers the chosen layers for future quick screenshots.
+	public void PersistLayerPreferences(LayerSelection selection)
+	{
+		_layerPreferences = selection;
+	}
+
+	// Falls back to the dev-configured default until the player explicitly
+	// picks a selection via the preview.
+	private LayerSelection CurrentLayerPreferences => _layerPreferences ?? LayersFromEnum(DefaultCaptureLayers);
+
+	private static LayerSelection LayersFromEnum(CaptureLayersEnum layers) => layers switch
+	{
+		CaptureLayersEnum.None => new LayerSelection(),
+		CaptureLayersEnum.CoreOnly => new LayerSelection { CoreUi = true },
+		CaptureLayersEnum.GameOnly => new LayerSelection { GameUi = true },
+		_ => LayerSelection.All
+	};
+
+	// Flattens the base photo with whichever layers are selected.
+	private Image ComposeFinalImage(LayerSelection selection)
+	{
+		Image final = (Image)CurrentPhoto!.GetImage().Duplicate();
+
+		final.ClearMipmaps();
+		if (final.GetFormat() != Image.Format.Rgba8)
+		{
+			final.Convert(Image.Format.Rgba8);
+		}
+
+		if (selection.CoreUi && CoreUiLayer != null)
+		{
+			Image layer = CoreUiLayer.GetImage();
+			final.BlendRect(layer, new Rect2I(Vector2I.Zero, layer.GetSize()), Vector2I.Zero);
+		}
+		if (selection.GameUi && GameUiLayer != null)
+		{
+			Image layer = GameUiLayer.GetImage();
+			final.BlendRect(layer, new Rect2I(Vector2I.Zero, layer.GetSize()), Vector2I.Zero);
+		}
+		return final;
+	}
+
+	// Live preview texture (caller owns and must dispose it).
+	public ImageTexture ComposePreview(LayerSelection selection)
+	{
+		return ImageTexture.CreateFromImage(ComposeFinalImage(selection));
+	}
+
+	public void SaveCurrentPhoto(LayerSelection selection)
 	{
 		if (CurrentPhoto == null) return;
+		Image final = ComposeFinalImage(selection);
+
 		DateTime time = DateTime.Now;
 		string formattedTime = time.ToString("yyyyMMdd-hhmmss");
 		string filename = "PolytoriaScreenshot-" + formattedTime + ".png";
@@ -132,17 +210,31 @@ public sealed partial class CaptureService : Instance
 		}
 		string photoPath = baseFolder.PathJoin(filename);
 		CurrentPhotoPath = photoPath;
-		CurrentPhoto.GetImage().SavePng(photoPath);
+		final.SavePng(photoPath);
 	}
 
-	public async void UploadCurrentPhoto(string caption = "")
+	public async void UploadCurrentPhoto(string caption, LayerSelection selection)
 	{
 		if (CurrentPhoto == null) return;
 		if (CapturePublisher == null) throw new MissingComponentException("Missing capture publisher component");
 
-		byte[] screenshotBytes = CurrentPhoto.GetImage().SavePngToBuffer();
+		byte[] screenshotBytes = ComposeFinalImage(selection).SavePngToBuffer();
 
 		await CapturePublisher.Publish(screenshotBytes, caption, true);
+	}
+
+	// Cancels the pending photo without saving.
+	public void DiscardCurrentPhoto()
+	{
+		CurrentPhoto?.Dispose();
+		CurrentPhoto = null;
+		CurrentPhotoPath = null;
+
+		CoreUiLayer?.Dispose();
+		CoreUiLayer = null;
+
+		GameUiLayer?.Dispose();
+		GameUiLayer = null;
 	}
 
 	public void ViewCurrentPhoto()
@@ -154,6 +246,77 @@ public sealed partial class CaptureService : Instance
 	{
 		if (CurrentPhotoPath == null) return;
 		OS.ShellOpen(CurrentPhotoPath);
+	}
+
+	// Wraps a UIField for offscreen rendering
+	private async Task<GUI> PrepareOverlayGui(UIField source)
+	{
+		GUI gui = New<GUI>();
+		UIField clone = (UIField)source.Clone();
+		clone.Visible = true;
+		clone.Parent = gui;
+		gui.Parent = this;
+
+		// Wait one frame for all node control to init
+		await Globals.Singleton.WaitFrame();
+
+		// Override parent check for visible
+		foreach (Instance des in gui.GetDescendants())
+		{
+			if (des is UIField field)
+			{
+				field.OverrideParentCheck = true;
+				field.RecomputeVisible();
+			}
+		}
+
+		return gui;
+	}
+
+	// GameMenu shares CoreUIRoot's canvas, so a mid-fade close would otherwise
+	// show in the captured layer. Hides it for the render and restores it after.
+	private async Task<ImageTexture?> CaptureCoreUiLayer(Vector2I size)
+	{
+		CoreUIRoot? core = CoreUIRoot.Singleton;
+		if (core == null) return null;
+
+		bool wasMenuVisible = core.GameMenu.Visible;
+		core.GameMenu.Visible = false;
+
+		ImageTexture? result = await CaptureLiveCanvasLayer(core, size);
+
+		core.GameMenu.Visible = wasMenuVisible;
+
+		return result;
+	}
+
+	// Renders a live CanvasLayer into an offscreen viewport by attaching its
+	// existing rendering-server canvas to a second viewport.
+	private async Task<ImageTexture?> CaptureLiveCanvasLayer(CanvasLayer? liveLayer, Vector2I size)
+	{
+		if (liveLayer == null) return null;
+
+		SubViewport layerView = new()
+		{
+			Size = size,
+			TransparentBg = true,
+			RenderTargetClearMode = SubViewport.ClearMode.Once,
+			RenderTargetUpdateMode = SubViewport.UpdateMode.Once
+		};
+		GDNode.AddChild(layerView, @internal: Node.InternalMode.Back);
+
+		Rid canvas = liveLayer.GetCanvas();
+		RenderingServer.ViewportAttachCanvas(layerView.GetViewportRid(), canvas);
+
+		await Globals.Singleton.ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
+
+		Image img = layerView.GetTexture().GetImage();
+		ImageTexture texture = ImageTexture.CreateFromImage(img);
+
+		RenderingServer.ViewportRemoveCanvas(layerView.GetViewportRid(), canvas);
+		layerView.QueueFree();
+
+		return texture;
 	}
 
 	[ScriptMethod]
@@ -194,25 +357,7 @@ public sealed partial class CaptureService : Instance
 
 		if (overlay != null)
 		{
-			guiOverlay = New<GUI>();
-			UIField clone = (UIField)overlay.Clone();
-			clone.Visible = true;
-			clone.Parent = guiOverlay;
-			guiOverlay.Parent = this;
-
-			// Wait one frame for all node control to init
-			await Globals.Singleton.WaitFrame();
-
-			// Override parent check for visible
-			foreach (Instance des in guiOverlay.GetDescendants())
-			{
-				if (des is UIField field)
-				{
-					field.OverrideParentCheck = true;
-					field.RecomputeVisible();
-				}
-			}
-
+			guiOverlay = await PrepareOverlayGui(overlay);
 			guiOverlay.GDNode.Reparent(subview);
 		}
 
@@ -239,28 +384,30 @@ public sealed partial class CaptureService : Instance
 		img.FixAlphaEdges();
 		img.GenerateMipmaps();
 
-
 		CurrentPhoto?.Dispose();
 		CurrentPhoto = ImageTexture.CreateFromImage(img);
 
-		subview.QueueFree();
+		CoreUiLayer?.Dispose();
+		GameUiLayer?.Dispose();
+		CoreUiLayer = await CaptureCoreUiLayer(subview.Size);
+		GameUiLayer = overlay == null ? await CaptureLiveCanvasLayer(Root.PlayerGUI?.GDNode as CanvasLayer, subview.Size) : null;
 
-		PostPhotoTaken();
+		subview.QueueFree();
 	}
 
 	private async void PostPhotoTaken()
 	{
+		ImageTexture icon = ComposePreview(CurrentLayerPreferences);
 		Root.CoreUI.CoreUI.NotificationCenter.FireNotification(
 			UINotification.NotificationType.Screenshot,
 			new UIScreenshotNotification.ScreenshotNotifyPayload()
 			{
-				Icon = CurrentPhoto
+				Icon = icon
 			}
 		);
 		await Globals.Singleton.WaitAsync(CaptureCooldownSec);
 		_debounce = false;
 	}
-
 
 	private void PrePhotoTake()
 	{
@@ -271,6 +418,7 @@ public sealed partial class CaptureService : Instance
 	{
 		if (@event.IsActionPressed("screenshot"))
 		{
+			_isQuickScreenshot = true;
 			TakePhoto();
 		}
 	}

--- a/Polytoria/scripts/enums/CaptureLayers.cs
+++ b/Polytoria/scripts/enums/CaptureLayers.cs
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Polytoria.Attributes;
+
+namespace Polytoria.Enums;
+
+[ScriptEnum("CaptureLayers")]
+public enum CaptureLayersEnum
+{
+	None,
+	CoreOnly,
+	GameOnly,
+	All
+}

--- a/Polytoria/scripts/enums/CaptureLayers.cs.uid
+++ b/Polytoria/scripts/enums/CaptureLayers.cs.uid
@@ -1,0 +1,1 @@
+uid://b3dsdqucxka1x


### PR DESCRIPTION
## Summary

Adds selectable UI layers to screenshots, allowing the player to choose if they want to include the game/core UI in their screenshot.

Aditionally, a "DefaultCaptureLayers" property was added to CaptureService to let developers pick what layers best fit their game by default.

## Related issue or discussion

Closes #791

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/e347698f-4c73-4487-802f-5fb5b5a86df1

(I'm no UI/Icon designer so that area is going to need some polish).

## AI/LLM use

Claude was used to draft rendering related code, as well as for code review/cleanup, and troubleshooting. All code was manually reviewed and tested, but nonetheless i've labeled this as a draft due to it's usage.