### PR TITLE
Add ClothingAsync to InsertService

### DIFF
--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -124,6 +124,22 @@ public sealed partial class InsertService : Instance
 #endif
 
 	[ScriptMethod]
+	public async Task<Clothing?> ClothingAsync(int id)
+	{
+		APIStoreItem storeItem = await GetStoreItemCachedAsync(id);
+
+		PTImageAsset imageAsset = New<PTImageAsset>();
+		imageAsset.ImageID = (uint)id;
+		imageAsset.ImageType = ImageTypeEnum.Asset;
+
+		Clothing clothing = New<Clothing>();
+		clothing.Name = storeItem.Name;
+		clothing.Image = imageAsset;
+
+		return clothing;
+	}
+
+	[ScriptMethod]
 	public async Task<Accessory?> AccessoryAsync(int id)
 	{
 		APIStoreItem storeItem = await GetStoreItemCachedAsync(id);

--- a/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
@@ -92,6 +92,10 @@ public class LuaMetatable : LuaObject
 					{
 						LangProvider.PushValueToLua(state, netObjTask.Result);
 					}
+					else if (task is Task<Clothing> clothingTask)
+					{
+						LangProvider.PushValueToLua(state, clothingTask.Result);
+					}
 					else if (task is Task<Accessory> accessoryTask)
 					{
 						LangProvider.PushValueToLua(state, accessoryTask.Result);


### PR DESCRIPTION
## Summary

Added ClothingAsync function to InsertService, to match AccessoryAsync and ToolAsync.

## Related issue or discussion

Fixes #912 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None