### PR TITLE
Fix: StyLua Executes in Non-Lua Files

### DIFF
--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -124,8 +124,13 @@ public partial class TextEditorRoot : Node
 		{
 			case FormatMenuId:
 				{
-					CodeEditor.Text = await LuaFormatService.FormatScriptAsync(Container.TargetFilePathAbsolute, CodeEditor.Text);
-					OnCodeEditTextChanged();
+					if (Container.CodeCompletion == FileTypeEnum.Lua)
+					{
+						CodeEditor.Text = await LuaFormatService.FormatScriptAsync(Container.TargetFilePathAbsolute, CodeEditor.Text);
+						OnCodeEditTextChanged();
+					}
+
+
 					break;
 				}
 		}
@@ -285,7 +290,7 @@ public partial class TextEditorRoot : Node
 	public async Task Save()
 	{
 		bool formatOnSave = CreatorSettingsService.Instance.Get<bool>(CreatorSettingKeys.CodeEditor.FormatOnSave);
-		if (formatOnSave)
+		if (formatOnSave && Container.CodeCompletion == FileTypeEnum.Lua)
 		{
 			CodeEditor.Text = await LuaFormatService.FormatScriptAsync(Container.TargetFilePathAbsolute, CodeEditor.Text);
 		}


### PR DESCRIPTION
## Summary

Fixes bug introduced by formatting implementation

## Related issue or discussion

Fixes #929 


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
Nope

## AI/LLM use
None