### PR TITLE
Fix Gizmos

### DIFF
--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -34,11 +34,11 @@ public sealed partial class Gizmos : Node
 	public bool HoveringUIGizmo { get; set; }
 	public bool IsDraggingDynamic => _isDraggingDyn;
 
-	public static Color[] AxisColors { get; private set; } =
+	public static readonly Color[] AxisColors =
 	[
-			new(0.96f, 0.20f, 0.32f),
-			new(0.53f, 0.84f, 0.01f),
-			new(0.16f, 0.55f, 0.96f),
+		new(0.96f, 0.20f, 0.32f),
+		new(0.53f, 0.84f, 0.01f),
+		new(0.16f, 0.55f, 0.96f),
 	];
 
 	public MoveGizmo Move = new();

--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -27,7 +27,6 @@ public sealed partial class Gizmos : Node
 	private bool _isDragPending;
 	private Vector2 _dragStartPos;
 	private const float DragThreshold = 8f;
-	private Dynamic? _lastHovered;
 	private SelectionBox _paintBox = null!;
 	private SelectionBox _hoverBox = null!;
 
@@ -128,7 +127,6 @@ public sealed partial class Gizmos : Node
 
 		Vector3 oldScaleVector = _pivotStart.Basis[column];
 		Vector3 currentAxisVector = oldScaleVector * globalDirection;
-		int localDirection = rawMotion.Dot(currentAxisVector) > 0 ? 1 : -1;
 
 		Vector3 axisDir = currentAxisVector.Normalized();
 		float snappedDelta = Mathf.Snapped(rawMotion.Dot(axisDir), moveSnap);
@@ -157,7 +155,7 @@ public sealed partial class Gizmos : Node
 				newBasis[i] = newScaleVector;
 				if (!isAltPressed)
 				{
-					totalOriginOffset += (globalDirection * snappedDelta * _pivotStart.Basis[i].Normalized() / 2);
+					totalOriginOffset += globalDirection * snappedDelta * _pivotStart.Basis[i].Normalized() / 2;
 				}
 			}
 			else if (isShiftPressed)
@@ -437,15 +435,11 @@ public sealed partial class Gizmos : Node
 		Dynamic? hoveringOn = null;
 		if (intersection.Count > 0)
 		{
-			Node collider = (Node)intersection["collider"];
+			Node collider = (Node)(GodotObject)intersection["collider"];
 			hoveringOn = Dynamic.GetDynFromCreatorBounds(collider);
 			if (hoveringOn == null && collider is CollisionObject3D colObj)
 			{
-				hoveringOn = Physical.GetPhysicalFromBody(colObj);
-				if (hoveringOn == null)
-				{
-					hoveringOn = Physical.GetPhysicalFromCollider(collider);
-				}
+				hoveringOn = Physical.GetPhysicalFromBody(colObj) ?? Physical.GetPhysicalFromCollider(collider);
 			}
 		}
 
@@ -590,8 +584,6 @@ public sealed partial class Gizmos : Node
 				DragSelectedDynamics();
 			}
 		}
-
-		_lastHovered = hoveringOn;
 	}
 
 	private void RotateSelectedAround(float angle)

--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -62,12 +62,12 @@ public sealed partial class Gizmos : Node
 		game.Loaded.Once(() =>
 		{
 			_history = Root.CreatorContext.History;
+			_camera = Root.CreatorContext.Freelook.Camera3D;
 		});
 	}
 
 	public override void _Ready()
 	{
-		_camera = Root.CreatorContext.Freelook.Camera3D;
 		Move.RootGizmos = this;
 		Rotate.RootGizmos = this;
 		Scale.RootGizmos = this;


### PR DESCRIPTION
## Summary

moves `Gizmos._camera` to be set after `game.Loaded` instead of `_Ready`. also shuts up some warnings

## Related issue or discussion

Fixes #883

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None