### PR TITLE
change default value of `FormatOnSave` from `True` to `False` and change its name to `FormatSave`

### DIFF
--- a/Polytoria/scripts/creator/settings/CreatorSettingKeys.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingKeys.cs
@@ -28,7 +28,7 @@ public static class CreatorSettingKeys
 		public const string IndentationMode = "code_editor.indentation_mode";
 		public const string IndentationSize = "code_editor.indentation_size";
 
-		public const string FormatAtSave = "code_editor.formatter.format_at_save";
+		public const string FormatSave = "code_editor.formatter.format_save";
 	}
 
 	public static class Popups

--- a/Polytoria/scripts/creator/settings/CreatorSettingKeys.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingKeys.cs
@@ -28,7 +28,7 @@ public static class CreatorSettingKeys
 		public const string IndentationMode = "code_editor.indentation_mode";
 		public const string IndentationSize = "code_editor.indentation_size";
 
-		public const string FormatOnSave = "code_editor.formatter.format_on_save";
+		public const string FormatAtSave = "code_editor.formatter.format_at_save";
 	}
 
 	public static class Popups

--- a/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
@@ -164,7 +164,7 @@ public static class CreatorSettingsRegistry
 				Description = "When enabled, the editor will automatically format scripts on save.",
 				ValueKind = SettingValueKind.Bool,
 				ControlKind = SettingControlKind.Toggle,
-				DefaultValue = true,
+				DefaultValue = false,
 				Conditions = [
 					new SettingCondition<PreferredEditorEnum>() {
 						Target = CreatorSettingKeys.CodeEditor.PreferredEditor,

--- a/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
@@ -155,10 +155,10 @@ public static class CreatorSettingsRegistry
 				]
 			});
 
-		defs.Add(CreatorSettingKeys.CodeEditor.FormatAtSave,
+		defs.Add(CreatorSettingKeys.CodeEditor.FormatSave,
 			new SettingDef<bool>
 			{
-				Key = CreatorSettingKeys.CodeEditor.FormatAtSave,
+				Key = CreatorSettingKeys.CodeEditor.FormatSave,
 				SectionKey = "code_editor",
 				Label = "Format on save",
 				Description = "When enabled, the editor will automatically format scripts on save.",

--- a/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
@@ -155,10 +155,10 @@ public static class CreatorSettingsRegistry
 				]
 			});
 
-		defs.Add(CreatorSettingKeys.CodeEditor.FormatOnSave,
+		defs.Add(CreatorSettingKeys.CodeEditor.FormatAtSave,
 			new SettingDef<bool>
 			{
-				Key = CreatorSettingKeys.CodeEditor.FormatOnSave,
+				Key = CreatorSettingKeys.CodeEditor.FormatAtSave,
 				SectionKey = "code_editor",
 				Label = "Format on save",
 				Description = "When enabled, the editor will automatically format scripts on save.",

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -284,8 +284,8 @@ public partial class TextEditorRoot : Node
 
 	public async Task Save()
 	{
-		bool formatOnSave = CreatorSettingsService.Instance.Get<bool>(CreatorSettingKeys.CodeEditor.FormatOnSave);
-		if (formatOnSave)
+		bool formatAtSave = CreatorSettingsService.Instance.Get<bool>(CreatorSettingKeys.CodeEditor.FormatAtSave);
+		if (formatAtSave)
 		{
 			CodeEditor.Text = await LuaFormatService.FormatScriptAsync(Container.TargetFilePathAbsolute, CodeEditor.Text);
 		}

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -284,8 +284,8 @@ public partial class TextEditorRoot : Node
 
 	public async Task Save()
 	{
-		bool formatAtSave = CreatorSettingsService.Instance.Get<bool>(CreatorSettingKeys.CodeEditor.FormatAtSave);
-		if (formatAtSave)
+		bool formatSave = CreatorSettingsService.Instance.Get<bool>(CreatorSettingKeys.CodeEditor.FormatSave);
+		if (formatSave)
 		{
 			CodeEditor.Text = await LuaFormatService.FormatScriptAsync(Container.TargetFilePathAbsolute, CodeEditor.Text);
 		}


### PR DESCRIPTION
## Summary
change default value of "format on save" from `True` to `False` to prevent formatting of scripts when saving

## Related issue or discussion

Fixes #921

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [X] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video



## AI/LLM use

None