### PR TITLE
Add different outline modes

### DIFF
--- a/Polytoria/scripts/datamodel/UIView.cs
+++ b/Polytoria/scripts/datamodel/UIView.cs
@@ -4,6 +4,7 @@
 
 using Godot;
 using Polytoria.Attributes;
+using Polytoria.Enums;
 
 namespace Polytoria.Datamodel;
 
@@ -12,6 +13,7 @@ public partial class UIView : UIField
 {
 	private Color _borderColor;
 	private Color _color;
+	private BorderModeEnum _borderMode;
 	private float _borderWidth;
 	private float _cornerRadius;
 
@@ -42,6 +44,39 @@ public partial class UIView : UIField
 			OnPropertyChanged();
 		}
 	}
+	
+	private void UpdateBorderOffset()
+	{
+		int rounded = Mathf.RoundToInt(_borderWidth);
+		if (_borderMode == BorderModeEnum.Outline) {
+			_styleBox.ExpandMarginBottom = rounded;
+			_styleBox.ExpandMarginLeft = rounded;
+			_styleBox.ExpandMarginRight = rounded;
+			_styleBox.ExpandMarginTop = rounded;
+		} else if (_borderMode == BorderModeEnum.Middle) {
+			_styleBox.ExpandMarginBottom = rounded / 2;
+			_styleBox.ExpandMarginLeft = rounded / 2;
+			_styleBox.ExpandMarginRight = rounded / 2;
+			_styleBox.ExpandMarginTop = rounded / 2;
+		} else {
+			_styleBox.ExpandMarginBottom = 0;
+			_styleBox.ExpandMarginLeft = 0;
+			_styleBox.ExpandMarginRight = 0;
+			_styleBox.ExpandMarginTop = 0;
+		}
+	}
+	
+	[Editable, ScriptProperty]
+	public BorderModeEnum BorderMode
+	{
+		get => _borderMode;
+		set
+		{
+			_borderMode = value;
+			UpdateBorderOffset();
+			OnPropertyChanged();
+		}
+	}
 
 	[Editable, ScriptProperty]
 	public float BorderWidth
@@ -65,6 +100,7 @@ public partial class UIView : UIField
 				var bw = SavedBorderWidths;
 				bw[0] = bw[1] = bw[2] = bw[3] = rounded;
 			}
+			UpdateBorderOffset();
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/UIView.cs
+++ b/Polytoria/scripts/datamodel/UIView.cs
@@ -44,28 +44,33 @@ public partial class UIView : UIField
 			OnPropertyChanged();
 		}
 	}
-	
+
 	private void UpdateBorderOffset()
 	{
 		int rounded = Mathf.RoundToInt(_borderWidth);
-		if (_borderMode == BorderModeEnum.Outline) {
+		if (_borderMode == BorderModeEnum.Outline)
+		{
 			_styleBox.ExpandMarginBottom = rounded;
 			_styleBox.ExpandMarginLeft = rounded;
 			_styleBox.ExpandMarginRight = rounded;
 			_styleBox.ExpandMarginTop = rounded;
-		} else if (_borderMode == BorderModeEnum.Middle) {
+		}
+		else if (_borderMode == BorderModeEnum.Middle)
+		{
 			_styleBox.ExpandMarginBottom = rounded / 2;
 			_styleBox.ExpandMarginLeft = rounded / 2;
 			_styleBox.ExpandMarginRight = rounded / 2;
 			_styleBox.ExpandMarginTop = rounded / 2;
-		} else {
+		}
+		else
+		{
 			_styleBox.ExpandMarginBottom = 0;
 			_styleBox.ExpandMarginLeft = 0;
 			_styleBox.ExpandMarginRight = 0;
 			_styleBox.ExpandMarginTop = 0;
 		}
 	}
-	
+
 	[Editable, ScriptProperty]
 	public BorderModeEnum BorderMode
 	{

--- a/Polytoria/scripts/enums/BorderMode.cs
+++ b/Polytoria/scripts/enums/BorderMode.cs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Polytoria.Attributes;
+
+namespace Polytoria.Enums;
+
+[ScriptEnum("BorderMode")]
+public enum BorderModeEnum
+{
+	Inset,
+	Middle,
+	Outline
+}

--- a/Polytoria/scripts/enums/BorderMode.cs.uid
+++ b/Polytoria/scripts/enums/BorderMode.cs.uid
@@ -1,0 +1,1 @@
+uid://bejcioer5l2bt


### PR DESCRIPTION
## Summary

Adds a BorderMode property to control the position of the border relative to the edges. The default option follows Godot's behavior.

## Related issue or discussion

Closes #214

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Inset
<img width="134" height="125" alt="image" src="https://github.com/user-attachments/assets/09ca2a01-b027-4ebe-9747-82cab25f8bff" />
Middle
<img width="138" height="135" alt="image" src="https://github.com/user-attachments/assets/fae1b73d-d14f-4590-8d7c-4571a208e2f2" />
Outline
<img width="145" height="143" alt="image" src="https://github.com/user-attachments/assets/7d2a185b-3b38-4452-9e96-7c63e90520fc" />


## AI/LLM use

None.