### PR TITLE
Fix `TagAdded` and `TagRemoved` not being fired on the client

### DIFF
--- a/Polytoria/scripts/datamodel/Instance.cs
+++ b/Polytoria/scripts/datamodel/Instance.cs
@@ -265,7 +265,19 @@ public partial class Instance : NetworkedObject
 				return;
 			}
 
+			string[] oldTags = _tags;
 			_tags = value;
+
+			foreach (string tag in value.Except(oldTags))
+			{
+				TagAdded.Invoke(tag);
+			}
+
+			foreach (string tag in oldTags.Except(value))
+			{
+				TagRemoved.Invoke(tag);
+			}
+
 			OnPropertyChanged();
 		}
 	}
@@ -881,7 +893,7 @@ public partial class Instance : NetworkedObject
 			List<string> tags = [.. Tags];
 			tags.Add(tag);
 			Tags = [.. tags];
-			TagAdded.Invoke(tag);
+			//TagAdded.Invoke(tag); // Notified in Tags setter so the client gets notified if the server adds the tag
 		}
 	}
 
@@ -891,10 +903,10 @@ public partial class Instance : NetworkedObject
 		List<string> tags = [.. Tags];
 		bool removed = tags.Remove(tag);
 		Tags = [.. tags];
-		if (removed)
-		{
-			TagRemoved.Invoke(tag);
-		}
+		//if (removed)
+		//{
+		//	TagRemoved.Invoke(tag); // Notified in Tags setter so the client gets notified if the server adds the tag
+		//}
 	}
 
 	[ScriptMethod]

--- a/Polytoria/scripts/datamodel/Instance.cs
+++ b/Polytoria/scripts/datamodel/Instance.cs
@@ -888,25 +888,21 @@ public partial class Instance : NetworkedObject
 	[ScriptMethod]
 	public void AddTag(string tag)
 	{
-		if (tag != null && !Tags.Contains(tag))
-		{
-			List<string> tags = [.. Tags];
-			tags.Add(tag);
-			Tags = [.. tags];
-			//TagAdded.Invoke(tag); // Notified in Tags setter so the client gets notified if the server adds the tag
-		}
+		if (string.IsNullOrEmpty(tag) || Tags.Contains(tag))
+			return;
+
+		Tags = [.. Tags, tag];
+		// Notified in Tags setter
 	}
 
 	[ScriptMethod]
 	public void RemoveTag(string tag)
 	{
-		List<string> tags = [.. Tags];
-		bool removed = tags.Remove(tag);
-		Tags = [.. tags];
-		//if (removed)
-		//{
-		//	TagRemoved.Invoke(tag); // Notified in Tags setter so the client gets notified if the server adds the tag
-		//}
+		if (string.IsNullOrEmpty(tag) || !Tags.Contains(tag))
+			return;
+
+		Tags = [.. Tags.Where(t => t != tag)];
+		// Notified in Tags setter
 	}
 
 	[ScriptMethod]


### PR DESCRIPTION


## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
Moved TagAdded and TagRemoved invokes inside Tags setter so if the server adds or removes a tag, the client will receive the event.
I also simplified the code for AddTag and RemoveTag so that it doesn't create a new list every time it wants to add or remove a tag.

## Related issue or discussion

Fixes #926

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [x] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

https://github.com/user-attachments/assets/df74c4b5-6c64-4388-a627-5a526aa15fdf

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None