### PR TITLE
Expand `_CLIENT` and `_SERVER` globals

### DIFF
--- a/Polytoria/modules/creator/codehint/luau/globals.d.luau
+++ b/Polytoria/modules/creator/codehint/luau/globals.d.luau
@@ -16,6 +16,10 @@ declare _POLY_2: boolean
 
 declare _LOCALTEST: boolean
 
+declare _CLIENT: boolean
+
+declare _SERVER: boolean
+
 declare function warn(message: string)
 
 declare function wait(seconds: number?)

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -41,7 +41,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 	private const string WeakUserdataCache = "__UDCACHE";
 	private static readonly int ThreadDataKey = 0x1247;
 
-	private static readonly ConditionalWeakTable<object, string> _objectIDS = new();
+	private static readonly ConditionalWeakTable<object, string> _objectIDS = [];
 	private static long _nextObjectID;
 
 	private static int _allocsSinceLastGC = 0;
@@ -721,7 +721,6 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 	{
 		LuaState state = LuaState.FromIntPtr(L);
 
-		Script script = GetScriptInstance(state);
 		object? obj = LuaToObject(state, 1);
 
 		ModuleScript? ms = null;
@@ -1001,9 +1000,9 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		}
 		else
 		{
-			string errorMessage = thread.ToString(-1);
+			string? errorMessage = thread.ToString(-1);
 			lua.PushBoolean(false);
-			lua.PushString(errorMessage);
+			lua.PushString(errorMessage ?? "unknown");
 
 			return 2;
 		}
@@ -1067,7 +1066,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		}
 		else
 		{
-			return lua.Error(thread.ToString(-1));
+			return lua.Error(thread.ToString(-1) ?? "unknown");
 		}
 	}
 

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -1002,7 +1002,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		{
 			string? errorMessage = thread.ToString(-1);
 			lua.PushBoolean(false);
-			lua.PushString(errorMessage ?? "unknown");
+			lua.PushString(errorMessage ?? "");
 
 			return 2;
 		}
@@ -1066,7 +1066,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		}
 		else
 		{
-			return lua.Error(thread.ToString(-1) ?? "unknown");
+			return lua.Error(thread.ToString(-1) ?? "");
 		}
 	}
 

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -239,6 +239,13 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		state.PushBoolean(true);
 		state.SetGlobal("_POLY_2");
 
+		// Globals to identify if script is running on server/client
+		bool isServer = script.Root.Network.IsServer;
+		state.PushBoolean(!isServer);
+		state.SetGlobal("_CLIENT");
+		state.PushBoolean(isServer);
+		state.SetGlobal("_SERVER");
+
 		Assembly assembly = Assembly.GetExecutingAssembly();
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
 		Type[] types = assembly.GetTypes();
@@ -749,13 +756,6 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 
 		// Sandbox thread
 		co.SandboxGlobals();
-
-		// Global to identify if calling from server/client
-		bool isClient = script is ClientScript;
-		co.PushBoolean(isClient);
-		co.SetGlobal("_CLIENT");
-		co.PushBoolean(!isClient);
-		co.SetGlobal("_SERVER");
 
 		Exception? capturedException1 = null;
 


### PR DESCRIPTION
## Summary

exposes the `_CLIENT` and `_SERVER` globals to all scripts (instead of just `ModuleScript`s), and adds them to the `globals.d.luau` file (included in composite `def.d.luau` file)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None