### PR TITLE
apply rotation to spawn position offset

### DIFF
--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -943,7 +943,7 @@ public sealed partial class Player : NPC
 		if (Root.Environment.SpawnPoints.Count > 0)
 		{
 			Entity spawnpoint = ArrayUtils.GetRandom(Root.Environment.SpawnPoints);
-			Position = spawnpoint.Position + new Vector3(0, spawnpoint.Size.Y + 2.0f, 0);
+			Position = spawnpoint.Position + new Vector3(0, spawnpoint.Size.Y + 2.0f, 0) * spawnpoint.Quaternion;
 			Rotation = new(0, spawnpoint.Rotation.Y, 0);
 		}
 		else


### PR DESCRIPTION
## Summary

rotation now affects where a player is spawned on a spawn point, e.g. turning a spawn point upsidedown will cause the player to be placed below the spawn point

## Related issue or discussion

Related to #904

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

none!