### PR TITLE
Cleanup file garbage

### DIFF
--- a/Polytoria/assets/textures/client/ui/chat/bubble_arrow.svg.import
+++ b/Polytoria/assets/textures/client/ui/chat/bubble_arrow.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/bubble_arrow.svg-7a2c8c2d94ea456995cba0aff08d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/client/ui/indicators/high_ping.svg.import
+++ b/Polytoria/assets/textures/client/ui/indicators/high_ping.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/high_ping.svg-1f1c727f4ad03d931a673bc5c4bfc5f
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/client/ui/indicators/high_pressure.svg.import
+++ b/Polytoria/assets/textures/client/ui/indicators/high_pressure.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/high_pressure.svg-da2ad5c07e8ebeea31babd2a3d6
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/client/ui/indicators/silence.svg.import
+++ b/Polytoria/assets/textures/client/ui/indicators/silence.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/silence.svg-690f4050d7d8113a10888d7708882dae.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/client/ui/purchase/sold.svg.import
+++ b/Polytoria/assets/textures/client/ui/purchase/sold.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/sold.svg-8055be2caa769dca12eb2390fd10b392.dpi
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/client/ui/settings/toggles/off.svg.import
+++ b/Polytoria/assets/textures/client/ui/settings/toggles/off.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/off.svg-6d8a6a003675f40fb647bf048817c0f4.dpit
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/client/ui/settings/toggles/on.svg.import
+++ b/Polytoria/assets/textures/client/ui/settings/toggles/on.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/on.svg-d8049d2e755a150c2d4bda939e13c73d.dpite
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/client/ui/settings/toggles/toggle_off.svg.import
+++ b/Polytoria/assets/textures/client/ui/settings/toggles/toggle_off.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/toggle_off.svg-d39c9bc482938ad9668b51f64fcea8
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/client/ui/settings/toggles/toggle_on.svg.import
+++ b/Polytoria/assets/textures/client/ui/settings/toggles/toggle_on.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/toggle_on.svg-9b58a8eef4ac95c513b0ed6a3916684
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/checked.svg.import
+++ b/Polytoria/assets/textures/creator/checked.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/checked.svg-206ce932611a1bb9b7fcd48cc81874b2.
 base_scale=0.8
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/close.svg.import
+++ b/Polytoria/assets/textures/creator/close.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/close.svg-1c14fe43cf73433e26a4ca49174d5455.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/close_x2.svg.import
+++ b/Polytoria/assets/textures/creator/close_x2.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/close_x2.svg-f0f3de3e00997ee48a9690d6b81395cb
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/folder.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/folder.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/folder.svg-1dd634148bb1c2aa9d2eace6c0a25a9c.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/gitattributes.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/gitattributes.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/gitattributes.svg-20b475c0a82000cbd11ec2e6b3c
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/gitignore.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/gitignore.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/gitignore.svg-443de1a7b965c9f46dbdb575d17381f
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/input.json.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/input.json.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/input.json.svg-2816798b693608a7a0a8cbdbf34ee5
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/json.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/json.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/json.svg-2f8ef89726560447a00a46c4fe93cd83.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/lua.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/lua.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/lua.svg-8867cce5247e3ed118238f4a80fa86d5.dpit
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/luau.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/luau.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/luau.svg-7051bfd4da55fcecf409519731738aa9.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/model.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/model.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/model.svg-ec473b4aafe225c1798ea88423bd4cc4.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/poly.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/poly.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/poly.svg-34adcd900f8a58220f7b46f17070cc14.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/polytoria.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/polytoria.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/polytoria.svg-f5570e045523036ab1aebab40d1ac61
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/filebrowser/icons/unknown.svg.import
+++ b/Polytoria/assets/textures/creator/filebrowser/icons/unknown.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/unknown.svg-24eb76483893cdf8b196273180e61f2a.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/logo.svg.import
+++ b/Polytoria/assets/textures/creator/logo.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/logo.svg-76f571e344d50fbadfabfbeccf27f2d9.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/ribbon/brush.svg.import
+++ b/Polytoria/assets/textures/creator/ribbon/brush.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/brush.svg-50b758f1142b2f4a4c9d16d51badb7e7.dp
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/ribbon/insert.svg.import
+++ b/Polytoria/assets/textures/creator/ribbon/insert.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/insert.svg-8a532b9647d01f1e06d1c96e38a73131.d
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/ribbon/move.svg.import
+++ b/Polytoria/assets/textures/creator/ribbon/move.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/move.svg-4cb9de9a2d461d56e0d19331c1f20d5c.dpi
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/ribbon/paint.svg.import
+++ b/Polytoria/assets/textures/creator/ribbon/paint.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/paint.svg-24faf4afff3fac0ca3eb5c54d8527cb0.dp
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/ribbon/paint_color.svg.import
+++ b/Polytoria/assets/textures/creator/ribbon/paint_color.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/paint_color.svg-f48b8ca3a1d84c6f4a7ffc3516443
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/ribbon/rotate.svg.import
+++ b/Polytoria/assets/textures/creator/ribbon/rotate.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/rotate.svg-1d96fed157a32929cd96daf6b5a37fde.d
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/ribbon/scale.svg.import
+++ b/Polytoria/assets/textures/creator/ribbon/scale.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/scale.svg-5f497adf675f38ae1175b1cd74e94864.dp
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/ribbon/select.svg.import
+++ b/Polytoria/assets/textures/creator/ribbon/select.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/select.svg-58d79dc4d989daa54cff153dabd7cafd.d
 base_scale=2.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/spatial/icons/Particles.svg.import
+++ b/Polytoria/assets/textures/creator/spatial/icons/Particles.svg.import
@@ -1,45 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://nvr4pwvk637c"
-path.s3tc="res://.godot/imported/Particles.svg-6ac6d2b785af46db8fe2adfad4e13ba3.s3tc.ctex"
-path.etc2="res://.godot/imported/Particles.svg-6ac6d2b785af46db8fe2adfad4e13ba3.etc2.ctex"
-metadata={
-"imported_formats": ["s3tc_bptc", "etc2_astc"],
-"vram_texture": true
-}
+path="res://.godot/imported/Particles.svg-6ac6d2b785af46db8fe2adfad4e13ba3.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/creator/spatial/icons/Particles.svg"
-dest_files=["res://.godot/imported/Particles.svg-6ac6d2b785af46db8fe2adfad4e13ba3.s3tc.ctex", "res://.godot/imported/Particles.svg-6ac6d2b785af46db8fe2adfad4e13ba3.etc2.ctex"]
+dest_files=["res://.godot/imported/Particles.svg-6ac6d2b785af46db8fe2adfad4e13ba3.dpitex"]
 
 [params]
 
-compress/mode=2
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=true
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=0
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/creator/spatial/icons/PointLight.svg.import
+++ b/Polytoria/assets/textures/creator/spatial/icons/PointLight.svg.import
@@ -1,45 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://n4rnkwlufdxe"
-path.s3tc="res://.godot/imported/PointLight.svg-f2325bef24e46204a087ada4fbbed4a0.s3tc.ctex"
-path.etc2="res://.godot/imported/PointLight.svg-f2325bef24e46204a087ada4fbbed4a0.etc2.ctex"
-metadata={
-"imported_formats": ["s3tc_bptc", "etc2_astc"],
-"vram_texture": true
-}
+path="res://.godot/imported/PointLight.svg-f2325bef24e46204a087ada4fbbed4a0.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/creator/spatial/icons/PointLight.svg"
-dest_files=["res://.godot/imported/PointLight.svg-f2325bef24e46204a087ada4fbbed4a0.s3tc.ctex", "res://.godot/imported/PointLight.svg-f2325bef24e46204a087ada4fbbed4a0.etc2.ctex"]
+dest_files=["res://.godot/imported/PointLight.svg-f2325bef24e46204a087ada4fbbed4a0.dpitex"]
 
 [params]
 
-compress/mode=2
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=true
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=0
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/creator/spatial/icons/Sound.svg.import
+++ b/Polytoria/assets/textures/creator/spatial/icons/Sound.svg.import
@@ -1,45 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://cb5wihp7v1rmb"
-path.s3tc="res://.godot/imported/Sound.svg-63a79a125077971a732a9ad29f2b59c4.s3tc.ctex"
-path.etc2="res://.godot/imported/Sound.svg-63a79a125077971a732a9ad29f2b59c4.etc2.ctex"
-metadata={
-"imported_formats": ["s3tc_bptc", "etc2_astc"],
-"vram_texture": true
-}
+path="res://.godot/imported/Sound.svg-63a79a125077971a732a9ad29f2b59c4.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/creator/spatial/icons/Sound.svg"
-dest_files=["res://.godot/imported/Sound.svg-63a79a125077971a732a9ad29f2b59c4.s3tc.ctex", "res://.godot/imported/Sound.svg-63a79a125077971a732a9ad29f2b59c4.etc2.ctex"]
+dest_files=["res://.godot/imported/Sound.svg-63a79a125077971a732a9ad29f2b59c4.dpitex"]
 
 [params]
 
-compress/mode=2
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=true
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=0
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/creator/spatial/icons/SpotLight.svg.import
+++ b/Polytoria/assets/textures/creator/spatial/icons/SpotLight.svg.import
@@ -1,45 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://c16j8urkk6jbm"
-path.s3tc="res://.godot/imported/SpotLight.svg-2dccf846e257a689522b9005db6ffd2b.s3tc.ctex"
-path.etc2="res://.godot/imported/SpotLight.svg-2dccf846e257a689522b9005db6ffd2b.etc2.ctex"
-metadata={
-"imported_formats": ["s3tc_bptc", "etc2_astc"],
-"vram_texture": true
-}
+path="res://.godot/imported/SpotLight.svg-2dccf846e257a689522b9005db6ffd2b.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/creator/spatial/icons/SpotLight.svg"
-dest_files=["res://.godot/imported/SpotLight.svg-2dccf846e257a689522b9005db6ffd2b.s3tc.ctex", "res://.godot/imported/SpotLight.svg-2dccf846e257a689522b9005db6ffd2b.etc2.ctex"]
+dest_files=["res://.godot/imported/SpotLight.svg-2dccf846e257a689522b9005db6ffd2b.dpitex"]
 
 [params]
 
-compress/mode=2
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=true
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=0
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/creator/spatial/icons/SunLight.svg.import
+++ b/Polytoria/assets/textures/creator/spatial/icons/SunLight.svg.import
@@ -1,45 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://x3ibhktuheup"
-path.s3tc="res://.godot/imported/SunLight.svg-04d5aad7c1648580c02aede6f922e068.s3tc.ctex"
-path.etc2="res://.godot/imported/SunLight.svg-04d5aad7c1648580c02aede6f922e068.etc2.ctex"
-metadata={
-"imported_formats": ["s3tc_bptc", "etc2_astc"],
-"vram_texture": true
-}
+path="res://.godot/imported/SunLight.svg-04d5aad7c1648580c02aede6f922e068.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/creator/spatial/icons/SunLight.svg"
-dest_files=["res://.godot/imported/SunLight.svg-04d5aad7c1648580c02aede6f922e068.s3tc.ctex", "res://.godot/imported/SunLight.svg-04d5aad7c1648580c02aede6f922e068.etc2.ctex"]
+dest_files=["res://.godot/imported/SunLight.svg-04d5aad7c1648580c02aede6f922e068.dpitex"]
 
 [params]
 
-compress/mode=2
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=true
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=0
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/creator/tabs/text_editor/code_completion/Method.svg.import
+++ b/Polytoria/assets/textures/creator/tabs/text_editor/code_completion/Method.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Method.svg-a59d1b7d3656e5aada0bcc2e4255ebb0.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/tabs/text_editor/code_completion/None.svg.import
+++ b/Polytoria/assets/textures/creator/tabs/text_editor/code_completion/None.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/None.svg-b9a56c8c5bd658d8ba68dad123243b65.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/tabs/text_editor/code_completion/Property.svg.import
+++ b/Polytoria/assets/textures/creator/tabs/text_editor/code_completion/Property.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Property.svg-fee07478dd470bdd8206106089b917a9
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/tabs/text_editor/error.svg.import
+++ b/Polytoria/assets/textures/creator/tabs/text_editor/error.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/error.svg-49ecb34088686ba5cd66921eaf8b24f7.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/creator/toolbox/Sound.svg.import
+++ b/Polytoria/assets/textures/creator/toolbox/Sound.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://cq6gm8uafwol0"
-path="res://.godot/imported/Sound.svg-f0e8e267d34c692709923e36eeb3d12a.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/Sound.svg-f0e8e267d34c692709923e36eeb3d12a.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/creator/toolbox/Sound.svg"
-dest_files=["res://.godot/imported/Sound.svg-f0e8e267d34c692709923e36eeb3d12a.ctex"]
+dest_files=["res://.godot/imported/Sound.svg-f0e8e267d34c692709923e36eeb3d12a.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/creator/unchecked.svg.import
+++ b/Polytoria/assets/textures/creator/unchecked.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/unchecked.svg-2f3c6815128cbfe39490ced777c6c8c
 base_scale=0.8
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Accessory.svg.import
+++ b/Polytoria/assets/textures/datamodel/Accessory.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Accessory.svg-2add68d4aa19f95c4734641c0deb422
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/AchievementsService.svg.import
+++ b/Polytoria/assets/textures/datamodel/AchievementsService.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://dpgnfd7aymnny"
-path="res://.godot/imported/AchievementsService.svg-749562a3a38db4c7c87877d21115a77d.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/AchievementsService.svg-749562a3a38db4c7c87877d21115a77d.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/AchievementsService.svg"
-dest_files=["res://.godot/imported/AchievementsService.svg-749562a3a38db4c7c87877d21115a77d.ctex"]
+dest_files=["res://.godot/imported/AchievementsService.svg-749562a3a38db4c7c87877d21115a77d.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/Animation.svg.import
+++ b/Polytoria/assets/textures/datamodel/Animation.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://15xenfjdk1hd"
-path="res://.godot/imported/Animation.svg-0ecc856bf1c5439058ec8ac0e30a4148.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/Animation.svg-0ecc856bf1c5439058ec8ac0e30a4148.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/Animation.svg"
-dest_files=["res://.godot/imported/Animation.svg-0ecc856bf1c5439058ec8ac0e30a4148.ctex"]
+dest_files=["res://.godot/imported/Animation.svg-0ecc856bf1c5439058ec8ac0e30a4148.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/Animator.svg.import
+++ b/Polytoria/assets/textures/datamodel/Animator.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Animator.svg-9587b572190bb4eb7745a442f1323a67
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/AssetService.svg.import
+++ b/Polytoria/assets/textures/datamodel/AssetService.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://cltb6sfsyqahx"
-path="res://.godot/imported/AssetService.svg-421bba52c68aef040f3e37e7fd574c75.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/AssetService.svg-421bba52c68aef040f3e37e7fd574c75.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/AssetService.svg"
-dest_files=["res://.godot/imported/AssetService.svg-421bba52c68aef040f3e37e7fd574c75.ctex"]
+dest_files=["res://.godot/imported/AssetService.svg-421bba52c68aef040f3e37e7fd574c75.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/AudioAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/AudioAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/AudioAsset.svg-b273c390624460c4e428fb28d62a73
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Backpack.svg.import
+++ b/Polytoria/assets/textures/datamodel/Backpack.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Backpack.svg-92f91292317122141118e84503e548d5
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/BaseAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/BaseAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/BaseAsset.svg-299954963fcec69a43d2a9ed95a11ef
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/BindableEvent.svg.import
+++ b/Polytoria/assets/textures/datamodel/BindableEvent.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/BindableEvent.svg-e5b14a345a5d2160ba361bfc62a
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/BodyPosition.svg.import
+++ b/Polytoria/assets/textures/datamodel/BodyPosition.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/BodyPosition.svg-ba63e0427bd7b362e34f2552a68e
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/BodyRotation.svg.import
+++ b/Polytoria/assets/textures/datamodel/BodyRotation.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/BodyRotation.svg-8e967828e53745cced01f6127069
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/BoolValue.svg.import
+++ b/Polytoria/assets/textures/datamodel/BoolValue.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/BoolValue.svg-0295c8c9b5909b9b841f8693ecbf9fd
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/BuiltInAudioAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/BuiltInAudioAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/BuiltInAudioAsset.svg-1a1064db24f809a3953536e
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/BuiltInFontAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/BuiltInFontAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/BuiltInFontAsset.svg-741f098ac8121470630e0684
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Camera.svg.import
+++ b/Polytoria/assets/textures/datamodel/Camera.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Camera.svg-3c20da9d7c4781dcd6744689eac186ad.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/CaptureService.svg.import
+++ b/Polytoria/assets/textures/datamodel/CaptureService.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://cohu72yostn68"
-path="res://.godot/imported/CaptureService.svg-2bf71888adecb328eac9d800896b1738.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/CaptureService.svg-2bf71888adecb328eac9d800896b1738.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/CaptureService.svg"
-dest_files=["res://.godot/imported/CaptureService.svg-2bf71888adecb328eac9d800896b1738.ctex"]
+dest_files=["res://.godot/imported/CaptureService.svg-2bf71888adecb328eac9d800896b1738.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/ChatService.svg.import
+++ b/Polytoria/assets/textures/datamodel/ChatService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ChatService.svg-53bed36dc26b5b6b6ebae6376bf29
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ClientScript.svg.import
+++ b/Polytoria/assets/textures/datamodel/ClientScript.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ClientScript.svg-e69b80c687858884d1752491abca
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Clothing.svg.import
+++ b/Polytoria/assets/textures/datamodel/Clothing.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Clothing.svg-bb02ef5f24687d930d15c3f46dfbd3f3
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ColorAdjustModifier.svg.import
+++ b/Polytoria/assets/textures/datamodel/ColorAdjustModifier.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://cxgtjk46bgwjc"
-path="res://.godot/imported/ColorAdjustModifier.svg-3766ec987bdf3dcf149c880db885acb0.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/ColorAdjustModifier.svg-3766ec987bdf3dcf149c880db885acb0.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/ColorAdjustModifier.svg"
-dest_files=["res://.godot/imported/ColorAdjustModifier.svg-3766ec987bdf3dcf149c880db885acb0.ctex"]
+dest_files=["res://.godot/imported/ColorAdjustModifier.svg-3766ec987bdf3dcf149c880db885acb0.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/ColorValue.svg.import
+++ b/Polytoria/assets/textures/datamodel/ColorValue.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ColorValue.svg-3e1ca566ceeeff1c9cf0568abfb992
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/CoreUIService.svg.import
+++ b/Polytoria/assets/textures/datamodel/CoreUIService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/CoreUIService.svg-c6e807940406d8d178def1de845
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/CreatorContext.svg.import
+++ b/Polytoria/assets/textures/datamodel/CreatorContext.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/CreatorContext.svg-25254289d8783ef05b336f2b0f
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/CreatorContextService.svg.import
+++ b/Polytoria/assets/textures/datamodel/CreatorContextService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/CreatorContextService.svg-50bdfbe5f8a5fa1f2a9
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/CreatorSelections.svg.import
+++ b/Polytoria/assets/textures/datamodel/CreatorSelections.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/CreatorSelections.svg-d3281a4cb4ff9ec82c87ee2
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/CreatorService.svg.import
+++ b/Polytoria/assets/textures/datamodel/CreatorService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/CreatorService.svg-2e11ccfca87c28682ea0116ec1
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/DatastoreService.svg.import
+++ b/Polytoria/assets/textures/datamodel/DatastoreService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/DatastoreService.svg-27fe25b35073319e3179f4b4
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Decal.svg.import
+++ b/Polytoria/assets/textures/datamodel/Decal.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Decal.svg-0f7f2860a6f243a0e0eb4b3696f377bc.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Dynamic.svg.import
+++ b/Polytoria/assets/textures/datamodel/Dynamic.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Dynamic.svg-51bc91d754f5fa656e3c51caf99e5466.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Entity.svg.import
+++ b/Polytoria/assets/textures/datamodel/Entity.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Entity.svg-b40193222d1f813864813b741cc48d32.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Environment.svg.import
+++ b/Polytoria/assets/textures/datamodel/Environment.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Environment.svg-62609cd8f833c08165c5212d815a4
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/FilterService.svg.import
+++ b/Polytoria/assets/textures/datamodel/FilterService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/FilterService.svg-45650b9effa01325edf0ab694c0
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Folder.svg.import
+++ b/Polytoria/assets/textures/datamodel/Folder.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Folder.svg-d54e74ef308a9a91860338dba6d265e7.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/FontAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/FontAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/FontAsset.svg-325f85ce1e7f867372ccb58f4ae0f34
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/GUI.svg.import
+++ b/Polytoria/assets/textures/datamodel/GUI.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/GUI.svg-a3b88c7b487fa5866bd6278b7af033ec.dpit
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/GUI3D.svg.import
+++ b/Polytoria/assets/textures/datamodel/GUI3D.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/GUI3D.svg-971d8db066d52e32712c8510f88daa99.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Grabbable.svg.import
+++ b/Polytoria/assets/textures/datamodel/Grabbable.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Grabbable.svg-a8ce1645ac885e516143c16c7b5b71b
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/GradientImageAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/GradientImageAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/GradientImageAsset.svg-ba67fee43fe58f4bb9dc4c
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/GradientSky.svg.import
+++ b/Polytoria/assets/textures/datamodel/GradientSky.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/GradientSky.svg-201150def10ce6c365d25d362859e
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Hidden.svg.import
+++ b/Polytoria/assets/textures/datamodel/Hidden.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Hidden.svg-7634625bd2795ef8f890547ca4b1d7d2.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/HttpService.svg.import
+++ b/Polytoria/assets/textures/datamodel/HttpService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/HttpService.svg-f01b56a47f2be1ebb749a0eeaf3d2
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Image3D.svg.import
+++ b/Polytoria/assets/textures/datamodel/Image3D.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Image3D.svg-efaebd9d59b73c80f23ac1e40e275bbe.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ImageAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/ImageAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ImageAsset.svg-11e97476241a8b9ef60fd915a942bc
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ImageSky.svg.import
+++ b/Polytoria/assets/textures/datamodel/ImageSky.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ImageSky.svg-aab8792fabf67074c76901c3ae292e0f
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/InputService.svg.import
+++ b/Polytoria/assets/textures/datamodel/InputService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/InputService.svg-e96a120631e83b36b0b542fbbbf9
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/InsertService.svg.import
+++ b/Polytoria/assets/textures/datamodel/InsertService.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://den1tbhgnflx3"
-path="res://.godot/imported/InsertService.svg-fa3da0fb5f23afe974e96c9e6d12b645.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/InsertService.svg-fa3da0fb5f23afe974e96c9e6d12b645.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/InsertService.svg"
-dest_files=["res://.godot/imported/InsertService.svg-fa3da0fb5f23afe974e96c9e6d12b645.ctex"]
+dest_files=["res://.godot/imported/InsertService.svg-fa3da0fb5f23afe974e96c9e6d12b645.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/Instance.svg.import
+++ b/Polytoria/assets/textures/datamodel/Instance.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Instance.svg-9b9bd1d4b339d08835864b56e6e53afa
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/InstanceValue.svg.import
+++ b/Polytoria/assets/textures/datamodel/InstanceValue.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/InstanceValue.svg-6f5a28a2028d58128849b869ce4
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/IntValue.svg.import
+++ b/Polytoria/assets/textures/datamodel/IntValue.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/IntValue.svg-1abfcd0e202eb82312cc44072c683f92
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/InteractionPrompt.svg.import
+++ b/Polytoria/assets/textures/datamodel/InteractionPrompt.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://b6ij2amfqajxx"
-path="res://.godot/imported/InteractionPrompt.svg-8ead592d6dc2400df7a5aae61ef80e11.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/InteractionPrompt.svg-8ead592d6dc2400df7a5aae61ef80e11.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/InteractionPrompt.svg"
-dest_files=["res://.godot/imported/InteractionPrompt.svg-8ead592d6dc2400df7a5aae61ef80e11.ctex"]
+dest_files=["res://.godot/imported/InteractionPrompt.svg-8ead592d6dc2400df7a5aae61ef80e11.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/Inventory.svg.import
+++ b/Polytoria/assets/textures/datamodel/Inventory.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Inventory.svg-81380c40da68d97d3efa182ccd98bfa
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Light.svg.import
+++ b/Polytoria/assets/textures/datamodel/Light.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Light.svg-a6b786aaabd78400f3a8a8223842055f.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Lighting.svg.import
+++ b/Polytoria/assets/textures/datamodel/Lighting.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Lighting.svg-4c1ab6d77d5f7c649552a4f6b562eca9
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Marker3D.svg.import
+++ b/Polytoria/assets/textures/datamodel/Marker3D.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Marker3D.svg-e60216aabc681ad9092886237ad778f8
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Mesh.svg.import
+++ b/Polytoria/assets/textures/datamodel/Mesh.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Mesh.svg-0fbd3c3f66389c4142dddff694f54065.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/MeshPart.svg.import
+++ b/Polytoria/assets/textures/datamodel/MeshPart.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/MeshPart.svg-61fd047b4f047ffb1461bfaf92081925
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Model.svg.import
+++ b/Polytoria/assets/textures/datamodel/Model.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Model.svg-16e2548164d41b08e321fe21f7de58fc.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ModuleScript.svg.import
+++ b/Polytoria/assets/textures/datamodel/ModuleScript.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ModuleScript.svg-2066eee103f1ca6f3c06091075e9
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/NPC.svg.import
+++ b/Polytoria/assets/textures/datamodel/NPC.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/NPC.svg-88b2dc8793fb7f4dd44d1dbb08c48f94.dpit
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/NetworkEvent.svg.import
+++ b/Polytoria/assets/textures/datamodel/NetworkEvent.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/NetworkEvent.svg-4271985fa86576fb055b563204b6
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/NetworkedObject.svg.import
+++ b/Polytoria/assets/textures/datamodel/NetworkedObject.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/NetworkedObject.svg-940340b52a88eb58a229d2515
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/NumberValue.svg.import
+++ b/Polytoria/assets/textures/datamodel/NumberValue.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/NumberValue.svg-884db302954a45df7cd439d9188d7
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PTAudioAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/PTAudioAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/PTAudioAsset.svg-df1bb82e7a449fe6969ab4a84425
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PTImageAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/PTImageAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/PTImageAsset.svg-9614f71b65298157d64b5687747c
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PTMeshAsset.svg.import
+++ b/Polytoria/assets/textures/datamodel/PTMeshAsset.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/PTMeshAsset.svg-9af2e1599b9d389b79b426408327e
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Part.svg.import
+++ b/Polytoria/assets/textures/datamodel/Part.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Part.svg-2e31b4fd74ea9a6dbfe569187a720e1c.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Particles.svg.import
+++ b/Polytoria/assets/textures/datamodel/Particles.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Particles.svg-e269987c821678ff4f57c328df6362c
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Physical.svg.import
+++ b/Polytoria/assets/textures/datamodel/Physical.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Physical.svg-8b510572b7e145122e2d8a66ec27dccd
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Player.svg.import
+++ b/Polytoria/assets/textures/datamodel/Player.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Player.svg-6f7004b6d4ea21cf83f05d404d9e31bd.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PlayerDefaults.svg.import
+++ b/Polytoria/assets/textures/datamodel/PlayerDefaults.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/PlayerDefaults.svg-2f9cecb2f4152f3e7cdce752be
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PlayerGUI.svg.import
+++ b/Polytoria/assets/textures/datamodel/PlayerGUI.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/PlayerGUI.svg-0a2388342c5e34129e95b069f675305
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Players.svg.import
+++ b/Polytoria/assets/textures/datamodel/Players.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Players.svg-8161438a3354f9219ab35c51d124f032.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PointLight.svg.import
+++ b/Polytoria/assets/textures/datamodel/PointLight.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/PointLight.svg-3cc2c019082067bd1d21053f0e6253
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PolytorianModel.svg.import
+++ b/Polytoria/assets/textures/datamodel/PolytorianModel.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/PolytorianModel.svg-c010526f18501deb8806597c6
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PreferencesService.svg.import
+++ b/Polytoria/assets/textures/datamodel/PreferencesService.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://bikws7vwujflc"
-path="res://.godot/imported/PreferencesService.svg-c4dacdb531694f72f00042b0b68039a1.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/PreferencesService.svg-c4dacdb531694f72f00042b0b68039a1.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/PreferencesService.svg"
-dest_files=["res://.godot/imported/PreferencesService.svg-c4dacdb531694f72f00042b0b68039a1.ctex"]
+dest_files=["res://.godot/imported/PreferencesService.svg-c4dacdb531694f72f00042b0b68039a1.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/PresenceService.svg.import
+++ b/Polytoria/assets/textures/datamodel/PresenceService.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://ibqyrbbcadyp"
-path="res://.godot/imported/PresenceService.svg-24f68c8a84b5ef2aada8a930413fdbea.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/PresenceService.svg-24f68c8a84b5ef2aada8a930413fdbea.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/PresenceService.svg"
-dest_files=["res://.godot/imported/PresenceService.svg-24f68c8a84b5ef2aada8a930413fdbea.ctex"]
+dest_files=["res://.godot/imported/PresenceService.svg-24f68c8a84b5ef2aada8a930413fdbea.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/ProceduralSky.svg.import
+++ b/Polytoria/assets/textures/datamodel/ProceduralSky.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ProceduralSky.svg-08a190bb17fdff34b8f47b053a8
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/PurchasesService.svg.import
+++ b/Polytoria/assets/textures/datamodel/PurchasesService.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://dfdk1u253cuxp"
-path="res://.godot/imported/PurchasesService.svg-1de5b6b68d309f7b07da19ebbe36b759.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/PurchasesService.svg-1de5b6b68d309f7b07da19ebbe36b759.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/PurchasesService.svg"
-dest_files=["res://.godot/imported/PurchasesService.svg-1de5b6b68d309f7b07da19ebbe36b759.ctex"]
+dest_files=["res://.godot/imported/PurchasesService.svg-1de5b6b68d309f7b07da19ebbe36b759.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/QuaternionValue.svg.import
+++ b/Polytoria/assets/textures/datamodel/QuaternionValue.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://dcaoc6ckc67qf"
-path="res://.godot/imported/QuaternionValue.svg-30c1b9d7e068f9bd51fc7c84278ad16a.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/QuaternionValue.svg-30c1b9d7e068f9bd51fc7c84278ad16a.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/QuaternionValue.svg"
-dest_files=["res://.godot/imported/QuaternionValue.svg-30c1b9d7e068f9bd51fc7c84278ad16a.ctex"]
+dest_files=["res://.godot/imported/QuaternionValue.svg-30c1b9d7e068f9bd51fc7c84278ad16a.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/RangeValue.svg.import
+++ b/Polytoria/assets/textures/datamodel/RangeValue.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://ca886uq4yk2tu"
-path="res://.godot/imported/RangeValue.svg-6e5c6cf18157d58cc85b88fd9e730313.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/RangeValue.svg-6e5c6cf18157d58cc85b88fd9e730313.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/datamodel/RangeValue.svg"
-dest_files=["res://.godot/imported/RangeValue.svg-6e5c6cf18157d58cc85b88fd9e730313.ctex"]
+dest_files=["res://.godot/imported/RangeValue.svg-6e5c6cf18157d58cc85b88fd9e730313.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/datamodel/RigidBody.svg.import
+++ b/Polytoria/assets/textures/datamodel/RigidBody.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/RigidBody.svg-d38665c5cd8831644ce35826c35d595
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Script.svg.import
+++ b/Polytoria/assets/textures/datamodel/Script.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Script.svg-320189d339398841fffd3f495b802504.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ScriptService.svg.import
+++ b/Polytoria/assets/textures/datamodel/ScriptService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ScriptService.svg-e9cf640c43c02ffa5bf6a3f0700
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Seat.svg.import
+++ b/Polytoria/assets/textures/datamodel/Seat.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Seat.svg-51eb3ba59760ceccf7aea2ad1d506a1a.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ServerHidden.svg.import
+++ b/Polytoria/assets/textures/datamodel/ServerHidden.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ServerHidden.svg-9903264186aa99d77f604593035e
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ServerScript.svg.import
+++ b/Polytoria/assets/textures/datamodel/ServerScript.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ServerScript.svg-95a610b0e3b3c6bca900c0dfacc8
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Sound.svg.import
+++ b/Polytoria/assets/textures/datamodel/Sound.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Sound.svg-c4e5c05f2834487fb3a1e77fa8f9072c.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/SpotLight.svg.import
+++ b/Polytoria/assets/textures/datamodel/SpotLight.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/SpotLight.svg-21c76f6130eda30d257259ea51209c8
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Stat.svg.import
+++ b/Polytoria/assets/textures/datamodel/Stat.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Stat.svg-22857ff2497c8912271af3dfc175562f.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Stats.svg.import
+++ b/Polytoria/assets/textures/datamodel/Stats.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Stats.svg-c1afbe5444390b30f45cba517a3d31d2.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/StringValue.svg.import
+++ b/Polytoria/assets/textures/datamodel/StringValue.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/StringValue.svg-bdef53c739090fa0e6c6f051c0343
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/SunLight.svg.import
+++ b/Polytoria/assets/textures/datamodel/SunLight.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/SunLight.svg-2fbce8e0c4d79a939d862121e5244389
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Team.svg.import
+++ b/Polytoria/assets/textures/datamodel/Team.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Team.svg-21e67d02808e3c75a17b5224a7d460be.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Teams.svg.import
+++ b/Polytoria/assets/textures/datamodel/Teams.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Teams.svg-22afbc6275cc77cfd3401d4cdeb5ea47.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Text3D.svg.import
+++ b/Polytoria/assets/textures/datamodel/Text3D.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Text3D.svg-582e2aec6ff0084fa7103c1ed688f624.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Tool.svg.import
+++ b/Polytoria/assets/textures/datamodel/Tool.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Tool.svg-67c00766a042068d4677a118bdc7218c.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Truss.svg.import
+++ b/Polytoria/assets/textures/datamodel/Truss.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Truss.svg-e8ac02f90ac2d0dfae6aeadbf9dfdca5.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/TweenService.svg.import
+++ b/Polytoria/assets/textures/datamodel/TweenService.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/TweenService.svg-1de05d6dc6ef22423db5af657639
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIAspectRatioRestraint.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIAspectRatioRestraint.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIAspectRatioRestraint.svg-fdecd0f953453ec8be
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIButton.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIButton.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIButton.svg-9095360962ae2acd9b83940b11a45069
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIField.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIField.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIField.svg-f492fad4c9aa1f6b9eef15f4c5b1423f.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIGridLayout.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIGridLayout.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIGridLayout.svg-778758989d59fdd5876f2555f2b5
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIHFlow.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIHFlow.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIHFlow.svg-6239a4ccbe8b61fd70b327d3f80a132a.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIHLayout.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIHLayout.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIHLayout.svg-1bb4dd9e6d738ccd9739f25a522d796
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIImage.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIImage.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIImage.svg-75afe2e5e4fd74ec46b953d668506827.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UILabel.svg.import
+++ b/Polytoria/assets/textures/datamodel/UILabel.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UILabel.svg-1d8c206619660e4b4e6a13349fafcb1b.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIScrollView.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIScrollView.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIScrollView.svg-14c9451ba52de15452d99af4c266
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UITextInput.svg.import
+++ b/Polytoria/assets/textures/datamodel/UITextInput.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UITextInput.svg-4d243ae22bffb3fac4a0b0b2621f0
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIVFlow.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIVFlow.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIVFlow.svg-0e0a878737c4dea0de63c84653255bca.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIVLayout.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIVLayout.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIVLayout.svg-e75392b6347b026889a7e1d2e6c3b27
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIView.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIView.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIView.svg-07fd5ffbc5e662cb7a982994468ac821.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/UIViewport.svg.import
+++ b/Polytoria/assets/textures/datamodel/UIViewport.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/UIViewport.svg-7e3294b122bc25192b24a082a0f1ee
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Unknown.svg.import
+++ b/Polytoria/assets/textures/datamodel/Unknown.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Unknown.svg-d88b8760f991ab31d1c86294817dcdcd.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/ValueBase.svg.import
+++ b/Polytoria/assets/textures/datamodel/ValueBase.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ValueBase.svg-4ef409b580816e0575ea63b90b9b751
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Vector2Value.svg.import
+++ b/Polytoria/assets/textures/datamodel/Vector2Value.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Vector2Value.svg-095a63cef4984102171898c4097b
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Vector3Value.svg.import
+++ b/Polytoria/assets/textures/datamodel/Vector3Value.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Vector3Value.svg-209539426e910da40f7acf4821c5
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/Weld.svg.import
+++ b/Polytoria/assets/textures/datamodel/Weld.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/Weld.svg-96d09d6b6d05903a4795a9c5a6da835b.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/datamodel/World.svg.import
+++ b/Polytoria/assets/textures/datamodel/World.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/World.svg-d18a3dc49fb7219fcf81dab853ccce7d.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/addon.svg.import
+++ b/Polytoria/assets/textures/ui-icons/addon.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/addon.svg-6fb83cb6be67577dab6695820b93a9d4.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/archive.svg.import
+++ b/Polytoria/assets/textures/ui-icons/archive.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/archive.svg-20e25217511d6e98f5ff8f6fad56cfd0.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/arrow-down.svg.import
+++ b/Polytoria/assets/textures/ui-icons/arrow-down.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/arrow-down.svg-55bf1ca5a2f9f3ae27b6727d270a1c
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/arrow-up.svg.import
+++ b/Polytoria/assets/textures/ui-icons/arrow-up.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/arrow-up.svg-6d9bbd28deed40b16bfb1bd57bca0fdf
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/award-filled.svg.import
+++ b/Polytoria/assets/textures/ui-icons/award-filled.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/award-filled.svg-5ad377d855dcfba0ed583e3e47dc
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/back.svg.import
+++ b/Polytoria/assets/textures/ui-icons/back.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/back.svg-0e2c86feabd9994c5b7a5442d0258eb3.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/barrier-block.svg.import
+++ b/Polytoria/assets/textures/ui-icons/barrier-block.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/barrier-block.svg-9a7601f9e0c3074aabc9af3c035
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/bodypart.svg.import
+++ b/Polytoria/assets/textures/ui-icons/bodypart.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/bodypart.svg-c2b109364485a382f579bacc5ce612cb
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/bomb.svg.import
+++ b/Polytoria/assets/textures/ui-icons/bomb.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/bomb.svg-8296ee596f85bf27167b5be3a22b81a3.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/book.svg.import
+++ b/Polytoria/assets/textures/ui-icons/book.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/book.svg-2828d350232c2288a422d5fca966a00f.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/brick.svg.import
+++ b/Polytoria/assets/textures/ui-icons/brick.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/brick.svg-dfb1ba2091db14b663a2b81ebb47dbcd.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/bug.svg.import
+++ b/Polytoria/assets/textures/ui-icons/bug.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/bug.svg-656fc009a7e7d4df84a355fa82b4c7ff.dpit
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/camera.svg.import
+++ b/Polytoria/assets/textures/ui-icons/camera.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/camera.svg-494ccf27d2e46b3a38748b820b4b4440.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/case-match.svg.import
+++ b/Polytoria/assets/textures/ui-icons/case-match.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/case-match.svg-c5fb33fb3bc65ddfb36970c9a020b5
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/chat-send.svg.import
+++ b/Polytoria/assets/textures/ui-icons/chat-send.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/chat-send.svg-4e008fae55d90743ff36bd1489a9e79
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/chevron-down.svg.import
+++ b/Polytoria/assets/textures/ui-icons/chevron-down.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://cpbnnrbrffye8"
-path="res://.godot/imported/chevron-down.svg-76c62e24f165ea25370ab8fe1d1b8d28.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/chevron-down.svg-76c62e24f165ea25370ab8fe1d1b8d28.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/ui-icons/chevron-down.svg"
-dest_files=["res://.godot/imported/chevron-down.svg-76c62e24f165ea25370ab8fe1d1b8d28.ctex"]
+dest_files=["res://.godot/imported/chevron-down.svg-76c62e24f165ea25370ab8fe1d1b8d28.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/ui-icons/chevron-left.svg.import
+++ b/Polytoria/assets/textures/ui-icons/chevron-left.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/chevron-left.svg-4f61f76815014e51e5c20d1c3b21
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/chevron-right.svg.import
+++ b/Polytoria/assets/textures/ui-icons/chevron-right.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/chevron-right.svg-7ab34ffd20127b5f2f636e6aecc
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/click.svg.import
+++ b/Polytoria/assets/textures/ui-icons/click.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/click.svg-78243912b404032dba066fd22cc2fb1e.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/clipboard.svg.import
+++ b/Polytoria/assets/textures/ui-icons/clipboard.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/clipboard.svg-365586dd7c8b1e070613ad1c7bb945d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/clock.svg.import
+++ b/Polytoria/assets/textures/ui-icons/clock.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/clock.svg-4a0f77606cb4e83b2204996cf8c27513.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/code.svg.import
+++ b/Polytoria/assets/textures/ui-icons/code.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/code.svg-6c8f2975308b25fced92896e6a640342.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/comments.svg.import
+++ b/Polytoria/assets/textures/ui-icons/comments.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/comments.svg-03829e6423fba0d3d6110e1e243c7763
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/copy.svg.import
+++ b/Polytoria/assets/textures/ui-icons/copy.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/copy.svg-ed4c25f9184e2e8dc4b49a9353c88a7d.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/cube.svg.import
+++ b/Polytoria/assets/textures/ui-icons/cube.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/cube.svg-ab0c00d396d69b1d49a66edb8585e369.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/cut.svg.import
+++ b/Polytoria/assets/textures/ui-icons/cut.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/cut.svg-f47d1368dfc9b0b9367d271e0c71f81b.dpit
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/door-exit.svg.import
+++ b/Polytoria/assets/textures/ui-icons/door-exit.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/door-exit.svg-0f897615c43ee4afeda403cde79dddd
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/dots.svg.import
+++ b/Polytoria/assets/textures/ui-icons/dots.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/dots.svg-318df7cf6632b6fc188ce88a5198f987.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/dpad.svg.import
+++ b/Polytoria/assets/textures/ui-icons/dpad.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/dpad.svg-e52721fc7d6bf649723c0c63c187b366.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/duplicate.svg.import
+++ b/Polytoria/assets/textures/ui-icons/duplicate.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/duplicate.svg-06da31dbc074d58fc8a11c2700cb010
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/edit.svg.import
+++ b/Polytoria/assets/textures/ui-icons/edit.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/edit.svg-1c7dc8642a689f7d1dc2afd6cff9d3dc.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/external-link.svg.import
+++ b/Polytoria/assets/textures/ui-icons/external-link.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/external-link.svg-72ac1c8ff9eaaa7894abc772413
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/face.svg.import
+++ b/Polytoria/assets/textures/ui-icons/face.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/face.svg-babca1e78c7d08c57cda0ae4f849733d.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/flag.svg.import
+++ b/Polytoria/assets/textures/ui-icons/flag.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/flag.svg-54753fd18a8176dc7720361b92b54c77.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/folder.svg.import
+++ b/Polytoria/assets/textures/ui-icons/folder.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/folder.svg-0a9115616954d7f37c5803a36579f0eb.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/gamepad.svg.import
+++ b/Polytoria/assets/textures/ui-icons/gamepad.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/gamepad.svg-7d72759f024b7484ab09c987a3cf4f5a.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/group.svg.import
+++ b/Polytoria/assets/textures/ui-icons/group.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/group.svg-5646bd36312c50dbfac76836b0579e6b.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/hat.svg.import
+++ b/Polytoria/assets/textures/ui-icons/hat.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/hat.svg-32b22ccca4c76558e448456c5680a8c4.dpit
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/heart-filled.svg.import
+++ b/Polytoria/assets/textures/ui-icons/heart-filled.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/heart-filled.svg-3ec57f492d3a7b27b4d803eba324
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/heart.svg.import
+++ b/Polytoria/assets/textures/ui-icons/heart.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/heart.svg-b5041261cae6d407f44e79476c150a73.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/home.svg.import
+++ b/Polytoria/assets/textures/ui-icons/home.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/home.svg-c583416bf1b75d95335320a85bee2898.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/input-axis.svg.import
+++ b/Polytoria/assets/textures/ui-icons/input-axis.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/input-axis.svg-2793b1e00d42c0c0d03dddcfb232eb
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/input-button.svg.import
+++ b/Polytoria/assets/textures/ui-icons/input-button.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/input-button.svg-cd4724e6981d7af7c115afc42f9a
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/input-vector2.svg.import
+++ b/Polytoria/assets/textures/ui-icons/input-vector2.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/input-vector2.svg-f8e9d68fde8b416235500c5bcbf
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/keyboard.svg.import
+++ b/Polytoria/assets/textures/ui-icons/keyboard.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/keyboard.svg-84797321049d60f4cf5f103de807e340
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/link-off.svg.import
+++ b/Polytoria/assets/textures/ui-icons/link-off.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/link-off.svg-0970bf7d345d676a62986ca76ba4696f
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/link.svg.import
+++ b/Polytoria/assets/textures/ui-icons/link.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/link.svg-dc5d9a21be9bd83128887c9ee488c7ca.dpi
 base_scale=0.75
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/lock.svg.import
+++ b/Polytoria/assets/textures/ui-icons/lock.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/lock.svg-745a624a112c43ce6af0a295427ff3ec.dpi
 base_scale=0.75
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/messages.svg.import
+++ b/Polytoria/assets/textures/ui-icons/messages.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/messages.svg-a7e794d488faa994b50930a408759422
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/mountain.svg.import
+++ b/Polytoria/assets/textures/ui-icons/mountain.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/mountain.svg-44cd955a01142779846f51e0ae549e5f
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/outfits.svg.import
+++ b/Polytoria/assets/textures/ui-icons/outfits.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/outfits.svg-cbdf96ffd1ba25af6af9f78d5bb305f5.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/pants.svg.import
+++ b/Polytoria/assets/textures/ui-icons/pants.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/pants.svg-bdc9569f5b34735c92828a89829e97c8.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/pause-filled.svg.import
+++ b/Polytoria/assets/textures/ui-icons/pause-filled.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/pause-filled.svg-a3231174d3ac57ddae218f63f3bd
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/planet.svg.import
+++ b/Polytoria/assets/textures/ui-icons/planet.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/planet.svg-bd7a9c0173b0b557b82c5be366fd3c45.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/play-filled.svg.import
+++ b/Polytoria/assets/textures/ui-icons/play-filled.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/play-filled.svg-f5274785fd5f354b9d3e4a8fa6380
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/play.svg.import
+++ b/Polytoria/assets/textures/ui-icons/play.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/play.svg-d76197309362ade215167fd660db6d5c.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/plus.svg.import
+++ b/Polytoria/assets/textures/ui-icons/plus.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/plus.svg-2a1f69cc56bda24a6b27991172aa55f6.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/publish.svg.import
+++ b/Polytoria/assets/textures/ui-icons/publish.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/publish.svg-de922ea04788787b77d9a90bb6a1dc9f.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/replace-all.svg.import
+++ b/Polytoria/assets/textures/ui-icons/replace-all.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/replace-all.svg-448988fc1c7195ff07e169d05fd1e
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/replace.svg.import
+++ b/Polytoria/assets/textures/ui-icons/replace.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/replace.svg-1e47bca897da8829c95e330a765b6de8.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/resize-handle.svg.import
+++ b/Polytoria/assets/textures/ui-icons/resize-handle.svg.import
@@ -1,43 +1,20 @@
 [remap]
 
-importer="texture"
-type="CompressedTexture2D"
+importer="svg"
+type="DPITexture"
 uid="uid://bctbyvslc3xgd"
-path="res://.godot/imported/resize-handle.svg-3d346789dec9165996cdc569e2968390.ctex"
-metadata={
-"vram_texture": false
-}
+path="res://.godot/imported/resize-handle.svg-3d346789dec9165996cdc569e2968390.dpitex"
 
 [deps]
 
 source_file="res://assets/textures/ui-icons/resize-handle.svg"
-dest_files=["res://.godot/imported/resize-handle.svg-3d346789dec9165996cdc569e2968390.ctex"]
+dest_files=["res://.godot/imported/resize-handle.svg-3d346789dec9165996cdc569e2968390.dpitex"]
 
 [params]
 
-compress/mode=0
-compress/high_quality=false
-compress/lossy_quality=0.7
-compress/uastc_level=0
-compress/rdo_quality_loss=0.0
-compress/hdr_compression=1
-compress/normal_map=0
-compress/channel_pack=0
-mipmaps/generate=false
-mipmaps/limit=-1
-roughness/mode=0
-roughness/src_normal=""
-process/channel_remap/red=0
-process/channel_remap/green=1
-process/channel_remap/blue=2
-process/channel_remap/alpha=3
-process/fix_alpha_border=true
-process/premult_alpha=false
-process/normal_map_invert_y=false
-process/hdr_as_srgb=false
-process/hdr_clamp_exposure=false
-process/size_limit=0
-detect_3d/compress_to=1
-svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+base_scale=1.0
+saturation=1.0
+color_map={}
+fix_alpha_border=false
+premult_alpha=false
+compress=true

--- a/Polytoria/assets/textures/ui-icons/respawn.svg.import
+++ b/Polytoria/assets/textures/ui-icons/respawn.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/respawn.svg-d7f536e4ce84b585039dff21464d12dd.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/rocket.svg.import
+++ b/Polytoria/assets/textures/ui-icons/rocket.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/rocket.svg-299561943eca68ca0e31194aa4cb500d.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/route.svg.import
+++ b/Polytoria/assets/textures/ui-icons/route.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/route.svg-79cd6d4c4b31f5ddac00dda0e75b0142.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/save.svg.import
+++ b/Polytoria/assets/textures/ui-icons/save.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/save.svg-4710c4bd2ee728ce50b3c5a1edaba90a.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/script.svg.import
+++ b/Polytoria/assets/textures/ui-icons/script.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/script.svg-ae71cd3c833885652314d6a3adb43717.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/search.svg.import
+++ b/Polytoria/assets/textures/ui-icons/search.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/search.svg-03c396b30c9d870b1749a1491ed1e22f.d
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/select-all.svg.import
+++ b/Polytoria/assets/textures/ui-icons/select-all.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/select-all.svg-6ea1c10ebd337a43d6f3e6f3c58347
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/settings.svg.import
+++ b/Polytoria/assets/textures/ui-icons/settings.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/settings.svg-d4fe7ce81aeafb8190a88531e2f2a8eb
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/shirt.svg.import
+++ b/Polytoria/assets/textures/ui-icons/shirt.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/shirt.svg-2fda5fce7828a1991881c641261ce834.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/shopping-cart.svg.import
+++ b/Polytoria/assets/textures/ui-icons/shopping-cart.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/shopping-cart.svg-4e717502f7bfc2de4a5e255dd88
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/star-filled.svg.import
+++ b/Polytoria/assets/textures/ui-icons/star-filled.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/star-filled.svg-dd79d86fe934dd391a2a3eb61e182
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/star.svg.import
+++ b/Polytoria/assets/textures/ui-icons/star.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/star.svg-ff32461562b3d36d63e945c1db98ad17.dpi
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/stop-filled.svg.import
+++ b/Polytoria/assets/textures/ui-icons/stop-filled.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/stop-filled.svg-2ddcfa5fb108e34826f6899a282c6
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/thumb-up.svg.import
+++ b/Polytoria/assets/textures/ui-icons/thumb-up.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/thumb-up.svg-0b7593fdfe310f2529e8d27745d5db1f
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/tools.svg.import
+++ b/Polytoria/assets/textures/ui-icons/tools.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/tools.svg-ab7530c5719e8b2331b729c268effdcb.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/trash.svg.import
+++ b/Polytoria/assets/textures/ui-icons/trash.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/trash.svg-062cffb72301c5553dd674ccb3d928c0.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/ungroup.svg.import
+++ b/Polytoria/assets/textures/ui-icons/ungroup.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/ungroup.svg-6e99c43db3ee70f3ff1b63dc24489572.
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/user-circle.svg.import
+++ b/Polytoria/assets/textures/ui-icons/user-circle.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/user-circle.svg-abaf989d185af407f74c23c7e1f62
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/users-group.svg.import
+++ b/Polytoria/assets/textures/ui-icons/users-group.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/users-group.svg-38b07b879d6f03f0ecc9cc3a9a5c0
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/users.svg.import
+++ b/Polytoria/assets/textures/ui-icons/users.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/users.svg-a6bc9b8c44ae38636d0b0bd0cac8526e.dp
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/whole-word.svg.import
+++ b/Polytoria/assets/textures/ui-icons/whole-word.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/whole-word.svg-f74f4d4fee5bab16787bf47ef04cc2
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/assets/textures/ui-icons/x.svg.import
+++ b/Polytoria/assets/textures/ui-icons/x.svg.import
@@ -15,4 +15,6 @@ dest_files=["res://.godot/imported/x.svg-d186de968c31b3cbd7a2bcbd6ea2cbe4.dpitex
 base_scale=1.0
 saturation=1.0
 color_map={}
+fix_alpha_border=false
+premult_alpha=false
 compress=true

--- a/Polytoria/scripts/creator/Camera.cs.uid
+++ b/Polytoria/scripts/creator/Camera.cs.uid
@@ -1,1 +1,0 @@
-uid://uvnebioy5quy

--- a/Polytoria/scripts/creator/Creator.cs.uid
+++ b/Polytoria/scripts/creator/Creator.cs.uid
@@ -1,1 +1,0 @@
-uid://dsg4nvmevpt3g

--- a/Polytoria/scripts/creator/State.cs.uid
+++ b/Polytoria/scripts/creator/State.cs.uid
@@ -1,1 +1,0 @@
-uid://dkr18on8f5g2q

--- a/Polytoria/scripts/creator/properties/wee.cs.uid
+++ b/Polytoria/scripts/creator/properties/wee.cs.uid
@@ -1,1 +1,0 @@
-uid://dafhryvcuemj4

--- a/Polytoria/scripts/creator/ui/popups/input_manager/SettingsPopup.cs.uid
+++ b/Polytoria/scripts/creator/ui/popups/input_manager/SettingsPopup.cs.uid
@@ -1,1 +1,0 @@
-uid://bmhg4ipqf3xcv

--- a/Polytoria/scripts/creator/ui/popups/input_manager/components/SettingsPropertyUI.cs.uid
+++ b/Polytoria/scripts/creator/ui/popups/input_manager/components/SettingsPropertyUI.cs.uid
@@ -1,1 +1,0 @@
-uid://by0gad1g3b8mn

--- a/Polytoria/scripts/datamodel/Vehicle.cs.uid
+++ b/Polytoria/scripts/datamodel/Vehicle.cs.uid
@@ -1,1 +1,0 @@
-uid://byv5ste4173e8

--- a/Polytoria/scripts/datamodel/VehicleSeat.cs.uid
+++ b/Polytoria/scripts/datamodel/VehicleSeat.cs.uid
@@ -1,1 +1,0 @@
-uid://bwfxmed5qhnx3

--- a/Polytoria/scripts/datamodel/VehicleWheel.cs.uid
+++ b/Polytoria/scripts/datamodel/VehicleWheel.cs.uid
@@ -1,1 +1,0 @@
-uid://db4hqx2rspqfy

--- a/Polytoria/scripts/scripting/datatypes/LuaBounds.cs.uid
+++ b/Polytoria/scripts/scripting/datatypes/LuaBounds.cs.uid
@@ -1,1 +1,0 @@
-uid://c4sd8jw2w4kwe

--- a/Polytoria/scripts/scripting/datatypes/LuaColor.cs.uid
+++ b/Polytoria/scripts/scripting/datatypes/LuaColor.cs.uid
@@ -1,1 +1,0 @@
-uid://rfh4scnju2fy

--- a/Polytoria/scripts/scripting/datatypes/LuaQuaternion.cs.uid
+++ b/Polytoria/scripts/scripting/datatypes/LuaQuaternion.cs.uid
@@ -1,1 +1,0 @@
-uid://dlwex1qplshjy

--- a/Polytoria/scripts/scripting/datatypes/LuaVector2.cs.uid
+++ b/Polytoria/scripts/scripting/datatypes/LuaVector2.cs.uid
@@ -1,1 +1,0 @@
-uid://dyxykmnvuwwud

--- a/Polytoria/scripts/scripting/datatypes/LuaVector3.cs.uid
+++ b/Polytoria/scripts/scripting/datatypes/LuaVector3.cs.uid
@@ -1,1 +1,0 @@
-uid://dh0x1oqljka7o

--- a/Polytoria/scripts/scripting/languages/luau/LuaProvider.cs.uid
+++ b/Polytoria/scripts/scripting/languages/luau/LuaProvider.cs.uid
@@ -1,1 +1,0 @@
-uid://m0y0ihltnpmm


### PR DESCRIPTION
## Summary

deletes some orphan uids (my favorite is `wee.cs.uid`), changes all svgs to import as `DPITexture`s (to be consistent, a couple were `Texture2D`s before), and reimports all svgs (to add the new `fix_alpha_border` and `premult_alpha` properties added in Godot 4.7). shouldn't majorly affect anything

this might break your svg previews just give Godot a minute to re-render everything :grin:

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [X] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [X] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None