### PR TITLE
Prevent http access to private addresses

### DIFF
--- a/Polytoria.Tests/DatamodelServiceTest.cs
+++ b/Polytoria.Tests/DatamodelServiceTest.cs
@@ -26,9 +26,14 @@ public class DatamodelServiceTest
 		// Prevent access to non HTTP(S)
 		Assert.Throws<InvalidOperationException>(() => HttpService.CheckURLPass("file://hello.txt", false));
 		Assert.Throws<InvalidOperationException>(() => HttpService.CheckURLPass("ftp://127.0.0.1:6942", false));
+
+		// Prevent access to private address ranges
 		Assert.Throws<InvalidOperationException>(() => HttpService.CheckURLPass("http://localhost:8000", false));
 		Assert.Throws<InvalidOperationException>(() => HttpService.CheckURLPass("https://localhost:8000", false));
 		Assert.Throws<InvalidOperationException>(() => HttpService.CheckURLPass("https://127.0.0.1:8000", false));
+		Assert.Throws<InvalidOperationException>(() => HttpService.CheckURLPass("https://0.0.0.0:8000", false));
+		Assert.Throws<InvalidOperationException>(() => HttpService.CheckURLPass("https://127.0.0.1.nip.io:8000", false));
+		Assert.Throws<InvalidOperationException>(() => HttpService.CheckURLPass("https://0.0.0.0.nip.io:8000", false));
 
 		// Normal access should pass in production
 		HttpService.CheckURLPass("https://example.com", false);

--- a/Polytoria/scripts/datamodel/services/HttpService.cs
+++ b/Polytoria/scripts/datamodel/services/HttpService.cs
@@ -6,8 +6,10 @@ using Polytoria.Attributes;
 using Polytoria.Datamodel.Data;
 using Polytoria.Scripting;
 using Polytoria.Shared;
+using Polytoria.Utils;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -176,6 +178,12 @@ public sealed partial class HttpService : Instance
 			if (IPAddress.TryParse(host, out _))
 			{
 				throw new InvalidOperationException("Access to raw IP addresses is not allowed in production");
+			}
+
+			var addresses = Dns.GetHostAddresses(host);
+			if (addresses.Any(ip => ip.IsPrivate()))
+			{
+				throw new InvalidOperationException("Access to private IP addresses is not allowed in production");
 			}
 		}
 	}

--- a/Polytoria/scripts/utils/NetworkUtils.cs
+++ b/Polytoria/scripts/utils/NetworkUtils.cs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 
@@ -16,5 +17,46 @@ public static class NetworkUtils
 		int port = ((IPEndPoint)listener.LocalEndpoint).Port;
 		listener.Stop();
 		return port;
+	}
+
+	public static bool IsPrivate(this IPAddress ip)
+	{
+		if (ip.IsIPv4MappedToIPv6)
+			ip = ip.MapToIPv4();
+
+		if (IPAddress.IsLoopback(ip))
+			return true;
+
+		switch (ip.AddressFamily)
+		{
+			case AddressFamily.InterNetwork:
+				var bytes = ip.GetAddressBytes();
+
+				// RFC 1918; Class A, B, C https://www.ietf.org/rfc/rfc1918.txt
+				if (bytes[0] == 10)
+					return true;
+
+				if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31)
+					return true;
+
+				if (bytes[0] == 192 && bytes[1] == 168)
+					return true;
+
+				// RFC 3927; IPv4 Link-local https://www.ietf.org/rfc/rfc3927.txt
+				if (bytes[0] == 169 && bytes[1] == 254)
+					return true;
+
+				// https://en.wikipedia.org/wiki/0.0.0.0
+				// https://www.theregister.com/security/2024/08/09/chrome-firefox-safari-patch-0000-security-hole/1347382
+				// https://archive.ph/Jpi0U
+				if (bytes.All(b => b == 0))
+					return true;
+
+				return false;
+			case AddressFamily.InterNetworkV6:
+				return ip.IsIPv6LinkLocal || ip.IsIPv6UniqueLocal || ip.IsIPv6SiteLocal;
+			default:
+				return true;
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Prevents http requests from being made to private addresses (credits to @little-meow-meow through email)

## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->