### PR TITLE
Fix gravity strength

### DIFF
--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -79,8 +79,15 @@ public sealed partial class Environment : Instance
 
 			Rid space = Root.World3D.Space;
 			float gravityMagnitude = _gravity.Length();
-			PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, gravityMagnitude / -5f);
-			PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityVector, _gravity / gravityMagnitude);
+			if (gravityMagnitude == 0)
+			{
+				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityOverrideMode, (long)PhysicsServer3D.AreaSpaceOverrideMode.Disabled);
+			}
+			else
+			{
+				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, gravityMagnitude / -5f);
+				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityVector, _gravity / gravityMagnitude);
+			}
 
 			OnPropertyChanged();
 		}

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -283,7 +283,7 @@ public sealed partial class Environment : Instance
 		{
 			Vector3 hitPos = (Vector3)result["position"];
 			Vector3 normal = (Vector3)result["normal"];
-			Node collider = (Node)result["collider"];
+			Node collider = (Node)(GodotObject)result["collider"];
 
 			return new()
 			{
@@ -329,7 +329,7 @@ public sealed partial class Environment : Instance
 			Vector3 normal = (Vector3)result["normal"];
 			Rid colliderRid = (Rid)result["rid"];
 			ignoreRids.Add(colliderRid);
-			Node collider = (Node)result["collider"];
+			Node collider = (Node)(GodotObject)result["collider"];
 
 			rayResults.Add(new()
 			{
@@ -414,7 +414,7 @@ public sealed partial class Environment : Instance
 
 		foreach (Godot.Collections.Dictionary result in results)
 		{
-			Node collider = (Node)result["collider"];
+			Node collider = (Node)(GodotObject)result["collider"];
 			Instance? i = ColliderToInstance(collider);
 
 			if (i != null)

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -81,7 +81,7 @@ public sealed partial class Environment : Instance
 			float strengthSquared = _gravity.LengthSquared();
 			if (strengthSquared == 0)
 			{
-				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityOverrideMode, (long)PhysicsServer3D.AreaSpaceOverrideMode.Disabled);
+				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, 0);
 			}
 			else
 			{

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -78,8 +78,9 @@ public sealed partial class Environment : Instance
 			_gravity = value;
 
 			Rid space = Root.World3D.Space;
-			PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, -(_gravity.Y / 5));
-			PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityVector, _gravity.Normalized());
+			float gravityMagnitude = _gravity.Length();
+			PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, gravityMagnitude / -5f);
+			PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityVector, _gravity / gravityMagnitude);
 
 			OnPropertyChanged();
 		}

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -78,15 +78,16 @@ public sealed partial class Environment : Instance
 			_gravity = value;
 
 			Rid space = Root.World3D.Space;
-			float gravityMagnitude = _gravity.Length();
-			if (gravityMagnitude == 0)
+			float strengthSquared = _gravity.LengthSquared();
+			if (strengthSquared == 0)
 			{
 				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityOverrideMode, (long)PhysicsServer3D.AreaSpaceOverrideMode.Disabled);
 			}
 			else
 			{
-				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, gravityMagnitude / -5f);
-				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityVector, _gravity / gravityMagnitude);
+				float strength = Mathf.Sqrt(strengthSquared);
+				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, strength / -5f);
+				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityVector, _gravity / strength);
 			}
 
 			OnPropertyChanged();

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -78,14 +78,13 @@ public sealed partial class Environment : Instance
 			_gravity = value;
 
 			Rid space = Root.World3D.Space;
-			float strengthSquared = _gravity.LengthSquared();
-			if (strengthSquared == 0)
+			if (_gravity == Vector3.Zero)
 			{
 				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, 0);
 			}
 			else
 			{
-				float strength = Mathf.Sqrt(strengthSquared);
+				float strength = _gravity.Length();
 				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.Gravity, strength / -5f);
 				PhysicsServer3D.AreaSetParam(space, PhysicsServer3D.AreaParameter.GravityVector, _gravity / strength);
 			}


### PR DESCRIPTION
## Summary

makes the strength of gravity dependent on the length of `Environment.Gravity` rather than just its `Y` axis

## Related issue or discussion

Fixes #916

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None