### PR TITLE
more accurate `RigidBody`/`Physical` inclusion

### DIFF
--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -359,23 +359,18 @@ public partial class Physical : Dynamic
 		PhysicalRoot = null;
 		Instance? current = Parent;
 
-		// Find physical until parent is not physical (top physical as root)
+		// Find topmost physical among ancestors (top physical as root)
 		while (current != null)
 		{
-			Type ct = current.GetType();
 
 			if (current is Physical pr)
 			{
 				PhysicalRoot = pr;
-			}
-			else
-			{
-				break;
-			}
-
-			if (ct.IsDefined(typeof(PhysicalRootStopAttribute), false))
-			{
-				break;
+				Type ct = current.GetType();
+				if (ct.IsDefined(typeof(PhysicalRootStopAttribute), false))
+				{
+					break;
+				}
 			}
 
 			current = current.Parent;

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -637,7 +637,10 @@ public partial class Physical : Dynamic
 	internal void PostCollisionShapeUpdate(CollisionShape3D collisionShape)
 	{
 		RemoveCollisionShape(collisionShape, false);
-		AddCollisionShape(collisionShape);
+		if (CanCollide)
+		{
+			AddCollisionShape(collisionShape);
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary

`CanCollide` is now respected for children of a `Physical`
subparts are now fully integrated even if they're buffered by a non`Physical` node

## Related issue or discussion

Fixes #843
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use
none