### PR TITLE
change default value of `FormatOnSave` to `false`

### DIFF
--- a/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
+++ b/Polytoria/scripts/creator/settings/CreatorSettingsRegistry.cs
@@ -164,7 +164,7 @@ public static class CreatorSettingsRegistry
 				Description = "When enabled, the editor will automatically format scripts on save.",
 				ValueKind = SettingValueKind.Bool,
 				ControlKind = SettingControlKind.Toggle,
-				DefaultValue = true,
+				DefaultValue = false,
 				Conditions = [
 					new SettingCondition<PreferredEditorEnum>() {
 						Target = CreatorSettingKeys.CodeEditor.PreferredEditor,


### PR DESCRIPTION
## Summary

changes the format on save setting's default value to false

## Related issue or discussion

old pr #925

fixes #921 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video


## AI/LLM use

None