### PR TITLE
Set NPC velocity to resulting vector from MoveAndSlide in NPC:Move

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -724,6 +724,8 @@ public partial class NPC : Physical
 		UpdateVelocityInternal(CharacterVelocity);
 		CharBody3D.Velocity = Velocity;
 		CharBody3D.MoveAndSlide();
+		CharacterVelocity = CharBody3D.Velocity;
+		UpdateVelocityInternal(CharacterVelocity);
 	}
 
 	[ScriptMethod]


### PR DESCRIPTION
## Summary

The `CharacterBody3D.MoveAndSlide` Godot function modifies the `Velocity` property of the `CharacterBody3D` if a slide collision occurred. This vector is useful to those overriding the default movement system of the player. This PR makes the `NPC:Move` function mimic this behavior.

## Related issue or discussion

Fixes #395

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Not applicable

## AI/LLM use

None