### PR TITLE
emancipate default character features from `Player` and `NPC` into `CharacterModel`

### DIFF
--- a/Polytoria/scenes/datamodel/PolytorianModel.tscn
+++ b/Polytoria/scenes/datamodel/PolytorianModel.tscn
@@ -4624,7 +4624,8 @@ nodes/DynBlend/node = SubResource("AnimationNodeBlend2_dpcmo")
 nodes/DynBlend/position = Vector2(1880, 100)
 node_connections = [&"output", 0, &"DynBlend", &"GearHold_R", 0, &"Sit", &"GearHold_R", 1, &"Animation", &"Sit", 0, &"TimeScale", &"Sit", 1, &"Animation 3", &"TimeScale", 0, &"StateMachine", &"LookYAdd", 0, &"Animation 6", &"LookYAdd", 1, &"GearHold_R", &"LookYAdd", 2, &"Animation 7", &"LookXAdd", 0, &"Animation 8", &"LookXAdd", 1, &"LookYAdd", &"LookXAdd", 2, &"Animation 9", &"DynBlend", 0, &"LookXAdd", &"DynBlend", 1, &"DynBlendTree"]
 
-[node name="Character" type="Node3D" unique_id=1577145919]
+[node name="Character" type="CharacterBody3D" unique_id=1614401625]
+wall_min_slide_angle = 1.3962634
 
 [node name="Character" type="Node3D" parent="." unique_id=1061713509]
 transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, -3, 0)

--- a/Polytoria/scenes/datamodel/PolytorianModel.tscn
+++ b/Polytoria/scenes/datamodel/PolytorianModel.tscn
@@ -4625,7 +4625,7 @@ nodes/DynBlend/position = Vector2(1880, 100)
 node_connections = [&"output", 0, &"DynBlend", &"GearHold_R", 0, &"Sit", &"GearHold_R", 1, &"Animation", &"Sit", 0, &"TimeScale", &"Sit", 1, &"Animation 3", &"TimeScale", 0, &"StateMachine", &"LookYAdd", 0, &"Animation 6", &"LookYAdd", 1, &"GearHold_R", &"LookYAdd", 2, &"Animation 7", &"LookXAdd", 0, &"Animation 8", &"LookXAdd", 1, &"LookYAdd", &"LookXAdd", 2, &"Animation 9", &"DynBlend", 0, &"LookXAdd", &"DynBlend", 1, &"DynBlendTree"]
 
 [node name="Character" type="CharacterBody3D" unique_id=1614401625]
-wall_min_slide_angle = 1.3962634
+floor_max_angle = 1.3962634
 
 [node name="Character" type="Node3D" parent="." unique_id=1061713509]
 transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, -3, 0)

--- a/Polytoria/scripts/client/spatial/Nametag.cs
+++ b/Polytoria/scripts/client/spatial/Nametag.cs
@@ -14,7 +14,7 @@ public partial class Nametag : Node3D
 	private ProgressBar _healthBar = null!;
 	private Node3D _nametag = null!;
 
-	public CharacterModel Target = null!;
+	public CharacterModel? Target = null!;
 
 	public override void _Ready()
 	{
@@ -33,9 +33,13 @@ public partial class Nametag : Node3D
 
 	public void UpdateNameTag()
 	{
+		if (Target is null) {
+			Visible = false;
+			return;
+		}
 		bool useNametag = Target.UseNametag;
 
-		Camera? cam = Target.Root.Environment.CurrentCamera;
+		Camera? cam = Target.Controller?.Root.Environment.CurrentCamera;
 
 		// Check distance from camera if is with-in radius
 		if (cam != null && useNametag)
@@ -44,13 +48,13 @@ public partial class Nametag : Node3D
 		}
 
 		// Hide if self is Target
-		if (Target == Target.Root.Players?.LocalPlayer.Character)
+		if (Target.Controller == Target.Controller?.Root?.Players?.LocalPlayer)
 		{
 			useNametag = false;
 		}
 
 		Visible = useNametag;
-		_titleLabel.Text = Target._controller.DisplayName != string.Empty ? Target._controller.DisplayName : Target.Name;
+		_titleLabel.Text = Target.Controller is null ? "" : Target.Controller.DisplayName != string.Empty ? Target.Controller.DisplayName : Target.Name;
 		_healthBar.Visible = (Target.Health < Target.MaxHealth);
 		_healthBar.Value = Target.Health;
 		_healthBar.MaxValue = Target.MaxHealth;

--- a/Polytoria/scripts/client/spatial/Nametag.cs
+++ b/Polytoria/scripts/client/spatial/Nametag.cs
@@ -14,7 +14,7 @@ public partial class Nametag : Node3D
 	private ProgressBar _healthBar = null!;
 	private Node3D _nametag = null!;
 
-	public NPC Target = null!;
+	public CharacterModel Target = null!;
 
 	public override void _Ready()
 	{
@@ -44,13 +44,13 @@ public partial class Nametag : Node3D
 		}
 
 		// Hide if self is Target
-		if (Target == Target.Root.Players?.LocalPlayer)
+		if (Target == Target.Root.Players?.LocalPlayer.Character)
 		{
 			useNametag = false;
 		}
 
 		Visible = useNametag;
-		_titleLabel.Text = Target.DisplayName != string.Empty ? Target.DisplayName : Target.Name;
+		_titleLabel.Text = Target._controller.DisplayName != string.Empty ? Target._controller.DisplayName : Target.Name;
 		_healthBar.Visible = (Target.Health < Target.MaxHealth);
 		_healthBar.Value = Target.Health;
 		_healthBar.MaxValue = Target.MaxHealth;

--- a/Polytoria/scripts/client/spatial/Nametag.cs
+++ b/Polytoria/scripts/client/spatial/Nametag.cs
@@ -33,7 +33,8 @@ public partial class Nametag : Node3D
 
 	public void UpdateNameTag()
 	{
-		if (Target is null) {
+		if (Target is null)
+		{
 			Visible = false;
 			return;
 		}

--- a/Polytoria/scripts/client/spatial/chat/BubbleChat.cs
+++ b/Polytoria/scripts/client/spatial/chat/BubbleChat.cs
@@ -17,23 +17,30 @@ public partial class BubbleChat : Node3D
 	private readonly List<BubbleItem> _activeBubbles = [];
 
 	[Export] private Control _itemContainer = null!;
-	public Player TargetPlayer = null!;
+	private Player? TargetPlayer = null;
+
+	public void SetTarget(Player plr)
+	{
+		if (TargetPlayer != null) TargetPlayer.Chatted.Disconnect(OnPlayerChatted);
+		TargetPlayer = plr;
+		if (TargetPlayer != null) TargetPlayer.Chatted.Connect(OnPlayerChatted);
+	}
 
 	public override void _EnterTree()
 	{
-		TargetPlayer.Chatted.Connect(OnPlayerChatted);
+		if (TargetPlayer != null) TargetPlayer.Chatted.Connect(OnPlayerChatted);
 		base._EnterTree();
 	}
 
 	public override void _ExitTree()
 	{
-		TargetPlayer.Chatted.Disconnect(OnPlayerChatted);
+		if (TargetPlayer != null) TargetPlayer.Chatted.Disconnect(OnPlayerChatted);
 		base._ExitTree();
 	}
 
 	private void OnPlayerChatted(string msg)
 	{
-		if (TargetPlayer.Character != null)
+		if (TargetPlayer!.Character != null)
 		{
 			Aabb? bounds = TargetPlayer.Character.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).CalculateBounds();
 			if (bounds.HasValue)

--- a/Polytoria/scripts/client/spatial/chat/BubbleChat.cs
+++ b/Polytoria/scripts/client/spatial/chat/BubbleChat.cs
@@ -19,7 +19,7 @@ public partial class BubbleChat : Node3D
 	[Export] private Control _itemContainer = null!;
 	private Player? TargetPlayer = null;
 
-	public void SetTarget(Player plr)
+	public void SetTarget(Player? plr)
 	{
 		if (TargetPlayer != null) TargetPlayer.Chatted.Disconnect(OnPlayerChatted);
 		TargetPlayer = plr;
@@ -42,7 +42,7 @@ public partial class BubbleChat : Node3D
 	{
 		if (TargetPlayer!.Character != null)
 		{
-			Aabb? bounds = TargetPlayer.Character.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).CalculateBounds();
+			Aabb? bounds = (TargetPlayer.Character.Head ?? TargetPlayer.Character).CalculateBounds();
 			if (bounds.HasValue)
 			{
 				int decrease = 0;

--- a/Polytoria/scripts/client/ui/UIHealthbar.cs
+++ b/Polytoria/scripts/client/ui/UIHealthbar.cs
@@ -30,25 +30,27 @@ public partial class UIHealthbar : Control
 
 	public override void _Process(double delta)
 	{
-		if (CoreUI.Root.Players.LocalPlayer != null)
+		Player? localplayer = CoreUI.Root.Players.LocalPlayer;
+		if (localplayer == null) return;
+		CharacterModel? localcharacter = localplayer.Character;
+		if (localcharacter == null) return;
 		{
-			Player localplayer = CoreUI.Root.Players.LocalPlayer;
-			float health = localplayer.Health;
-			float maxHealth = localplayer.MaxHealth;
+			float health = localcharacter.Health;
+			float maxHealth = localcharacter.MaxHealth;
 			Color healthClr = _healthOutColor.Lerp(_healthFullColor, Mathf.Clamp(health / maxHealth, 0, 1));
 
 			_heart.Modulate = healthClr;
 			_healthBar.Modulate = healthClr;
 
-			_staminaBar.Visible = localplayer.UseStamina;
-			_staminaBar.Value = localplayer.Stamina;
-			_staminaBar.MaxValue = localplayer.MaxStamina;
+			_staminaBar.Visible = localcharacter.UseStamina;
+			_staminaBar.Value = localcharacter.Stamina;
+			_staminaBar.MaxValue = localcharacter.MaxStamina;
 
 			_healthBar.Value = health;
 			_healthBar.MaxValue = maxHealth;
 
 			// Hide/Show the stamina bar
-			if (localplayer.Stamina == localplayer.MaxStamina || !localplayer.UseStamina)
+			if (localcharacter.Stamina == localcharacter.MaxStamina || !localcharacter.UseStamina)
 			{
 				if (_staminaBarAppeared)
 				{

--- a/Polytoria/scripts/client/ui/UIHealthbar.cs
+++ b/Polytoria/scripts/client/ui/UIHealthbar.cs
@@ -14,9 +14,11 @@ public partial class UIHealthbar : Control
 	[Export] private Label _healthLabel = null!;
 	[Export] private TextureRect _heart = null!;
 	[Export] private AnimationPlayer _staminaBarAnim = null!;
+	[Export] private AnimationPlayer _healthBarAnim = null!;
 	public CoreUIRoot CoreUI = null!;
 
 	private bool _staminaBarAppeared = false;
+	private bool _healthBarAppeared = false;
 
 	private Color _healthFullColor;
 	private Color _healthOutColor;
@@ -33,7 +35,26 @@ public partial class UIHealthbar : Control
 		Player? localplayer = CoreUI.Root.Players.LocalPlayer;
 		if (localplayer == null) return;
 		CharacterModel? localcharacter = localplayer.Character;
-		if (localcharacter == null) return;
+		if (localcharacter == null)
+		{
+			if (_healthBarAppeared)
+			{
+				_healthBar.Value = 0;
+				_healthLabel.Text = "D:";
+				_heart.Modulate = _healthOutColor;
+				_healthBar.Modulate = _healthOutColor;
+				_healthBarAppeared = false;
+				_healthBarAnim.Play("disappear");
+			}
+
+			// Hide/Show the stamina bar
+			if (_staminaBarAppeared)
+			{
+				_staminaBarAppeared = false;
+				_staminaBarAnim.Play("disappear");
+			}
+		}
+		else
 		{
 			float health = localcharacter.Health;
 			float maxHealth = localcharacter.MaxHealth;
@@ -48,6 +69,12 @@ public partial class UIHealthbar : Control
 
 			_healthBar.Value = health;
 			_healthBar.MaxValue = maxHealth;
+
+			if (!_healthBarAppeared)
+			{
+				_healthBarAppeared = true;
+				_healthBarAnim.Play("appear");
+			}
 
 			// Hide/Show the stamina bar
 			if (localcharacter.Stamina == localcharacter.MaxStamina || !localcharacter.UseStamina)

--- a/Polytoria/scripts/client/ui/chat/UIChat.cs
+++ b/Polytoria/scripts/client/ui/chat/UIChat.cs
@@ -193,7 +193,7 @@ public partial class UIChat : Control
 			}
 
 			string emoteName = cmd[0][1..];
-			Root.Players.LocalPlayer.PlayEmote(emoteName);
+			Root.Players.LocalPlayer.Character?.PlayEmote(emoteName);
 			return;
 		}
 

--- a/Polytoria/scripts/client/ui/emotes/UIEmoteWheel.cs
+++ b/Polytoria/scripts/client/ui/emotes/UIEmoteWheel.cs
@@ -123,7 +123,7 @@ public partial class UIEmoteWheel : Control
 			if (!_hoveringClose)
 			{
 				string selected = GetSelectedEmoteName();
-				CoreUIRoot.Singleton.Root.Players.LocalPlayer.PlayEmote(selected);
+				CoreUIRoot.Singleton.Root.Players.LocalPlayer.Character?.PlayEmote(selected);
 			}
 			CloseEmoteWheel();
 		}

--- a/Polytoria/scripts/client/ui/inventory/UIInventory.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIInventory.cs
@@ -212,10 +212,10 @@ public partial class UIInventory : Control
 
 	public void PutToolInBackpack(Tool tool, int slot)
 	{
-		if (tool.Holder == _localplr)
+		if (tool.Holder != null && tool.Holder == _localplr.Character)
 		{
 			// Unequip tool if holding right now
-			_localplr.UnequipTool();
+			_localplr.Character.UnequipTool();
 		}
 		UIToolItem? item = GetToolItemFromTool(tool);
 		if (item != null)
@@ -283,7 +283,7 @@ public partial class UIInventory : Control
 			UpdateSlots();
 		}
 
-		if (tool.Holder == _localplr)
+		if (tool.Holder != null && tool.Holder == _localplr.Character)
 		{
 			// Set active if holding
 			item.SetPressedNoSignal(true);
@@ -380,11 +380,13 @@ public partial class UIInventory : Control
 
 	private void EquipSlot(int index)
 	{
-		Tool? oldTool = _localplr.HoldingTool;
-		if (_localplr.HoldingTool != null)
+		CharacterModel charModel = _localplr.Character;
+		if (charModel == null) return;
+		Tool? oldTool = charModel.HoldingTool;
+		if (charModel.HoldingTool != null)
 		{
 			CurrentSlotIndex = -1;
-			_localplr.UnequipTool();
+			charModel.UnequipTool();
 		}
 		if (index < 0 || index >= _toolSlot.Count) { return; }
 		if (_toolSlot[index] != null)
@@ -392,7 +394,7 @@ public partial class UIInventory : Control
 			Tool tool = _toolSlot[index]!;
 			if (oldTool == tool) return;
 			CurrentSlotIndex = index;
-			_localplr.EquipTool(tool);
+			charModel.EquipTool(tool);
 		}
 	}
 }

--- a/Polytoria/scripts/client/ui/inventory/UIInventory.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIInventory.cs
@@ -11,7 +11,7 @@ namespace Polytoria.Client.UI;
 public partial class UIInventory : Control
 {
 	public const int MaximumToolSlot = 6;
-	private Inventory _inventory = null!;
+	private Inventory? _inventory = null!;
 	private Player _localplr = null!;
 	private Control _layout = null!;
 	private readonly Dictionary<Tool, UIToolItem> _tools = [];
@@ -30,19 +30,18 @@ public partial class UIInventory : Control
 	public override void _Ready()
 	{
 		_localplr = World.Current!.Players.LocalPlayer;
-		_inventory = _localplr.Inventory;
+		_inventory = _localplr.Character?.Inventory;
 		_layout = GetNode<Control>("Layout");
-		_inventory.ChildAdded.Connect(OnChildEnterInventory);
-		_inventory.ChildRemoved.Connect(OnChildExitInventory);
-		_localplr.ChildAdded.Connect(OnChildEnterInventory);
-		_localplr.ChildRemoved.Connect(OnChildExitInventory);
-
 		PackedScene packed = GD.Load<PackedScene>("res://scenes/client/ui/inventory/slot_add_item.tscn");
 		_addSlotItemBtn = packed.Instantiate<UIToolAddItem>();
 		_addSlotItemBtn.Root = this;
 		_layout.AddChild(_addSlotItemBtn, false, InternalMode.Back);
 		_addSlotItemBtn.Visible = false;
 
+		if (_inventory is null) return;
+
+		_inventory.ChildAdded.Connect(OnChildEnterInventory);
+		_inventory.ChildRemoved.Connect(OnChildExitInventory);
 		foreach (Instance item in _inventory.GetChildren())
 		{
 			OnChildEnterInventory(item);
@@ -363,7 +362,7 @@ public partial class UIInventory : Control
 			await tool.TreeEntered.Wait();
 
 		// If the tool was reparented back to the player or their inventory, keep it
-		if (!tool.IsDeleted && (tool.Parent == _localplr || tool.Parent == _localplr.Inventory)) return;
+		if (!tool.IsDeleted && (tool.Parent is null || tool.Parent == _localplr.Character?.Inventory)) return;
 
 		if (_tools.TryGetValue(tool, out UIToolItem? toolItem))
 		{

--- a/Polytoria/scripts/client/ui/inventory/UIInventory.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIInventory.cs
@@ -60,7 +60,7 @@ public partial class UIInventory : Control
 			_inventory.ChildRemoved.Disconnect(OnChildExitInventory);
 			foreach (Instance item in _inventory.GetChildren())
 			{
-				OnChildExitInventory(item);
+				if (item is Tool tool) ForceRemoveTool(tool);
 			}
 		}
 		_inventory = newinv;
@@ -396,15 +396,8 @@ public partial class UIInventory : Control
 		_backpackNoneView.Visible = _backpackSlot.Count == 0;
 	}
 
-	private async void RemoveTool(Tool tool)
+	private void ForceRemoveTool(Tool tool)
 	{
-		// Wait for tool to enter another tree first
-		if (!tool.IsDeleted)
-			await tool.TreeEntered.Wait();
-
-		// If the tool was reparented back to the player or their inventory, keep it
-		if (!tool.IsDeleted && (tool.Parent is null || tool.Parent == _inventory || tool.Parent == _localchar)) return;
-
 		if (_tools.TryGetValue(tool, out UIToolItem? toolItem))
 		{
 			_tools.Remove(tool);
@@ -418,9 +411,21 @@ public partial class UIInventory : Control
 		}
 	}
 
+	private async void RemoveTool(Tool tool)
+	{
+		// Wait for tool to enter another tree first
+		if (!tool.IsDeleted)
+			await tool.TreeEntered.Wait();
+
+		// If the tool was reparented back to the player or their inventory, keep it
+		if (!tool.IsDeleted && (tool.Parent is null || tool.Parent == _inventory || tool.Parent == _localchar)) return;
+
+		ForceRemoveTool(tool);
+	}
+
 	private void EquipSlot(int index)
 	{
-		CharacterModel charModel = _localplr.Character;
+		CharacterModel charModel = _localplr.Character!;
 		if (charModel == null) return;
 		Tool? oldTool = charModel.HoldingTool;
 		if (charModel.HoldingTool != null)

--- a/Polytoria/scripts/client/ui/inventory/UIInventory.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIInventory.cs
@@ -13,6 +13,7 @@ public partial class UIInventory : Control
 	public const int MaximumToolSlot = 6;
 	private Inventory? _inventory = null!;
 	private Player _localplr = null!;
+	private CharacterModel _localchar = null!;
 	private Control _layout = null!;
 	private readonly Dictionary<Tool, UIToolItem> _tools = [];
 	private readonly List<Tool?> _toolSlot = [];
@@ -30,7 +31,6 @@ public partial class UIInventory : Control
 	public override void _Ready()
 	{
 		_localplr = World.Current!.Players.LocalPlayer;
-		_inventory = _localplr.Character?.Inventory;
 		_layout = GetNode<Control>("Layout");
 		PackedScene packed = GD.Load<PackedScene>("res://scenes/client/ui/inventory/slot_add_item.tscn");
 		_addSlotItemBtn = packed.Instantiate<UIToolAddItem>();
@@ -38,6 +38,13 @@ public partial class UIInventory : Control
 		_layout.AddChild(_addSlotItemBtn, false, InternalMode.Back);
 		_addSlotItemBtn.Visible = false;
 
+		_localchar = _localplr.Character!;
+		if (_localchar is null) return;
+
+		_localchar.ChildAdded.Connect(OnChildEnterInventory);
+		_localchar.ChildRemoved.Connect(OnChildExitInventory);
+
+		_inventory = _localchar.Inventory;
 		if (_inventory is null) return;
 
 		_inventory.ChildAdded.Connect(OnChildEnterInventory);

--- a/Polytoria/scripts/client/ui/inventory/UIInventory.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIInventory.cs
@@ -12,8 +12,8 @@ public partial class UIInventory : Control
 {
 	public const int MaximumToolSlot = 6;
 	private Inventory? _inventory = null!;
+	private CharacterModel? _localchar = null!;
 	private Player _localplr = null!;
-	private CharacterModel _localchar = null!;
 	private Control _layout = null!;
 	private readonly Dictionary<Tool, UIToolItem> _tools = [];
 	private readonly List<Tool?> _toolSlot = [];
@@ -28,6 +28,53 @@ public partial class UIInventory : Control
 	public bool IsBackpackOpened = false;
 	public int CurrentSlotIndex = -1;
 
+	public void UpdateCharacter()
+	{
+		SetCharacter(_localplr.Character);
+	}
+
+	public void SetCharacter(CharacterModel? newchar)
+	{
+		if (newchar == _localchar) return;
+		if (_localchar is not null)
+		{
+			_localchar.ChildAdded.Disconnect(OnChildEnterInventory);
+			_localchar.ChildRemoved.Disconnect(OnChildExitInventory);
+		}
+		_localchar = newchar;
+		if (newchar is not null)
+		{
+			newchar.ChildAdded.Connect(OnChildEnterInventory);
+			newchar.ChildRemoved.Connect(OnChildExitInventory);
+		}
+
+		SetInventory(newchar?.Inventory);
+	}
+
+	public void SetInventory(Inventory? newinv)
+	{
+		if (newinv == _inventory) return;
+		if (_inventory is not null)
+		{
+			_inventory.ChildAdded.Disconnect(OnChildEnterInventory);
+			_inventory.ChildRemoved.Disconnect(OnChildExitInventory);
+			foreach (Instance item in _inventory.GetChildren())
+			{
+				OnChildExitInventory(item);
+			}
+		}
+		_inventory = newinv;
+		if (newinv is not null)
+		{
+			newinv.ChildAdded.Connect(OnChildEnterInventory);
+			newinv.ChildRemoved.Connect(OnChildExitInventory);
+			foreach (Instance item in newinv.GetChildren())
+			{
+				OnChildEnterInventory(item);
+			}
+		}
+	}
+
 	public override void _Ready()
 	{
 		_localplr = World.Current!.Players.LocalPlayer;
@@ -38,21 +85,8 @@ public partial class UIInventory : Control
 		_layout.AddChild(_addSlotItemBtn, false, InternalMode.Back);
 		_addSlotItemBtn.Visible = false;
 
-		_localchar = _localplr.Character!;
-		if (_localchar is null) return;
-
-		_localchar.ChildAdded.Connect(OnChildEnterInventory);
-		_localchar.ChildRemoved.Connect(OnChildExitInventory);
-
-		_inventory = _localchar.Inventory;
-		if (_inventory is null) return;
-
-		_inventory.ChildAdded.Connect(OnChildEnterInventory);
-		_inventory.ChildRemoved.Connect(OnChildExitInventory);
-		foreach (Instance item in _inventory.GetChildren())
-		{
-			OnChildEnterInventory(item);
-		}
+		UpdateCharacter();
+		_localplr.CharacterChanged.Connect(UpdateCharacter);
 	}
 
 	public void ToggleBackpack()
@@ -369,7 +403,7 @@ public partial class UIInventory : Control
 			await tool.TreeEntered.Wait();
 
 		// If the tool was reparented back to the player or their inventory, keep it
-		if (!tool.IsDeleted && (tool.Parent is null || tool.Parent == _localplr.Character?.Inventory)) return;
+		if (!tool.IsDeleted && (tool.Parent is null || tool.Parent == _inventory || tool.Parent == _localchar)) return;
 
 		if (_tools.TryGetValue(tool, out UIToolItem? toolItem))
 		{

--- a/Polytoria/scripts/client/ui/inventory/UIToolItem.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIToolItem.cs
@@ -206,13 +206,15 @@ public partial class UIToolItem : Button
 
 	private void OnToggled(bool to)
 	{
-		if (to)
-		{
-			Player.EquipTool(LinkedTool);
-		}
+		if (Player.Character != null) {
+			if (to)
+			{
+				Player.Character.EquipTool(LinkedTool);
+			}
 		else
-		{
-			Player.UnequipTool();
+			{
+				Player.Character.UnequipTool();
+			}
 		}
 	}
 }

--- a/Polytoria/scripts/client/ui/inventory/UIToolItem.cs
+++ b/Polytoria/scripts/client/ui/inventory/UIToolItem.cs
@@ -206,12 +206,13 @@ public partial class UIToolItem : Button
 
 	private void OnToggled(bool to)
 	{
-		if (Player.Character != null) {
+		if (Player.Character != null)
+		{
 			if (to)
 			{
 				Player.Character.EquipTool(LinkedTool);
 			}
-		else
+			else
 			{
 				Player.Character.UnequipTool();
 			}

--- a/Polytoria/scripts/client/ui/menu/views/UIMenuOverview.cs
+++ b/Polytoria/scripts/client/ui/menu/views/UIMenuOverview.cs
@@ -60,7 +60,7 @@ public sealed partial class UIMenuOverview : UIMenuViewBase
 	private void OnRespawn()
 	{
 		Menu.CoreUI.GameMenu.HideMenu();
-		Menu.CoreUI.Root.Players.LocalPlayer.Kill();
+		Menu.CoreUI.Root.Players.LocalPlayer.Character?.Kill();
 	}
 
 	private void OnScreenshot()
@@ -113,7 +113,7 @@ public sealed partial class UIMenuOverview : UIMenuViewBase
 			_userAvatarImage.LoadResource();
 		}
 
-		if (Menu.CoreUI.Service.CanRespawn)
+		if (Menu.CoreUI.Service.CanRespawn && Menu.CoreUI.Root.Players.LocalPlayer.Character != null)
 		{
 			_respawnButton.Modulate = new(1, 1, 1, 1f);
 			_respawnButton.MouseFilter = MouseFilterEnum.Stop;

--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -512,12 +512,6 @@ public sealed partial class Gizmos : Node
 
 			if (hoveringOn != null)
 			{
-				// Force select NPC instead of CharacterModel
-				if (selectInstance?.Parent is NPC)
-				{
-					selectInstance = selectInstance.Parent;
-				}
-
 				// Don't select creator freelook/current cam
 				if (selectInstance == Root.Environment.CurrentCamera)
 				{

--- a/Polytoria/scripts/creator/ui/ctxmenus/InsertMenuPopup.cs
+++ b/Polytoria/scripts/creator/ui/ctxmenus/InsertMenuPopup.cs
@@ -85,6 +85,9 @@ public partial class InsertMenuPopup : PopupPanel
 			"Accessory",
 			"Clothing",
 			"NPC",
+			"CharacterModel",
+			"PolytorianModel",
+			"Inventory",
 			"Tool",
 		},
 		/*

--- a/Polytoria/scripts/datamodel/Accessory.cs
+++ b/Polytoria/scripts/datamodel/Accessory.cs
@@ -28,9 +28,9 @@ public partial class Accessory : Dynamic
 
 	private void RefreshAttachment()
 	{
-		if (_targetCharacter == null || !GDNode.IsInsideTree()) { return; }
+		if (_targetCharacter is not PolytorianModel ptm || !GDNode.IsInsideTree()) { return; }
 		remoteTransform?.QueueFree();
-		Dynamic attachment = _targetCharacter.GetAttachment(TargetAttachment);
+		Dynamic attachment = ptm.GetAttachment(TargetAttachment);
 		remoteTransform = new()
 		{
 			UseGlobalCoordinates = true,

--- a/Polytoria/scripts/datamodel/BodyPosition.cs
+++ b/Polytoria/scripts/datamodel/BodyPosition.cs
@@ -58,18 +58,18 @@ public partial class BodyPosition : Instance
 		Vector3 gdPos = _targetPosition;
 		if (Parent != null)
 		{
-			if (Parent is NPC npc)
+			if (Parent is CharacterModel charModel)
 			{
-				if (npc.GetGlobalPosition().DistanceTo(gdPos) > AcceptanceDistance)
+				if (charModel.GetGlobalPosition().DistanceTo(gdPos) > AcceptanceDistance)
 				{
-					Vector3 currentPos = npc.Position;
+					Vector3 currentPos = charModel.Position;
 					Vector3 direction = (TargetPosition - currentPos).Normalized();
 					float distance = currentPos.DistanceTo(TargetPosition);
 
 					float forceMagnitude = Mathf.Min(Force * distance, Force);
 					Vector3 forceVector = direction * forceMagnitude * (float)delta;
 
-					npc.CharacterVelocity += forceVector;
+					charModel.CharacterVelocity += forceVector;
 				}
 			}
 			else if (Parent.GDNode is RigidBody3D rigid3D)

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -542,11 +542,12 @@ public sealed partial class Camera : Dynamic
 			float finalizedZoom = _currentZoom;
 
 			_turnY2.Position = new Vector3(0, 0, _currentZoom);
+			latentTrackedPos = Target?.Position ?? latentTrackedPos;
 
 			if (!ClipThroughWalls)
 			{
 				Vector3 desiredCamPos = _turnY2.GlobalPosition;
-				Vector3 origin = Position;
+				Vector3 origin = latentTrackedPos + targetLocalPos;
 
 				PhysicsDirectSpaceState3D spaceState = Camera3D.GetWorld3D().DirectSpaceState;
 				PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(origin, desiredCamPos);
@@ -559,6 +560,7 @@ public sealed partial class Camera : Dynamic
 
 				if (result.Count > 0)
 				{
+					GD.Print(((Node)result["collider"]).Name);
 					Vector3 hitPoint = (Vector3)result["position"];
 
 					float hitDist = origin.DistanceTo(hitPoint) - ClipSafeMargin;
@@ -577,7 +579,7 @@ public sealed partial class Camera : Dynamic
 			GDNode3D.GlobalBasis = _turnY.GlobalBasis;
 
 			targetLocalPos -= Forward * _distance;
-			latentTrackedPos = Target?.Position ?? latentTrackedPos;
+
 			Vector3 targetPos = targetLocalPos + latentTrackedPos; // avoid transform rotation
 
 			// Apply position/rotation

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -339,13 +339,19 @@ public sealed partial class Camera : Dynamic
 	{
 		get
 		{
-			if (_target != null && _target.IsDeleted)
-			{
-				_target = null!;
-			}
-			return _target;
+			return Parent is Dynamic dyn ? dyn : null;
 		}
-		set => _target = value;
+		set
+		{
+			if (value == null)
+			{
+				Parent = Root.Environment;
+			}
+			else
+			{
+				Parent = value;
+			}
+		}
 	}
 
 	[ScriptEnum]
@@ -374,10 +380,28 @@ public sealed partial class Camera : Dynamic
 	/// </summary>
 	internal bool UpdateCameraSelf = true;
 
+	private Instance? prevParent = null;
+
+	private void OnParentDeleting()
+	{
+		// bail out of a deleting instance
+		if (this == Root.Environment.CurrentCamera) Parent = Root.Environment;
+	}
+
 	public override void EnterTree()
 	{
 		// keep the current camera current
 		EnforceCurrentCam();
+
+		// prepare to bail
+		if (Parent != Root.Environment) {
+			Parent.Deleted += OnParentDeleting;
+			prevParent = Parent;
+		}
+		else
+		{
+			prevParent = null;
+		}
 
 		base.EnterTree();
 	}
@@ -386,6 +410,9 @@ public sealed partial class Camera : Dynamic
 	{
 		// keep the current camera current
 		EnforceCurrentCam();
+
+		// unprepare to bail
+		if (prevParent is not null) prevParent.Deleted -= OnParentDeleting;
 
 		base.ExitTree();
 	}
@@ -448,7 +475,7 @@ public sealed partial class Camera : Dynamic
 	internal void CameraProcess(double delta)
 	{
 		if (Root.Environment.CurrentCamera != this) return;
-		if (Mode == CameraModeEnum.Follow && Target != null)
+		if (Mode == CameraModeEnum.Follow)
 		{
 			if (Root.Input.IsGameFocused)
 			{
@@ -469,10 +496,10 @@ public sealed partial class Camera : Dynamic
 				LimitRotation();
 			}
 
-			Vector3 computedPosition = Target.Position + PositionOffset;
+			Vector3 targetLocalPos = PositionOffset;
 			Vector3 computedRotation = _targetRotation + RotationOffset;
 
-			_turnX.GlobalPosition = computedPosition;
+			_turnX.GlobalPosition = Position;
 			_turnX.RotationDegrees = computedRotation;
 
 			LimitZoomDistance();
@@ -517,7 +544,7 @@ public sealed partial class Camera : Dynamic
 			if (!ClipThroughWalls)
 			{
 				Vector3 desiredCamPos = _turnY2.GlobalPosition;
-				Vector3 origin = computedPosition;
+				Vector3 origin = Position;
 
 				PhysicsDirectSpaceState3D spaceState = Camera3D.GetWorld3D().DirectSpaceState;
 				PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(origin, desiredCamPos);
@@ -545,21 +572,20 @@ public sealed partial class Camera : Dynamic
 
 			_distance = finalizedZoom;
 
-			_turnY.Position = new Vector3(0, 0, _distance);
+			GDNode3D.GlobalBasis = _turnY.GlobalBasis;
 
-			Vector3 posSetto = _turnY.GlobalPosition;
+			targetLocalPos -= Forward * _distance;
+			Vector3 targetPos = targetLocalPos + Target?.Position ?? Vector3.Zero; // avoid transform rotation
 
 			// Apply position/rotation
 			if (FollowLerp)
 			{
-				GDNode3D.GlobalPosition = GDNode3D.GlobalPosition.Lerp(posSetto, MathUtils.ExpDecay((float)delta, LerpSpeed));
+				Position = Position.Lerp(targetPos, MathUtils.ExpDecay((float)delta, LerpSpeed));
 			}
 			else
 			{
-				GDNode3D.GlobalPosition = posSetto;
+				Position = targetPos;
 			}
-
-			GDNode3D.GlobalBasis = _turnY.GlobalBasis;
 		}
 		else if (Mode == CameraModeEnum.Free)
 		{

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -375,11 +375,6 @@ public sealed partial class Camera : Dynamic
 	[ScriptProperty]
 	public PTSignal FirstPersonExited { get; private set; } = new();
 
-	/// <summary>
-	/// Should camera be updating itself or not.
-	/// </summary>
-	internal bool UpdateCameraSelf = true;
-
 	private Instance? prevParent = null;
 
 	private void OnParentDeleting()
@@ -461,15 +456,6 @@ public sealed partial class Camera : Dynamic
 		_inputHelper.GodotInputEvent -= OnInputEarly;
 		_inputHelper.QueueFree();
 		base.PreDelete();
-	}
-
-	public override void Process(double delta)
-	{
-		if (UpdateCameraSelf)
-		{
-			CameraProcess(delta);
-		}
-		base.Process(delta);
 	}
 
 	private Vector3 latentTrackedPos = Vector3.Zero;

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -560,7 +560,6 @@ public sealed partial class Camera : Dynamic
 
 				if (result.Count > 0)
 				{
-					GD.Print(((Node)result["collider"]).Name);
 					Vector3 hitPoint = (Vector3)result["position"];
 
 					float hitDist = origin.DistanceTo(hitPoint) - ClipSafeMargin;

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -472,6 +472,8 @@ public sealed partial class Camera : Dynamic
 		base.Process(delta);
 	}
 
+	private Vector3 latentTrackedPos = Vector3.Zero;
+
 	internal void CameraProcess(double delta)
 	{
 		if (Root.Environment.CurrentCamera != this) return;
@@ -575,7 +577,8 @@ public sealed partial class Camera : Dynamic
 			GDNode3D.GlobalBasis = _turnY.GlobalBasis;
 
 			targetLocalPos -= Forward * _distance;
-			Vector3 targetPos = targetLocalPos + Target?.Position ?? Vector3.Zero; // avoid transform rotation
+			latentTrackedPos = Target?.Position ?? latentTrackedPos;
+			Vector3 targetPos = targetLocalPos + latentTrackedPos; // avoid transform rotation
 
 			// Apply position/rotation
 			if (FollowLerp)

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -53,6 +53,7 @@ public sealed partial class Camera : Dynamic
 	private float _moveSpeed = 8f;
 	private readonly float _rotateSpeed = 0.005f;
 	private Dynamic? _target = null!;
+	private RemoteTransform3D tracker = new() { UpdatePosition = false, UpdateRotation = false };
 
 	private bool _isMouseCaptured;
 	private Vector2I _lastMousePosition;
@@ -81,6 +82,7 @@ public sealed partial class Camera : Dynamic
 		set
 		{
 			_mode = value;
+			UpdateTracker(value);
 			OnPropertyChanged();
 		}
 	}
@@ -337,20 +339,13 @@ public sealed partial class Camera : Dynamic
 	[ScriptProperty]
 	public Dynamic? Target
 	{
-		get
-		{
-			return Parent is Dynamic dyn ? dyn : null;
-		}
+		get => _target;
 		set
 		{
-			if (value == null)
-			{
-				Parent = Root.Environment;
-			}
-			else
-			{
-				Parent = value;
-			}
+			_target?.Deleted -= OnTrackerThreatened;
+			_target = value;
+			value?.Deleted += OnTrackerThreatened;
+			OnPropertyChanged();
 		}
 	}
 
@@ -375,29 +370,28 @@ public sealed partial class Camera : Dynamic
 	[ScriptProperty]
 	public PTSignal FirstPersonExited { get; private set; } = new();
 
-	private Instance? prevParent = null;
-
-	private void OnParentDeleting()
+	public void UpdateTracker(CameraModeEnum? cammode = null)
 	{
-		// bail out of a deleting instance
-		if (this == Root.Environment.CurrentCamera) Parent = Root.Environment;
+		tracker.UpdatePosition = false;// (cammode ?? Mode) == CameraModeEnum.Follow;
+	}
+
+	public void OnTrackerThreatened()
+	{
+		tracker.UpdatePosition = false;
+		tracker.Reparent(GDNode);
+	}
+
+	public void InformTracker()
+	{
+		tracker.RemotePath = tracker.GetPathTo(GDNode3D);
 	}
 
 	public override void EnterTree()
 	{
 		// keep the current camera current
 		EnforceCurrentCam();
-
-		// prepare to bail
-		if (Parent != Root.Environment) {
-			Parent.Deleted += OnParentDeleting;
-			prevParent = Parent;
-		}
-		else
-		{
-			prevParent = null;
-		}
-
+		InformTracker();
+		UpdateTracker();
 		base.EnterTree();
 	}
 
@@ -405,10 +399,7 @@ public sealed partial class Camera : Dynamic
 	{
 		// keep the current camera current
 		EnforceCurrentCam();
-
-		// unprepare to bail
-		if (prevParent is not null) prevParent.Deleted -= OnParentDeleting;
-
+		tracker.UpdatePosition = false;
 		base.ExitTree();
 	}
 
@@ -425,6 +416,8 @@ public sealed partial class Camera : Dynamic
 	public override void Init()
 	{
 		base.Init();
+
+		InformTracker();
 
 		GDNode.AddChild(_inputHelper = new(), @internal: Node.InternalMode.Back);
 		_inputHelper.GodotUnhandledInputEvent += OnInput;

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -453,7 +453,7 @@ public sealed partial class Camera : Dynamic
 
 	private Vector3 latentTrackedPos = Vector3.Zero;
 
-	internal void CameraProcess(double delta)
+	public override void Process(double delta)
 	{
 		if (Root.Environment.CurrentCamera != this) return;
 		if (Mode == CameraModeEnum.Follow)

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -7,6 +7,7 @@ using Godot.Collections;
 using Polytoria.Attributes;
 using Polytoria.Client.Settings;
 using Polytoria.Scripting;
+using Polytoria.Shared;
 using Polytoria.Shared.Misc;
 using Polytoria.Utils;
 using System;
@@ -370,29 +371,31 @@ public sealed partial class Camera : Dynamic
 	[ScriptProperty]
 	public PTSignal FirstPersonExited { get; private set; } = new();
 
-	public void UpdateTracker(CameraModeEnum? cammode = null)
+	private void UpdateTracker(CameraModeEnum? cammode = null)
 	{
 		tracker.UpdatePosition = false;// (cammode ?? Mode) == CameraModeEnum.Follow;
 	}
 
-	public void OnTrackerThreatened()
+	private void OnTrackerThreatened()
 	{
 		tracker.UpdatePosition = false;
 		tracker.Reparent(GDNode);
 	}
 
-	public void InformTracker()
+	private async void InformTracker()
 	{
+		await Globals.Singleton.WaitFrame();
 		tracker.RemotePath = tracker.GetPathTo(GDNode3D);
+		UpdateTracker();
 	}
 
 	public override void EnterTree()
 	{
 		// keep the current camera current
 		EnforceCurrentCam();
-		InformTracker();
-		UpdateTracker();
 		base.EnterTree();
+		// this is needed because GetPath doesn't update when it entered tree
+		InformTracker();
 	}
 
 	public override void ExitTree()

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -382,10 +382,6 @@ public sealed partial class Camera : Dynamic
 	{
 		tracker.UpdatePosition = false;// (cammode ?? Mode) == CameraModeEnum.Follow;
 	}
-	private void UpdateTracker(CameraModeEnum? cammode = null)
-	{
-		tracker.UpdatePosition = false;// (cammode ?? Mode) == CameraModeEnum.Follow;
-	}
 
 	private void OnTrackerThreatened()
 	{

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -597,12 +597,6 @@ public partial class CharacterModel : Physical
 		// Only enable physics in client mode
 		if (Root.SessionType != World.SessionTypeEnum.Client) return;
 
-		// Kill character if fall off the map
-		if (Position.Y < Root.Environment.PartDestroyHeight)
-		{
-			Kill();
-		}
-
 		if (IsSitting)
 		{
 			// Add stamina while sitting
@@ -1209,9 +1203,9 @@ public partial class CharacterModel : Physical
 
 	public void OnDestroying()
 	{
-		if (Controller is Player plr)
+		if (Controller is not null)
 		{
-			plr.Character = null;
+			Controller.Character = null;
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -2,21 +2,963 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using Godot;
+using Godot.Collections;
 using Polytoria.Attributes;
+using Polytoria.Client;
+using Polytoria.Client.UI.Chat;
 using Polytoria.Datamodel.Services;
 using Polytoria.Networking;
+using Polytoria.Scripting;
+using Polytoria.Shared;
+using Polytoria.Utils;
 using System;
-using System.Collections.Generic;
+//using System.Collections.Generic;
 
 namespace Polytoria.Datamodel;
 
 [Instantiable]
-public partial class CharacterModel : Dynamic
+public partial class CharacterModel : Physical
 {
 	private CharacterModelStateEnum _currentState = CharacterModelStateEnum.Idle;
 	private float _currentSpeed = 1;
 	private readonly Dictionary<CharacterModelBlendEnum, float> _blendValues = [];
 	private Animator? _animator = null!;
+	public NPC? _controller = null;
+	public Inventory? _inventory = null;
+	public Vector3 CharacterVelocity = Vector3.Zero;
+	internal Vector3 LastVelocity;
+	internal Vector3 ExternalVelocity;
+	public CharacterBody3D CharBody3D = null!;
+	public const float NameTagHeightMinus = 3f;
+	private Vector3 _seatOffset = new(0, 1.7f, 0);
+	private float _health = 100;
+	private RemoteTransform3D? _toolRemoteTransform;
+	private float _maxHealth = 100;
+	private float _jumpPower = 36;
+	private float _walkSpeed = 16;
+	private float _sprintSpeed;
+	private float _stamina = 0;
+	private float _maxStamina = 3;
+	private bool _useStamina = true;
+	private float _staminaRegen = 1.2f;
+	private float _staminaBurn = 1.2f;
+	private const float StepHeight = 1.5f;
+	private bool _canMove = true;
+	internal bool ClimbDebounce = false;
+	internal bool JustFinishedClimbing = false;
+	private Tool? _holdingTool;
+	private Seat? _sittingIn;
+	private bool _keepInventory = false;
+	private bool _useHeadTurning = false;
+	private bool _useBubbleChat = true;
+	private bool _allowAnimationWhileMoving = false;
+	public BubbleChat _bubbleChat = null!;
+	public const string BubbleChatScene = "res://scenes/client/spatial/chat/bubble_chat.tscn";
+	private const float CoyoteTime = 0.15f;
+	private Sound? _jumpSound;
+
+	public const float ForwardRaycastRange = 1;
+	public const float StairForwardRaycastRange = 4;
+	protected RayCast3D FootFwdRaycast = null!;
+	private bool _lastOnFloorState = false;
+	private float _timeSinceGrounded = 0f;
+	private bool _coyoteUsed = false;
+
+	private Vector3 _nametagOffset = Vector3.Zero;
+	private Vector3 _fixedNametagOffset = new(0, 3, 0);
+	private float _nametagVisibleRadius = 40;
+	private bool _useNametag = true;
+	private Nametag _nametag = null!;
+
+	// List of all emotes
+	public static readonly string[] EmoteList =
+	[
+		"wave",
+		"dance",
+		"helicopter",
+		"sit",
+		"point",
+		"agree",
+		"disagree",
+		"scream",
+		"dance2",
+		"disappointed",
+	];
+
+	// Oneshot emotes
+	public static readonly string[] OneShotEmoteList =
+	[
+		"wave",
+		"point",
+		"disagree",
+		"agree",
+		"scream",
+		"disappointed",
+	];
+
+	[Editable, ScriptProperty]
+	public Sound? JumpSound
+	{
+		get => _jumpSound;
+		set
+		{
+			_jumpSound = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool AllowAnimationWhileMoving
+	{
+		get => _allowAnimationWhileMoving;
+		set
+		{
+			_allowAnimationWhileMoving = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool KeepInventory
+	{
+		get => _keepInventory;
+		set
+		{
+			_keepInventory = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool UseHeadTurning
+	{
+		get => _useHeadTurning;
+		set
+		{
+			_useHeadTurning = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[SyncVar, ScriptProperty]
+	public Tool? HoldingTool
+	{
+		get
+		{
+			if (_holdingTool != null && _holdingTool.IsDeleted)
+			{
+				_holdingTool = null;
+			}
+			return _holdingTool;
+		}
+		internal set => _holdingTool = value;
+	}
+
+	internal void InternalDetachTool()
+	{
+		if (_toolRemoteTransform != null && Node.IsInstanceValid(_toolRemoteTransform))
+		{
+			_toolRemoteTransform?.QueueFree();
+		}
+
+		SetBlendValue(CharacterModel.CharacterModelBlendEnum.ToolHoldRight, 0);
+	}
+
+	[ScriptMethod, ScriptLegacyMethod("DropTools")]
+	public void DropTool()
+	{
+		if (HoldingTool != null)
+		{
+			Tool tool = HoldingTool;
+			Rpc(nameof(NetDropTool), tool.NetworkedObjectID);
+		}
+	}
+
+	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, CallLocal = true)]
+	private async void NetDropTool(string id)
+	{
+		Tool? tool = (Tool?)await Root.WaitForNetObjectAsync(id);
+
+		if (tool != null && tool.Droppable)
+		{
+			tool.Reparent(Root.Environment);
+			HoldingTool = null;
+			InternalDetachTool();
+			tool.InvokeDropped();
+		}
+	}
+
+	[ScriptMethod]
+	public void LoadAppearance(int userID)
+	{
+		if (this is PolytorianModel ptm)
+		{
+			ptm.LoadAppearance(userID, Root.PlayerDefaults.LoadAppearanceTools);
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float SprintSpeed
+	{
+		get => _sprintSpeed;
+		set
+		{
+			_sprintSpeed = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, SyncVar(Unreliable = true, AllowAuthorWrite = true)]
+	public float Stamina
+	{
+		get => _stamina;
+		set
+		{
+			_stamina = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float MaxStamina
+	{
+		get => _maxStamina;
+		set
+		{
+			_maxStamina = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, ScriptLegacyProperty("StaminaEnabled")]
+	public bool UseStamina
+	{
+		get => _useStamina;
+		set
+		{
+			_useStamina = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float StaminaRegen
+	{
+		get => _staminaRegen;
+		set
+		{
+			_staminaRegen = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float StaminaBurn
+	{
+		get => _staminaBurn;
+		set
+		{
+			_staminaBurn = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public Vector3 SeatOffset
+	{
+		get => _seatOffset;
+		set
+		{
+			_seatOffset = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool UseNametag
+	{
+		get => _useNametag;
+		set
+		{
+			_useNametag = value;
+			_nametag?.UpdateNameTag();
+			OnPropertyChanged();
+		}
+	}
+
+
+	[Editable, ScriptProperty]
+	public Vector3 NametagOffset
+	{
+		get => _nametagOffset;
+		set
+		{
+			_nametagOffset = value;
+			RecalculateNametagOffset();
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float NametagVisibleRadius
+	{
+		get => _nametagVisibleRadius;
+		set
+		{
+			_nametagVisibleRadius = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public Inventory? Inventory
+	{
+		get => _inventory;
+		set
+		{
+			_inventory = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool CanMove
+	{
+		get => _canMove;
+		set
+		{
+			_canMove = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[SyncVar(AllowAuthorWrite = true), ScriptProperty]
+	public bool IsClimbing { get; internal set; }
+
+	[SyncVar(AllowAuthorWrite = true), ScriptProperty]
+	public Truss? ClimbingTruss { get; internal set; }
+
+	[ScriptProperty, ScriptLegacyProperty("Grounded")]
+	public bool IsOnGround => CharBody3D.IsOnFloor();
+
+	[ScriptProperty]
+	public bool IsOnCeiling => CharBody3D.IsOnCeiling();
+
+	public override void InitGDNode()
+	{
+		CharBody3D = (CharacterBody3D)GDNode;
+		base.InitGDNode();
+		CollisionLayers = 2;
+		CollisionMask = 3;
+	}
+
+	internal void AddStaminaTick(double delta)
+	{
+		if (!UseStamina) { return; }
+		Stamina += (float)(delta * StaminaRegen);
+		if (Stamina > MaxStamina)
+		{
+			Stamina = MaxStamina;
+		}
+	}
+
+	internal void RemoveStaminaTick(double delta)
+	{
+		if (!UseStamina) { return; }
+		Stamina -= (float)(delta * StaminaBurn);
+		if (Stamina < 0)
+		{
+			Stamina = 0;
+		}
+	}
+
+	[NetRpc(AuthorityMode.Server, TransferMode = TransferMode.Reliable, CallLocal = true)]
+	private async void NetSit(string seatID)
+	{
+		Seat? seat = (Seat?)await Root.WaitForNetObjectAsync(seatID);
+
+		if (seat != null)
+		{
+			InternalSit(seat);
+		}
+	}
+
+	private void InternalSit(Seat seat)
+	{
+		IsSitting = true;
+		OverrideNetworkTransform = true;
+		SittingIn = seat;
+		seat.Occupant = this;
+		seat.InvokeSat(this);
+		SetBlendValue(CharacterModel.CharacterModelBlendEnum.Sitting, 1);
+	}
+
+	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, CallLocal = true)]
+	private void NetJumpFromSeat()
+	{
+		if (IsSitting)
+		{
+			// Unsit the NPC
+			IsSitting = false;
+			OverrideNetworkTransform = false;
+
+			if (SittingIn != null)
+			{
+				SittingIn.Occupant = null;
+				SittingIn.InvokeVacated(this);
+				SittingIn = null;
+			}
+
+			SetBlendValue(CharacterModel.CharacterModelBlendEnum.Sitting, 0);
+		}
+	}
+
+	[ScriptMethod]
+	public void ClearAppearance()
+	{
+		if (this is PolytorianModel ptm)
+		{
+			ptm.ClearAppearance();
+		}
+	}
+
+	[ScriptMethod]
+	public void ResetAppearance()
+	{
+		ClearAppearance();
+		if (_controller is Player plr && plr.AutoLoadAppearance)
+		{
+			if (Root.Entry != null && Root.Entry.IsSoloTest)
+			{
+				LoadAppearance(1144);
+			}
+			else
+			{
+				LoadAppearance(plr.UserID);
+			}
+		}
+	}
+
+	public void WrapToSpawnPoint()
+	{
+		if (Root.Environment.SpawnPoints.Count > 0)
+		{
+			Entity spawnpoint = ArrayUtils.GetRandom(Root.Environment.SpawnPoints);
+			Position = spawnpoint.Position + new Vector3(0, spawnpoint.Size.Y + 2.0f, 0);
+			Rotation = new(0, spawnpoint.Rotation.Y, 0);
+		}
+		else if (_controller is Player player)
+		{
+			Position = player.DefaultSpawnLocation;
+			Rotation = new(0, 0, 0);
+		}
+
+		// Spawn at custom position
+#if CREATOR
+		if (_controller is Player plr)
+		{
+			if (Root.Entry != null && Root.Entry.DebugSpawnPos != null)
+			{
+				if (!plr._spawnedAtCreatorPos)
+				{
+					plr._spawnedAtCreatorPos = true;
+					Position = Root.Entry.DebugSpawnPos.Value;
+					Rotation = Vector3.Zero;
+				}
+			}
+		}
+#endif
+		SendNetTransformReliable();
+	}
+
+	public override void Ready()
+	{
+		if (IsSitting && SittingIn != null)
+		{
+			InternalSit(SittingIn);
+		}
+
+		if (HoldingTool != null)
+		{
+			InternalAttachTool(HoldingTool);
+		}
+		RecalculateNametagOffset();
+	}
+
+	[Editable, ScriptProperty]
+	public float Health
+	{
+		get => _health;
+		set
+		{
+			if (_controller is Player plr && !plr.IsReady) return;
+			_health = value;
+			if (_health <= 0 && !IsDead)
+			{
+				TriggerDead();
+			}
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float MaxHealth
+	{
+		get => _maxHealth;
+		set
+		{
+			_maxHealth = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float JumpPower
+	{
+		get => _jumpPower;
+		set
+		{
+			_jumpPower = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float WalkSpeed
+	{
+		get => _walkSpeed;
+		set
+		{
+			_walkSpeed = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[SyncVar, ScriptProperty]
+	public bool IsSitting { get; internal set; } = false;
+
+	[SyncVar, ScriptProperty]
+	public bool IsDead { get; internal set; } = false;
+
+	[SyncVar, ScriptProperty]
+	public Seat? SittingIn
+	{
+		get
+		{
+			if (_sittingIn != null && _sittingIn.IsDeleted)
+			{
+				_sittingIn = null;
+			}
+			return _sittingIn;
+		}
+		internal set => _sittingIn = value;
+	}
+
+	[Editable, ScriptProperty]
+	public bool UseBubbleChat
+	{
+		get => _useBubbleChat;
+		set
+		{
+			_useBubbleChat = value;
+			_bubbleChat?.Visible = _useBubbleChat;
+			OnPropertyChanged();
+		}
+	}
+
+	public override void PhysicsProcess(double delta)
+	{
+		base.PhysicsProcess(delta);
+
+		if (Root == null) return;
+		if (Anchored || IsHidden) return;
+		if (!Root.IsLoaded) return;
+
+		// Only enable physics in client mode
+		if (Root.SessionType != World.SessionTypeEnum.Client) return;
+
+		// Kill player if fall off the map
+		if (Position.Y < Root.Environment.PartDestroyHeight)
+		{
+			Kill();
+		}
+
+		if (IsSitting)
+		{
+			// Add stamina while sitting
+			AddStaminaTick(delta);
+			if (!Root.Network.IsServer && SittingIn != null)
+			{
+				Velocity = Vector3.Zero;
+				Position = SittingIn.Position + SeatOffset.Y * Up;
+				if (!SittingIn.SitDirectionLocked)
+				{
+					Rotation = new Vector3(SittingIn.Rotation.X, Rotation.Y, SittingIn.Rotation.Z);
+				}
+				else
+				{
+					Rotation = SittingIn.Rotation;
+				}
+				PlayIdle();
+			}
+			return;
+		}
+
+		if (_controller is Player plr)
+		{
+			if (!plr.IsLocal)
+			{
+				return;
+			}
+			if (plr.MovementMode == Player.PlayerMovementModeEnum.Scripted)
+			{
+				return;
+			}
+		}
+
+		if (Root.Network.LocalPeerID != NetworkAuthority && ExistInNetwork) return;
+
+		if (CharBody3D != null)
+		{
+			bool isOnFloor = IsOnGround;
+			bool isOnCeiling = IsOnCeiling;
+
+			if (isOnFloor)
+			{
+				_timeSinceGrounded = 0f;
+			}
+			else
+			{
+				_timeSinceGrounded += (float)delta;
+			}
+
+			_controller?.Navigate(delta);
+
+			// Apply gravity
+			if (!isOnFloor)
+			{
+				CharacterVelocity.Y += Root.Environment.Gravity.Y * (float)delta;
+			}
+			else if (isOnFloor && CharacterVelocity.Y < 0)
+			{
+				// Cancel downward velocity when on floor
+				CharacterVelocity.Y = 0;
+			}
+
+			// Prevent sticking
+			if (isOnCeiling && CharacterVelocity.Y > 0)
+			{
+				CharacterVelocity.Y = 0;
+			}
+
+			UpdateVelocityInternal(CharacterVelocity);
+			if (_controller is not Player)
+			{
+				CharBody3D.Velocity = Velocity;
+				CharBody3D.MoveAndSlide();
+			}
+
+			if (isOnFloor != _lastOnFloorState)
+			{
+				_lastOnFloorState = isOnFloor;
+
+				// On floor change
+				if (isOnFloor)
+				{
+					_coyoteUsed = false;
+					Landed.Invoke();
+				}
+			}
+
+			if (FootFwdRaycast.IsColliding())
+			{
+				Node collider = (Node)FootFwdRaycast.GetCollider();
+				if (collider != null && GetNetObjFromProxy(collider) is Truss truss)
+				{
+					if (!IsClimbing)
+					{
+						if (!ClimbDebounce)
+						{
+							ClimbingTruss = truss;
+							IsClimbing = true;
+							PlayClimb();
+						}
+
+					}
+				}
+				else
+				{
+					EndClimb();
+				}
+			}
+			else
+			{
+				EndClimb();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Attach tool to hand
+	/// </summary>
+	/// <param name="tool"></param>
+	private async void InternalAttachTool(Tool tool)
+	{
+		tool.Holder = this;
+
+		if (_toolRemoteTransform != null && Node.IsInstanceValid(_toolRemoteTransform))
+		{
+			_toolRemoteTransform.QueueFree();
+		}
+
+		_toolRemoteTransform = new()
+		{
+			UpdatePosition = true,
+			UpdateRotation = true,
+			UpdateScale = false
+		};
+
+		Dynamic attachment = GetAttachment(CharacterModel.CharacterAttachmentEnum.HandRight);
+		attachment.GDNode.AddChild(_toolRemoteTransform, @internal: Node.InternalMode.Back);
+
+		// stick and stones
+		// this is needed because GetPath doesn't update when it entered tree
+		await Globals.Singleton.WaitFrame();
+		_toolRemoteTransform.Position = new Vector3(0, 0, 0);
+		_toolRemoteTransform.RotationDegrees = new Vector3(0, -90, -90);
+		_toolRemoteTransform.UpdateScale = false;
+		_toolRemoteTransform.RemotePath = _toolRemoteTransform.GetPathTo(tool.GDNode);
+	}
+
+	[ScriptMethod]
+	public void TakeDamage(float dmg)
+	{
+		Health -= dmg;
+	}
+
+	[ScriptMethod]
+	public void Heal(float amount)
+	{
+		Health += amount;
+	}
+
+	[ScriptMethod]
+	public void UnequipTool()
+	{
+		if (HoldingTool == null) return;
+		Rpc(nameof(NetUnequipTool), HoldingTool.NetworkedObjectID);
+	}
+
+	[NetRpc(AuthorityMode.Authority, CallLocal = true, TransferMode = TransferMode.Reliable)]
+	private async void NetUnequipTool(string networkID)
+	{
+		NetworkedObject? netObj = await Root.WaitForNetObjectAsync(networkID);
+
+		if (netObj == null) { return; }
+
+		Tool tool = (Tool)netObj;
+
+		SetBlendValue(CharacterModel.CharacterModelBlendEnum.ToolHoldRight, 0);
+		if (Inventory != null)
+		{
+			tool.Parent = Inventory;
+			HoldingTool = null;
+			InternalDetachTool();
+			tool.InvokeUnequipped();
+		}
+		else if (tool.Droppable)
+		{
+			tool.Reparent(Root.Environment);
+			HoldingTool = null;
+			InternalDetachTool();
+			tool.InvokeDropped();
+		}
+	}
+
+	[ScriptMethod]
+	public void EquipTool(Tool tool)
+	{
+		if (IsDead) return;
+		// Check if tool is already held
+		if (HoldingTool != null)
+		{
+			UnequipTool();
+		}
+
+		Rpc(nameof(NetEquipTool), tool.NetworkedObjectID);
+	}
+
+	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, CallLocal = true)]
+	private async void NetEquipTool(string networkID)
+	{
+		NetworkedObject? netObj = await Root.WaitForNetObjectAsync(networkID);
+
+		if (netObj == null) { return; }
+
+		Tool tool = (Tool)netObj;
+
+		if (tool != null)
+		{
+			HoldingTool = tool;
+
+			// If is authority, attach the tool
+			if (HasAuthority)
+			{
+				tool.Holder = this;
+				tool.Parent = this;
+			}
+
+			tool.InvokeEquipped();
+		}
+	}
+
+	[ScriptMethod]
+	public bool TryStepUp()
+	{
+		if (CharBody3D == null)
+		{
+			return false;
+		}
+
+		if (!CharBody3D.IsOnFloor())
+		{
+			return false;
+		}
+
+		int slideCount = CharBody3D.GetSlideCollisionCount();
+
+		if (slideCount <= 0)
+		{
+			return false;
+		}
+
+		Vector3 desiredVelocity = Velocity;
+		Vector3 desiredXZ = new(desiredVelocity.X, 0f, desiredVelocity.Z);
+		if (desiredXZ.LengthSquared() < 0.0001f)
+		{
+			return false;
+		}
+
+		float groundY;
+		{
+			var downHit = new KinematicCollision3D();
+			bool hasGround = CharBody3D.TestMove(CharBody3D.GlobalTransform, Vector3.Down * (StepHeight + 0.05f), downHit, 0.001f, true);
+			if (!hasGround)
+			{
+				return false;
+			}
+
+			groundY = downHit.GetPosition().Y;
+		}
+
+		const float stepSearchOvershoot = 0.05f;
+
+		var spaceState = World.Current!.World3D.DirectSpaceState;
+
+		for (int i = 0; i < slideCount; i++)
+		{
+			KinematicCollision3D stepTest = CharBody3D.GetSlideCollision(i);
+			Vector3 n = stepTest.GetNormal();
+			Vector3 p = stepTest.GetPosition();
+
+			if (Mathf.Abs(n.Y) >= 0.01f)
+			{
+				continue;
+			}
+
+			if (!(p.Y - groundY < StepHeight))
+			{
+				continue;
+			}
+
+			float stepHeight = p.Y + StepHeight + 0.0001f;
+			Vector3 stepTestInvDir = new Vector3(-n.X, 0, -n.Z).Normalized();
+			Vector3 origin = new Vector3(p.X, stepHeight, p.Z) + (stepTestInvDir * stepSearchOvershoot);
+			Vector3 direction = Vector3.Down * StepHeight;
+
+			Dictionary result = spaceState.IntersectRay(new PhysicsRayQueryParameters3D()
+			{
+				From = origin,
+				To = origin + direction,
+				Exclude = [CharBody3D.GetRid()],
+				CollideWithAreas = false,
+				CollideWithBodies = true,
+			});
+
+			if (result.Count == 0)
+			{
+				continue;
+			}
+
+			Vector3 hitPos = result["position"].AsVector3();
+
+			Vector3 stepUpPoint = new Vector3(p.X, hitPos.Y + 0.01f, p.Z) + (stepTestInvDir * stepSearchOvershoot);
+			Vector3 stepUpPointOffset = stepUpPoint - new Vector3(p.X, groundY, p.Z);
+
+			CharBody3D.GlobalPosition += stepUpPointOffset;
+			CharBody3D.Velocity = desiredVelocity;
+
+			return true;
+		}
+
+		return false;
+	}
+
+	[ScriptMethod]
+	public virtual void Jump()
+	{
+		bool canJump = (CharBody3D.IsOnFloor() || (!_coyoteUsed && _timeSinceGrounded <= CoyoteTime)) && JumpPower > 0;
+		bool playJumpSound = false;
+		if (canJump)
+		{
+			_coyoteUsed = true;
+			CharacterVelocity.Y = JumpPower;
+			playJumpSound = true;
+		}
+		if (IsSitting)
+		{
+			playJumpSound = true;
+			Unsit();
+		}
+		if (playJumpSound && JumpSound != null && !JumpSound.Playing)
+		{
+			JumpSound?.Play();
+		}
+		if (IsClimbing)
+		{
+			EndClimb();
+			ClimbDebounce = true;
+		}
+	}
+
+	[ScriptMethod]
+	public void Respawn()
+	{
+		Health = MaxHealth;
+		Anchored = false;
+		IsDead = false;
+
+		if (this is PolytorianModel ptmodel)
+		{
+			ptmodel.StopRagdoll();
+		}
+		CharacterVelocity = Vector3.Zero;
+
+		OverrideCanCollide = false;
+		UpdateCollision();
+	}
+
+	[ScriptMethod]
+	public void Move(Vector3 velo)
+	{
+		CharacterVelocity = velo;
+		UpdateVelocityInternal(CharacterVelocity);
+		CharBody3D.Velocity = Velocity;
+		CharBody3D.MoveAndSlide();
+		CharacterVelocity = CharBody3D.Velocity;
+		UpdateVelocityInternal(CharacterVelocity);
+	}
 
 	[ScriptEnum]
 	public enum CharacterModelStateEnum
@@ -35,6 +977,115 @@ public partial class CharacterModel : Dynamic
 		ToolHoldRight,
 		LookX,
 		LookY,
+	}
+
+	public void TriggerDead()
+	{
+		if (IsDead) return;
+		if (Root.SessionType != World.SessionTypeEnum.Client) return;
+		Anchored = true;
+		OverrideCanCollide = true;
+		OverrideCanCollideTo = false;
+		Unsit(false);
+		UpdateCollision();
+
+		Animator?.StopAnimation();
+		Animator?.StopOneShotAnimation();
+
+		if (this is PolytorianModel ptmodel)
+		{
+			ptmodel.StartRagdoll(Velocity);
+		}
+		IsDead = true;
+		Died.Invoke();
+	}
+
+	[ScriptMethod]
+	public void Sit(Seat seat)
+	{
+		Rpc(nameof(NetSit), seat.NetworkedObjectID);
+	}
+
+	[ScriptMethod]
+	public void Unsit(bool addForce = true)
+	{
+		Rpc(nameof(NetJumpFromSeat));
+
+		// Reset rotation
+		Rotation = new(0, Rotation.Y, 0);
+
+		if (addForce)
+		{
+			Position += SeatOffset * 2;
+		}
+	}
+
+	private void RecalculateNametagOffset()
+	{
+		if (!_nametag.IsInsideTree()) { return; }
+		_nametag.Position = NametagOffset + _fixedNametagOffset;
+	}
+
+	[ScriptMethod]
+	public void Kill()
+	{
+		Health = 0;
+		RpcId(1, nameof(NetKill));
+	}
+
+	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable)]
+	private void NetKill()
+	{
+		Health = 0;
+	}
+
+	[Editable, ScriptProperty, SyncVar(Unreliable = true, AllowAuthorWrite = true)]
+	public override Vector3 Velocity
+	{
+		get
+		{
+			return CharacterVelocity;
+		}
+		set
+		{
+			if (_controller is Player plr)
+			{
+				LastVelocity = value;
+			}
+
+			CharacterVelocity = value;
+
+			OnPropertyChanged();
+		}
+	}
+
+	internal void ApplyInternalVelocity(Vector3 velocity)
+	{
+		UpdateVelocityInternal(velocity);
+		CharacterVelocity = velocity;
+		OnPropertyChanged(nameof(Velocity));
+	}
+
+	internal void EndClimb()
+	{
+		if (!IsClimbing) { return; }
+		IsClimbing = false;
+		JustFinishedClimbing = true;
+		ClimbingTruss = null;
+		SetAnimSpeed(1);
+	}
+
+	[ScriptProperty, SyncVar(AllowAuthorWrite = true)]
+	public NPC? Controller
+	{
+		get => _controller;
+		set
+		{
+			_controller?.Character = null;
+			_controller = value;
+			value?.Character = this;
+			OnPropertyChanged();
+		}
 	}
 
 	[ScriptProperty, SyncVar(AllowAuthorWrite = true)]
@@ -79,6 +1130,37 @@ public partial class CharacterModel : Dynamic
 	public override void Init()
 	{
 		base.Init();
+		EnsureTouchArea();
+		OverridePhysicsProcess = true;
+
+		_bubbleChat = Globals.CreateInstanceFromScene<BubbleChat>(BubbleChatScene);
+		_bubbleChat.SetTarget(this._controller is Player plr ? plr : null);
+		_bubbleChat.Visible = _useBubbleChat;
+		GDNode.AddChild(_bubbleChat, @internal: Node.InternalMode.Back);
+		excludedBoundNodes.Add(_bubbleChat);
+
+		// Create nametag
+		_nametag = new()
+		{
+			Target = this
+		};
+		GDNode3D.AddChild(_nametag);
+		excludedBoundNodes.Add(_nametag);
+
+		FootFwdRaycast = new();
+		GDNode3D.AddChild(FootFwdRaycast, false, Node.InternalMode.Front);
+		FootFwdRaycast.Position = new Vector3(0, -3, 0);
+		FootFwdRaycast.TargetPosition = new Vector3(0, 0, ForwardRaycastRange);
+
+		ChildAdded.Connect(OnChildAdded);
+		ChildRemoved.Connect(OnChildRemoved);
+		Died.Connect(OnDied);
+
+		RecalculateNametagOffset();
+
+		// Force these to always be on
+		SetProcess(true);
+		SetPhysicsProcess(true);
 		if (Root != null && Root.Network != null && NetworkService.CheckAuthority(Root.Network.LocalPeerID, NetworkAuthority))
 		{
 			_peerReadySubscribed = true;
@@ -86,8 +1168,35 @@ public partial class CharacterModel : Dynamic
 		}
 	}
 
+	public override void Process(double delta)
+	{
+		base.Process(delta);
+		if (_controller is Player plr && Root.Network.IsServer && !IsSitting && !plr.IsLocal)
+		{
+			CharBody3D.Velocity = LastVelocity;
+			CharBody3D.MoveAndSlide();
+			LastVelocity = Vector3.Zero;
+			ApplyPushForce();
+		}
+	}
+
+	public void OnDied()
+	{
+		UnequipTool();
+		Velocity = Vector3.Zero;
+		if (_controller is Player plr) plr.OnPlayerDied();
+	}
+
+	public override void InitOverrides()
+	{
+		Anchored = false;
+	}
+
 	public override void PreDelete()
 	{
+		ChildAdded.Disconnect(OnChildAdded);
+		ChildRemoved.Disconnect(OnChildRemoved);
+		Died.Disconnect(OnDied);
 		if (_peerReadySubscribed)
 		{
 			Root.Network.PeerPreInit -= OnPeerPreInit;
@@ -102,6 +1211,42 @@ public partial class CharacterModel : Dynamic
 			RpcId(id, nameof(NetSetBlendValue), (int)blend, val);
 		}
 	}
+
+	private void OnChildAdded(Instance n)
+	{
+		if (n is Tool t)
+		{
+			InternalAttachTool(t);
+		}
+	}
+
+	private void OnChildRemoved(Instance n)
+	{
+		if (n is Tool)
+		{
+			InternalDetachTool();
+		}
+	}
+
+	internal void ApplyPushForce()
+	{
+		for (int i = 0; i < CharBody3D.GetSlideCollisionCount(); i++)
+		{
+			KinematicCollision3D collision = CharBody3D.GetSlideCollision(i);
+
+			if (GetNetObjFromProxy((Node)collision.GetCollider()) is Physical body)
+			{
+				// Push the rigidbody
+				body.ApplyForceFromPlayer(-collision.GetNormal());
+			}
+		}
+	}
+
+	[ScriptProperty]
+	public PTSignal Died { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal Landed { get; private set; } = new();
 
 	[ScriptMethod]
 	public void PlayIdle()
@@ -131,6 +1276,29 @@ public partial class CharacterModel : Dynamic
 	public void PlayClimb()
 	{
 		SetState(CharacterModelStateEnum.Climbing);
+	}
+
+	internal void PlayEmote(string emoteName)
+	{
+		if (IsSitting || IsDead) return;
+		if (!EmoteList.Contains(emoteName)) return;
+		bool isOneShot = false;
+		if (OneShotEmoteList.Contains(emoteName))
+		{
+			isOneShot = true;
+		}
+
+		Animator?.StopAnimation();
+		Animator?.StopOneShotAnimation();
+
+		if (isOneShot)
+		{
+			Animator?.PlayOneShotAnimation("emote_" + emoteName);
+		}
+		else
+		{
+			Animator?.PlayAnimation("emote_" + emoteName);
+		}
 	}
 
 	[ScriptMethod]

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -1095,6 +1095,14 @@ public partial class CharacterModel : Physical
 		SetAnimSpeed(1);
 	}
 
+#if CREATOR
+	public override void CreatorInserted()
+	{
+		Root.Insert.InitializeDefaultCharacter(this);
+		base.CreatorInserted();
+	}
+#endif
+
 	[Editable, ScriptProperty]
 	public NPC? Controller
 	{

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -58,6 +58,8 @@ public partial class CharacterModel : Physical
 	public const string BubbleChatScene = "res://scenes/client/spatial/chat/bubble_chat.tscn";
 	private const float CoyoteTime = 0.15f;
 	private Sound? _jumpSound;
+	public Dynamic? _head;
+	public Dynamic? _toolAttachment;
 
 	public const float ForwardRaycastRange = 1;
 	public const float StairForwardRaycastRange = 4;
@@ -74,8 +76,6 @@ public partial class CharacterModel : Physical
 
 	protected override float PositionSyncThreshold => 0.1f;
 	protected override float RotationSyncThreshold => 1f;
-
-	public virtual Dynamic Head => this;
 
 	// List of all emotes
 	public static readonly string[] EmoteList =
@@ -102,6 +102,28 @@ public partial class CharacterModel : Physical
 		"scream",
 		"disappointed",
 	];
+
+	[Editable, ScriptProperty]
+	public Dynamic? Head
+	{
+		get => _head;
+		set
+		{
+			_head = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, SyncVar]
+	public Dynamic? ToolAttachment
+	{
+		get => _toolAttachment;
+		set
+		{
+			_toolAttachment = value;
+			OnPropertyChanged();
+		}
+	}
 
 	[Editable, ScriptProperty]
 	public Sound? JumpSound
@@ -734,7 +756,7 @@ public partial class CharacterModel : Physical
 			UpdateScale = false
 		};
 
-		Dynamic attachment = GetAttachment(CharacterModel.CharacterAttachmentEnum.HandRight);
+		Dynamic attachment = ToolAttachment ?? this;
 		attachment.GDNode.AddChild(_toolRemoteTransform, @internal: Node.InternalMode.Back);
 
 		// stick and stones
@@ -1392,12 +1414,6 @@ public partial class CharacterModel : Physical
 
 	public virtual void RecvBlendValue(CharacterModelBlendEnum blendName, float blendValue) { }
 	public virtual void RecvSpeedValue(float speedValue) { }
-
-	[ScriptMethod]
-	public virtual Dynamic GetAttachment(CharacterAttachmentEnum attachmentEnum)
-	{
-		throw new NotImplementedException();
-	}
 
 	public virtual void ApplyCameraModifier(Camera camera) { }
 

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -458,15 +458,6 @@ public partial class CharacterModel : Physical
 	}
 
 	[ScriptMethod]
-	public void ClearAppearance()
-	{
-		if (this is PolytorianModel ptm)
-		{
-			ptm.ClearAppearance();
-		}
-	}
-
-	[ScriptMethod]
 	public void ResetAppearance()
 	{
 		ClearAppearance();

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -328,6 +328,10 @@ public partial class CharacterModel : Physical
 		set
 		{
 			_inventory = value;
+			if (Controller is Player plr && plr.IsLocal)
+			{
+				Root.CoreUI.CoreUI.Inventory.SetInventory(value);
+			}
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -12,6 +12,7 @@ using Polytoria.Networking;
 using Polytoria.Scripting;
 using Polytoria.Shared;
 using Polytoria.Utils;
+using Polytoria.Utils.DTOs;
 using System;
 //using System.Collections.Generic;
 
@@ -70,6 +71,9 @@ public partial class CharacterModel : Physical
 	private float _nametagVisibleRadius = 40;
 	private bool _useNametag = true;
 	private Nametag _nametag = null!;
+
+	protected override float PositionSyncThreshold => 0.1f;
+	protected override float RotationSyncThreshold => 1f;
 
 	// List of all emotes
 	public static readonly string[] EmoteList =
@@ -187,6 +191,12 @@ public partial class CharacterModel : Physical
 			InternalDetachTool();
 			tool.InvokeDropped();
 		}
+	}
+
+	internal override bool TransformNetworkCheck(TransformPayloadDto newTransform)
+	{
+		// TODO: Make sanity checks here
+		return true;
 	}
 
 	[ScriptMethod]
@@ -1171,12 +1181,16 @@ public partial class CharacterModel : Physical
 	public override void Process(double delta)
 	{
 		base.Process(delta);
-		if (_controller is Player plr && Root.Network.IsServer && !IsSitting && !plr.IsLocal)
+		if (_controller is Player plr && !plr.IsLocal)
 		{
-			CharBody3D.Velocity = LastVelocity;
-			CharBody3D.MoveAndSlide();
-			LastVelocity = Vector3.Zero;
-			ApplyPushForce();
+			UpdateTransformTick(delta);
+			if (Root.Network.IsServer && !IsSitting)
+			{
+				CharBody3D.Velocity = LastVelocity;
+				CharBody3D.MoveAndSlide();
+				LastVelocity = Vector3.Zero;
+				ApplyPushForce();
+			}
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -442,7 +442,7 @@ public partial class CharacterModel : Physical
 	public void ResetAppearance()
 	{
 		ClearAppearance();
-		if (_controller is Player plr && plr.AutoLoadAppearance)
+		if (Controller is Player plr && plr.AutoLoadAppearance)
 		{
 			if (Root.Entry != null && Root.Entry.IsSoloTest)
 			{
@@ -463,7 +463,7 @@ public partial class CharacterModel : Physical
 			Position = spawnpoint.Position + new Vector3(0, spawnpoint.Size.Y + 2.0f, 0);
 			Rotation = new(0, spawnpoint.Rotation.Y, 0);
 		}
-		else if (_controller is Player player)
+		else if (Controller is Player player)
 		{
 			Position = player.DefaultSpawnLocation;
 			Rotation = new(0, 0, 0);
@@ -471,7 +471,7 @@ public partial class CharacterModel : Physical
 
 		// Spawn at custom position
 #if CREATOR
-		if (_controller is Player plr)
+		if (Controller is Player plr)
 		{
 			if (Root.Entry != null && Root.Entry.DebugSpawnPos != null)
 			{
@@ -507,7 +507,7 @@ public partial class CharacterModel : Physical
 		get => _health;
 		set
 		{
-			if (_controller is Player plr && !plr.IsReady) return;
+			if (Controller is Player plr && !plr.IsReady) return;
 			_health = value;
 			if (_health <= 0 && !IsDead)
 			{
@@ -620,7 +620,7 @@ public partial class CharacterModel : Physical
 			return;
 		}
 
-		if (_controller is Player plr)
+		if (Controller is Player plr)
 		{
 			if (!plr.IsLocal)
 			{
@@ -648,7 +648,7 @@ public partial class CharacterModel : Physical
 				_timeSinceGrounded += (float)delta;
 			}
 
-			_controller?.Navigate(delta);
+			Controller?.Navigate(delta);
 
 			// Apply gravity
 			if (!isOnFloor)
@@ -668,7 +668,7 @@ public partial class CharacterModel : Physical
 			}
 
 			UpdateVelocityInternal(CharacterVelocity);
-			if (_controller is not Player)
+			if (Controller is not Player)
 			{
 				CharBody3D.Velocity = Velocity;
 				CharBody3D.MoveAndSlide();
@@ -1063,7 +1063,7 @@ public partial class CharacterModel : Physical
 		}
 		set
 		{
-			if (_controller is Player plr)
+			if (Controller is Player plr)
 			{
 				LastVelocity = value;
 			}
@@ -1090,15 +1090,15 @@ public partial class CharacterModel : Physical
 		SetAnimSpeed(1);
 	}
 
-	[ScriptProperty, SyncVar(AllowAuthorWrite = true)]
+	[Editable, ScriptProperty]
 	public NPC? Controller
 	{
 		get => _controller;
 		set
 		{
-			_controller?.Character = null;
+			_controller?._character = null;
 			_controller = value;
-			value?.Character = this;
+			value?._character = this;
 			OnPropertyChanged();
 		}
 	}
@@ -1149,7 +1149,7 @@ public partial class CharacterModel : Physical
 		OverridePhysicsProcess = true;
 
 		_bubbleChat = Globals.CreateInstanceFromScene<BubbleChat>(BubbleChatScene);
-		_bubbleChat.SetTarget(this._controller is Player plr ? plr : null);
+		_bubbleChat.SetTarget(this.Controller is Player plr ? plr : null);
 		_bubbleChat.Visible = _useBubbleChat;
 		GDNode.AddChild(_bubbleChat, @internal: Node.InternalMode.Back);
 		excludedBoundNodes.Add(_bubbleChat);
@@ -1186,7 +1186,7 @@ public partial class CharacterModel : Physical
 	public override void Process(double delta)
 	{
 		base.Process(delta);
-		if (_controller is Player plr && !plr.IsLocal)
+		if (Controller is Player plr && !plr.IsLocal)
 		{
 			UpdateTransformTick(delta);
 			if (Root.Network.IsServer && !IsSitting)
@@ -1203,7 +1203,7 @@ public partial class CharacterModel : Physical
 	{
 		UnequipTool();
 		Velocity = Vector3.Zero;
-		if (_controller is Player plr) plr.OnPlayerDied();
+		if (Controller is Player plr) plr.OnPlayerDied();
 	}
 
 	public override void InitOverrides()

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -1211,7 +1211,7 @@ public partial class CharacterModel : Physical
 
 	public void OnDestroying()
 	{
-		((Player)Controller)?.OnPlayerDied();
+		if (Controller is Player plr) plr?.OnPlayerDied();
 		Controller?.Character = null;
 	}
 

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -1211,10 +1211,8 @@ public partial class CharacterModel : Physical
 
 	public void OnDestroying()
 	{
-		if (Controller is not null)
-		{
-			Controller.Character = null;
-		}
+		((Player)Controller)?.OnPlayerDied();
+		Controller?.Character = null;
 	}
 
 	public override void Process(double delta)

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -457,23 +457,6 @@ public partial class CharacterModel : Physical
 		}
 	}
 
-	[ScriptMethod]
-	public void ResetAppearance()
-	{
-		ClearAppearance();
-		if (Controller is Player plr && plr.AutoLoadAppearance)
-		{
-			if (Root.Entry != null && Root.Entry.IsSoloTest)
-			{
-				LoadAppearance(1144);
-			}
-			else
-			{
-				LoadAppearance(plr.UserID);
-			}
-		}
-	}
-
 	public void WrapToSpawnPoint()
 	{
 		if (Root.Environment.SpawnPoints.Count > 0)

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -75,6 +75,8 @@ public partial class CharacterModel : Physical
 	protected override float PositionSyncThreshold => 0.1f;
 	protected override float RotationSyncThreshold => 1f;
 
+	public virtual Dynamic Head => this;
+
 	// List of all emotes
 	public static readonly string[] EmoteList =
 	[

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -355,6 +355,11 @@ public partial class CharacterModel : Physical
 	[ScriptProperty]
 	public bool IsOnCeiling => CharBody3D.IsOnCeiling();
 
+	public override Node CreateGDNode()
+	{
+		return new CharacterBody3D() { FloorMaxAngle = Mathf.DegToRad(80f) };
+	}
+
 	public override void InitGDNode()
 	{
 		CharBody3D = (CharacterBody3D)GDNode;

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -950,18 +950,25 @@ public partial class CharacterModel : Physical
 	[ScriptMethod]
 	public void Respawn()
 	{
-		Health = MaxHealth;
-		Anchored = false;
-		IsDead = false;
-
-		if (this is PolytorianModel ptmodel)
+		if (Controller is Player plr)
 		{
-			ptmodel.StopRagdoll();
+			plr.Respawn();
 		}
-		CharacterVelocity = Vector3.Zero;
+		else
+		{
+			Health = MaxHealth;
+			Anchored = false;
+			IsDead = false;
 
-		OverrideCanCollide = false;
-		UpdateCollision();
+			if (this is PolytorianModel ptmodel)
+			{
+				ptmodel.StopRagdoll();
+			}
+			CharacterVelocity = Vector3.Zero;
+
+			OverrideCanCollide = false;
+			UpdateCollision();
+		}
 	}
 
 	[ScriptMethod]
@@ -1182,6 +1189,7 @@ public partial class CharacterModel : Physical
 		ChildAdded.Connect(OnChildAdded);
 		ChildRemoved.Connect(OnChildRemoved);
 		Died.Connect(OnDied);
+		Destroying.Connect(OnDestroying);
 
 		RecalculateNametagOffset();
 
@@ -1192,6 +1200,14 @@ public partial class CharacterModel : Physical
 		{
 			_peerReadySubscribed = true;
 			Root.Network.PeerPreInit += OnPeerPreInit;
+		}
+	}
+
+	public void OnDestroying()
+	{
+		if (Controller is Player plr)
+		{
+			plr.Character = null;
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -593,7 +593,7 @@ public partial class CharacterModel : Physical
 		// Only enable physics in client mode
 		if (Root.SessionType != World.SessionTypeEnum.Client) return;
 
-		// Kill player if fall off the map
+		// Kill character if fall off the map
 		if (Position.Y < Root.Environment.PartDestroyHeight)
 		{
 			Kill();
@@ -1096,10 +1096,22 @@ public partial class CharacterModel : Physical
 		get => _controller;
 		set
 		{
-			_controller?._character = null;
-			_controller = value;
-			value?._character = this;
-			OnPropertyChanged();
+			if (value is null)
+			{
+				Controller?._character = null;
+				Controller?.OnPropertyChanged();
+				_controller = null;
+				OnPropertyChanged();
+				if (Root.Network.IsServer && ((value?.NetworkAuthority ?? 1) != 1))
+				{
+					SetNetworkAuthority(null);
+					SetNetworkAuthority(1, true);
+				}
+			}
+			else
+			{
+				value!.Character = this;
+			}
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -435,6 +435,7 @@ public partial class CharacterModel : Physical
 		seat.Occupant = this;
 		seat.InvokeSat(this);
 		SetBlendValue(CharacterModel.CharacterModelBlendEnum.Sitting, 1);
+		Seated.Invoke(seat);
 	}
 
 	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, CallLocal = true)]
@@ -448,9 +449,11 @@ public partial class CharacterModel : Physical
 
 			if (SittingIn != null)
 			{
-				SittingIn.Occupant = null;
-				SittingIn.InvokeVacated(this);
+				Seat seat = SittingIn;
+				seat.Occupant = null;
+				seat.InvokeVacated(this);
 				SittingIn = null;
+				Unseated.Invoke(seat);
 			}
 
 			SetBlendValue(CharacterModel.CharacterModelBlendEnum.Sitting, 0);
@@ -510,12 +513,17 @@ public partial class CharacterModel : Physical
 		set
 		{
 			if (Controller is Player plr && !plr.IsReady) return;
+			float oldHealth = _health;
 			_health = value;
 			if (_health <= 0 && !IsDead)
 			{
 				TriggerDead();
 			}
 			OnPropertyChanged();
+			if (_health != oldHealth)
+			{
+				HealthChanged.Invoke(_health, oldHealth);
+			}
 		}
 	}
 
@@ -679,6 +687,10 @@ public partial class CharacterModel : Physical
 				{
 					_coyoteUsed = false;
 					Landed.Invoke();
+				}
+				else
+				{
+					LeftGround.Invoke();
 				}
 			}
 
@@ -926,6 +938,7 @@ public partial class CharacterModel : Physical
 			_coyoteUsed = true;
 			CharacterVelocity.Y = JumpPower;
 			playJumpSound = true;
+			Jumped.Invoke();
 		}
 		if (IsSitting)
 		{
@@ -1296,6 +1309,21 @@ public partial class CharacterModel : Physical
 
 	[ScriptProperty]
 	public PTSignal Landed { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal<float, float> HealthChanged { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal Jumped { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal LeftGround { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal<Seat> Seated { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal<Seat> Unseated { get; private set; } = new();
 
 	[ScriptMethod]
 	public void PlayIdle()

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -430,6 +430,11 @@ public partial class CharacterModel : Physical
 
 	private void InternalSit(Seat seat)
 	{
+		if (IsSitting && SittingIn != null)
+		{
+			SittingIn.Occupant = null;
+			SittingIn.InvokeVacated(this);
+		}
 		IsSitting = true;
 		OverrideNetworkTransform = true;
 		SittingIn = seat;

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -48,6 +48,7 @@ public partial class CharacterModel : Physical
 	private bool _canMove = true;
 	internal bool ClimbDebounce = false;
 	internal bool JustFinishedClimbing = false;
+	private bool _canJumpWhileClimbing = true;
 	private Tool? _holdingTool;
 	private Seat? _sittingIn;
 	private bool _keepInventory = false;
@@ -702,6 +703,7 @@ public partial class CharacterModel : Physical
 					if (!IsClimbing && !ClimbDebounce && truss.Climbable)
 					{
 						ClimbingTruss = truss;
+						_canJumpWhileClimbing = false;
 						IsClimbing = true;
 						PlayClimb();
 					}
@@ -945,7 +947,7 @@ public partial class CharacterModel : Physical
 		{
 			JumpSound?.Play();
 		}
-		if (IsClimbing)
+		if (_canJumpWhileClimbing && IsClimbing)
 		{
 			EndClimb();
 			ClimbDebounce = true;

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -460,12 +460,12 @@ public partial class CharacterModel : Physical
 		}
 	}
 
-	public void WrapToSpawnPoint()
+	public void WarpToSpawnPoint()
 	{
 		if (Root.Environment.SpawnPoints.Count > 0)
 		{
 			Entity spawnpoint = ArrayUtils.GetRandom(Root.Environment.SpawnPoints);
-			Position = spawnpoint.Position + new Vector3(0, spawnpoint.Size.Y + 2.0f, 0);
+			Position = spawnpoint.Position + spawnpoint.Up * (spawnpoint.Size.Y / 2 + 3.0f);
 			Rotation = new(0, spawnpoint.Rotation.Y, 0);
 		}
 		else if (Controller is Player player)

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -699,15 +699,11 @@ public partial class CharacterModel : Physical
 				Node collider = (Node)FootFwdRaycast.GetCollider();
 				if (collider != null && GetNetObjFromProxy(collider) is Truss truss)
 				{
-					if (!IsClimbing)
+					if (!IsClimbing && !ClimbDebounce && truss.Climbable)
 					{
-						if (!ClimbDebounce)
-						{
-							ClimbingTruss = truss;
-							IsClimbing = true;
-							PlayClimb();
-						}
-
+						ClimbingTruss = truss;
+						IsClimbing = true;
+						PlayClimb();
 					}
 				}
 				else

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -48,7 +48,7 @@ public partial class CharacterModel : Physical
 	private bool _canMove = true;
 	internal bool ClimbDebounce = false;
 	internal bool JustFinishedClimbing = false;
-	private bool _canJumpWhileClimbing = true;
+	internal bool _canJumpWhileClimbing = true;
 	private Tool? _holdingTool;
 	private Seat? _sittingIn;
 	private bool _keepInventory = false;

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -805,9 +805,6 @@ public partial class Dynamic : Instance
 
 	public override void HiddenChanged(bool to)
 	{
-		// Player cannot be hidden
-		if (this is Player) return;
-
 		GDNode3D.Visible = !to;
 
 #if CREATOR

--- a/Polytoria/scripts/datamodel/Explosion.cs
+++ b/Polytoria/scripts/datamodel/Explosion.cs
@@ -176,12 +176,12 @@ public partial class Explosion : Dynamic
 					}
 				}
 			}
-			else if (item is Player plr)
+			else if (item is CharacterModel charModel)
 			{
-				if (plr.IsDead) continue;
+				if (charModel.IsDead) continue;
 
-				plr.TakeDamage(Damage);
-				AddPlrExplosionForce(plr);
+				charModel.TakeDamage(Damage);
+				AddCharExplosionForce(charModel);
 			}
 		}
 
@@ -196,16 +196,16 @@ public partial class Explosion : Dynamic
 		Delete();
 	}
 
-	private void AddPlrExplosionForce(Player player)
+	private void AddCharExplosionForce(CharacterModel charModel)
 	{
 		float force = Force * 0.02f;
-		Vector3 dir = player.GetGlobalTransform().Origin - GetGlobalTransform().Origin;
+		Vector3 dir = charModel.GetGlobalTransform().Origin - GetGlobalTransform().Origin;
 		float wearoff = 1 - (dir.Length() / (Radius * 2f));
 		wearoff = Mathf.Max(Mathf.Clamp(wearoff, 0, 1), 0.1f);
 		Vector3 f = dir.Normalized() * force;
 		f.X *= 1.5f;
 		f.Z *= 1.5f;
 
-		player.CharacterVelocity = f * wearoff;
+		charModel.CharacterVelocity = f * wearoff;
 	}
 }

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -149,10 +149,11 @@ public partial class Grabbable : Instance
 	private async void OnClicked(Player by)
 	{
 		if (_dragger != null) return;
+		if (by.Character == null) return;
 		if (_parent != null)
 		{
 			// Check grabbable range
-			if ((by.Position - _parent.Position).Length() > MaxGrabbableRange) return;
+			if ((by.Character.Position - _parent.Position).Length() > MaxGrabbableRange) return;
 		}
 		if (Root.Network.IsServer)
 		{
@@ -282,8 +283,9 @@ public partial class Grabbable : Instance
 					}
 
 					if (targetPos == null) return;
+					if (_dragger.Character == null) return;
 
-					Vector3 anchorPos = _dragger.Position;
+					Vector3 anchorPos = _dragger.Character.Position;
 					Vector3 direction = targetPos.Value - anchorPos;
 					float distance = direction.Length();
 

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -21,7 +21,7 @@ public partial class Grabbable : Instance
 	private float _maxRange;
 	private float _maxGrabbableRange;
 	private bool _useDragForce;
-	private Player? _dragger;
+	private NPC? _dragger;
 	private GrabbablePermissionModeEnum _permissionMode = GrabbablePermissionModeEnum.Everyone;
 
 	[Editable, ScriptProperty, DefaultValue(10)]
@@ -79,10 +79,10 @@ public partial class Grabbable : Instance
 		}
 	}
 
-	[ScriptProperty] public Player? Dragger => _dragger;
+	[ScriptProperty] public NPC? Dragger => _dragger;
 	[ScriptProperty] public PTFunction? PermissionPredicate { get; set; }
-	[ScriptProperty] public PTSignal<Player> Grabbed { get; private set; } = new();
-	[ScriptProperty] public PTSignal<Player> Released { get; private set; } = new();
+	[ScriptProperty] public PTSignal<NPC> Grabbed { get; private set; } = new();
+	[ScriptProperty] public PTSignal<NPC> Released { get; private set; } = new();
 
 	public override void EnterTree()
 	{

--- a/Polytoria/scripts/datamodel/InteractionPrompt.cs
+++ b/Polytoria/scripts/datamodel/InteractionPrompt.cs
@@ -302,7 +302,10 @@ public sealed partial class InteractionPrompt : Physical
 		_prompt.Scale = new Vector3(_scale, _scale, _scale);
 		if (Root.SessionType != World.SessionTypeEnum.Client) { return; }
 		if (!Root.IsLoaded) return;
-		var distance = Root.Players.LocalPlayer?.GetGlobalPosition().DistanceTo(GetGlobalPosition());
+		Player localPlayer = Root.Players.LocalPlayer;
+		if (localPlayer is null) return;
+		if (localPlayer.Character == null) return;
+		var distance = localPlayer.Character.GetGlobalPosition().DistanceTo(GetGlobalPosition());
 		_inRange = distance <= _maxDistance;
 		_prompt.Visible = false;
 		if (_inRange && _enabled && !_hiddenByServer)

--- a/Polytoria/scripts/datamodel/Inventory.cs
+++ b/Polytoria/scripts/datamodel/Inventory.cs
@@ -6,5 +6,4 @@ using Polytoria.Attributes;
 
 namespace Polytoria.Datamodel;
 
-[Static]
 public sealed partial class Inventory : HiddenBase { }

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -461,7 +461,7 @@ public partial class NPC : Instance
 	{
 		if (Character is PolytorianModel ptm)
 		{
-			ptm.LoadAppearance();
+			ptm.LoadAppearance(value);
 		}
 	}
 
@@ -845,10 +845,13 @@ public partial class NPC : Instance
 	}
 
 
-	[ScriptMethod, Attributes.Obsolete("Use Character.ResetAppearance() instead")]
+	[ScriptMethod, Attributes.Obsolete("Use Character.ResetAppearance() instead, only if it's a PolytorianModel")]
 	public void ResetAppearance()
 	{
-		Character?.ResetAppearance();
+		if (Character is PolytorianModel ptm)
+		{
+			ptm.ResetAppearance();
+		}
 	}
 
 	[Editable, ScriptProperty]

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -14,7 +14,7 @@ using Polytoria.Utils;
 namespace Polytoria.Datamodel;
 
 [Instantiable]
-public partial class NPC : Dynamic
+public partial class NPC : Instance
 {
 	private const float NavigationDistance = 2f;
 	public const float BodyRotateLerp = 10f;
@@ -33,10 +33,6 @@ public partial class NPC : Dynamic
 	private Color? _pendingLeftLegColor;
 	private Color? _pendingRightLegColor;
 	private int? _pendingFaceID;
-
-	protected override float PositionSyncThreshold => 0.1f;
-	protected override float RotationSyncThreshold => 1f;
-
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Apply them to Character"), CloneIgnore]
 	public Color HeadColor
@@ -257,9 +253,9 @@ public partial class NPC : Dynamic
 
 		if (walkTarget.HasValue)
 		{
-			Vector3 velo = GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Character.Position.Y });
+			Vector3 velo = Character.GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Character.Position.Y });
 			Character.CharacterVelocity = new(velo.X * Character.WalkSpeed, Character.CharacterVelocity.Y, velo.Z * Character.WalkSpeed);
-			Character.GDNode3D.GlobalRotationDegrees = new Vector3(Rotation.X, Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Character.Rotation.Y), Mathf.Atan2(Character.CharacterVelocity.X, Character.CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, BodyRotateLerp))), Character.Rotation.Z);
+			Character.GDNode3D.GlobalRotationDegrees = new Vector3(Character.Rotation.X, Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Character.Rotation.Y), Mathf.Atan2(Character.CharacterVelocity.X, Character.CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, BodyRotateLerp))), Character.Rotation.Z);
 
 			float distanceToTarget = Character.GetGlobalPosition().DistanceTo(walkTarget.Value);
 
@@ -350,6 +346,7 @@ public partial class NPC : Dynamic
 	public void SetNavDestination(Vector3 pos)
 	{
 		MoveTarget = null;
+		if (Character == null) return;
 		if (_navAgent == null)
 		{
 			_navAgentContainer = new();
@@ -357,12 +354,12 @@ public partial class NPC : Dynamic
 			{
 				PathDesiredDistance = NavigationDistance,
 				TargetDesiredDistance = 0.5f,
-				PathHeightOffset = -(CalculateBounds().Size.Y / 2),
+				PathHeightOffset = -(Character.CalculateBounds().Size.Y / 2),
 				PathMaxDistance = 3f
 			};
 
 			_navAgentContainer.AddChild(_navAgent);
-			GDNode3D.AddChild(_navAgentContainer);
+			Character.GDNode3D.AddChild(_navAgentContainer);
 			if (Globals.IsInGDEditor)
 			{
 				_navAgent.DebugEnabled = true;

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -14,41 +14,16 @@ using Polytoria.Utils;
 namespace Polytoria.Datamodel;
 
 [Instantiable]
-public partial class NPC : Physical
+public partial class NPC : Dynamic
 {
-	private const float CoyoteTime = 0.15f;
 	private const float NavigationDistance = 2f;
 	public const float BodyRotateLerp = 10f;
-	private const float StepHeight = 1.5f;
-	private Tool? _holdingTool;
-	private Seat? _sittingIn;
 	private CharacterModel? _character;
 	private Dynamic? _moveTarget;
 
-	public CharacterBody3D CharBody3D = null!;
-	public const float ForwardRaycastRange = 1;
-	public const float StairForwardRaycastRange = 4;
-	public const float NameTagHeightMinus = 3f;
-	private Vector3 _seatOffset = new(0, 1.7f, 0);
-	private float _health = 100;
-	private RemoteTransform3D? _toolRemoteTransform;
-	private float _maxHealth = 100;
-	private float _jumpPower = 36;
-	private float _walkSpeed = 16;
 	private string _displayName = "";
-	protected RayCast3D FootFwdRaycast = null!;
-	private Sound? _jumpSound;
-	private bool _lastOnFloorState = false;
-	private float _timeSinceGrounded = 0f;
-	private bool _coyoteUsed = false;
 	private Node3D? _navAgentContainer;
 	private NavigationAgent3D? _navAgent;
-
-	private Vector3 _nametagOffset = Vector3.Zero;
-	private Vector3 _fixedNametagOffset = new(0, 3, 0);
-	private float _nametagVisibleRadius = 40;
-	private bool _useNametag = true;
-	private Nametag _nametag = null!;
 
 	// Pending properties to apply to character
 	private Color? _pendingHeadColor;
@@ -61,34 +36,6 @@ public partial class NPC : Physical
 
 	protected override float PositionSyncThreshold => 0.1f;
 	protected override float RotationSyncThreshold => 1f;
-
-	[Editable, ScriptProperty, SyncVar(Unreliable = true, AllowAuthorWrite = true)]
-	public override Vector3 Velocity
-	{
-		get
-		{
-			return CharacterVelocity;
-		}
-		set
-		{
-			if (this is Player plr)
-			{
-				plr.LastVelocity = value;
-				plr.ExternalVelocity = value;
-			}
-
-			CharacterVelocity = value;
-
-			OnPropertyChanged();
-		}
-	}
-
-	internal void ApplyInternalVelocity(Vector3 velocity)
-	{
-		UpdateVelocityInternal(velocity);
-		CharacterVelocity = velocity;
-		OnPropertyChanged(nameof(Velocity));
-	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Apply them to Character"), CloneIgnore]
@@ -218,102 +165,6 @@ public partial class NPC : Physical
 	}
 
 	[Editable, ScriptProperty]
-	public Vector3 SeatOffset
-	{
-		get => _seatOffset;
-		set
-		{
-			_seatOffset = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float Health
-	{
-		get => _health;
-		set
-		{
-			if (this is Player plr && !plr.IsReady) return;
-			_health = value;
-			if (_health <= 0 && !IsDead)
-			{
-				TriggerNPCDead();
-			}
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float MaxHealth
-	{
-		get => _maxHealth;
-		set
-		{
-			_maxHealth = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float JumpPower
-	{
-		get => _jumpPower;
-		set
-		{
-			_jumpPower = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float WalkSpeed
-	{
-		get => _walkSpeed;
-		set
-		{
-			_walkSpeed = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public bool UseNametag
-	{
-		get => _useNametag;
-		set
-		{
-			_useNametag = value;
-			_nametag?.UpdateNameTag();
-			OnPropertyChanged();
-		}
-	}
-
-
-	[Editable, ScriptProperty]
-	public Vector3 NametagOffset
-	{
-		get => _nametagOffset;
-		set
-		{
-			_nametagOffset = value;
-			RecalculateNametagOffset();
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float NametagVisibleRadius
-	{
-		get => _nametagVisibleRadius;
-		set
-		{
-			_nametagVisibleRadius = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
 	public string DisplayName
 	{
 		get => _displayName;
@@ -322,51 +173,6 @@ public partial class NPC : Physical
 			_displayName = value;
 			OnPropertyChanged();
 		}
-	}
-
-	[Editable, ScriptProperty]
-	public Sound? JumpSound
-	{
-		get => _jumpSound;
-		set
-		{
-			_jumpSound = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[SyncVar, ScriptProperty]
-	public bool IsSitting { get; internal set; } = false;
-
-	[SyncVar, ScriptProperty]
-	public bool IsDead { get; internal set; } = false;
-
-	[SyncVar, ScriptProperty]
-	public Tool? HoldingTool
-	{
-		get
-		{
-			if (_holdingTool != null && _holdingTool.IsDeleted)
-			{
-				_holdingTool = null;
-			}
-			return _holdingTool;
-		}
-		internal set => _holdingTool = value;
-	}
-
-	[SyncVar, ScriptProperty]
-	public Seat? SittingIn
-	{
-		get
-		{
-			if (_sittingIn != null && _sittingIn.IsDeleted)
-			{
-				_sittingIn = null;
-			}
-			return _sittingIn;
-		}
-		internal set => _sittingIn = value;
 	}
 
 	[Editable, ScriptProperty, SyncVar]
@@ -380,7 +186,13 @@ public partial class NPC : Physical
 			}
 			return _character;
 		}
-		internal set => _character = value;
+		set
+		{
+			_character?.Controller = null;
+			_character = value;
+			value?.Controller = this;
+			OnPropertyChanged();
+		}
 	}
 
 	[SyncVar, ScriptProperty]
@@ -397,26 +209,12 @@ public partial class NPC : Physical
 		set => _moveTarget = value;
 	}
 
-	[ScriptProperty, ScriptLegacyProperty("Grounded")]
-	public bool IsOnGround => CharBody3D.IsOnFloor();
-
-	[ScriptProperty]
-	public bool IsOnCeiling => CharBody3D.IsOnCeiling();
-
 	[ScriptProperty] public float NavDestinationDistance => _navAgent == null ? Mathf.Inf : _navAgent.DistanceToTarget();
 
 	[ScriptProperty]
 	public bool NavDestinationReached { get; private set; } = false;
 
 	[ScriptProperty] public bool NavDestinationValid => _navAgent != null && _navAgent.IsTargetReachable();
-
-	public Vector3 CharacterVelocity = Vector3.Zero;
-
-	[ScriptProperty]
-	public PTSignal Died { get; private set; } = new();
-
-	[ScriptProperty]
-	public PTSignal Landed { get; private set; } = new();
 
 	[ScriptProperty]
 	public PTSignal NavFinished { get; private set; } = new();
@@ -426,67 +224,66 @@ public partial class NPC : Physical
 		return new CharacterBody3D() { FloorMaxAngle = Mathf.DegToRad(80f) };
 	}
 
-	public override void InitGDNode()
-	{
-		CharBody3D = (CharacterBody3D)GDNode;
-		base.InitGDNode();
-	}
-
-	public override void Init()
-	{
-		base.Init();
-		EnsureTouchArea();
-		OverridePhysicsProcess = true;
-
-		// Create nametag
-		_nametag = new()
-		{
-			Target = this
-		};
-		GDNode3D.AddChild(_nametag);
-		excludedBoundNodes.Add(_nametag);
-
-		FootFwdRaycast = new();
-		GDNode3D.AddChild(FootFwdRaycast, false, Node.InternalMode.Front);
-		FootFwdRaycast.Position = new Vector3(0, -3, 0);
-		FootFwdRaycast.TargetPosition = new Vector3(0, 0, ForwardRaycastRange);
-
-		ChildAdded.Connect(OnChildAdded);
-		ChildRemoved.Connect(OnChildRemoved);
-
-		RecalculateNametagOffset();
-
-		// Force these to always be on
-		SetProcess(true);
-		SetPhysicsProcess(true);
-	}
-
-	public override void InitOverrides()
-	{
-		Anchored = false;
-	}
-
 	public override void PreDelete()
 	{
-		ChildAdded.Disconnect(OnChildAdded);
-		ChildRemoved.Disconnect(OnChildRemoved);
 		_navAgent?.NavigationFinished -= OnNavFinished;
 		base.PreDelete();
 	}
 
-	private void OnChildAdded(Instance n)
+	public void Navigate(double delta)
 	{
-		if (n is Tool t)
-		{
-			InternalAttachTool(t);
-		}
-	}
+		if (Character == null) return;
 
-	private void OnChildRemoved(Instance n)
-	{
-		if (n is Tool)
+		bool isOnFloor = Character.IsOnGround;
+		bool isOnCeiling = Character.IsOnCeiling;
+		bool playerNPCOverride = Character != null && !Character.CanMove;
+
+		CharacterModel.CharacterModelStateEnum finalState = CharacterModel.CharacterModelStateEnum.Idle;
+		Vector3? walkTarget = null;
+		float animSpeed = 1;
+
+		if (MoveTarget != null)
 		{
-			InternalDetachTool();
+			walkTarget = MoveTarget.GetGlobalPosition();
+		}
+
+		if (_navAgent != null)
+		{
+			walkTarget = _navAgent.GetNextPathPosition();
+
+			// Adjust Nav agent position in-case of unstable Y position changes
+			_navAgentContainer?.GlobalPosition = _navAgentContainer.GlobalPosition with { Y = walkTarget.Value.Y };
+		}
+
+		if (walkTarget.HasValue)
+		{
+			Vector3 velo = GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Character.Position.Y });
+			Character.CharacterVelocity = new(velo.X * Character.WalkSpeed, Character.CharacterVelocity.Y, velo.Z * Character.WalkSpeed);
+			Character.GDNode3D.GlobalRotationDegrees = new Vector3(Rotation.X, Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Character.Rotation.Y), Mathf.Atan2(Character.CharacterVelocity.X, Character.CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, BodyRotateLerp))), Character.Rotation.Z);
+
+			float distanceToTarget = Character.GetGlobalPosition().DistanceTo(walkTarget.Value);
+
+			if (distanceToTarget > 0.5f)
+			{
+				finalState = CharacterModel.CharacterModelStateEnum.Walking;
+				animSpeed = Character.WalkSpeed / 8;
+				Character.TryStepUp();
+			}
+		}
+		else if (this is not Player || playerNPCOverride)
+		{
+			Character.CharacterVelocity = new(0, Character.CharacterVelocity.Y, 0);
+		}
+
+		if (!isOnFloor)
+		{
+			finalState = CharacterModel.CharacterModelStateEnum.Jumping;
+		}
+
+		if (this is not Player || playerNPCOverride)
+		{
+			Character.SetState(finalState);
+			Character.SetAnimSpeed(animSpeed);
 		}
 	}
 
@@ -537,17 +334,7 @@ public partial class NPC : Physical
 			}
 		}
 
-		if (IsSitting && SittingIn != null)
-		{
-			InternalSit(SittingIn);
-		}
-
-		if (HoldingTool != null)
-		{
-			InternalAttachTool(HoldingTool);
-		}
-
-		RecalculateNametagOffset();
+		if (Character != null) Character.Ready();
 		base.Ready();
 	}
 
@@ -558,518 +345,6 @@ public partial class NPC : Physical
 		base.CreatorInserted();
 	}
 #endif
-
-	private void RecalculateNametagOffset()
-	{
-		if (!_nametag.IsInsideTree()) { return; }
-		_nametag.Position = NametagOffset + _fixedNametagOffset;
-	}
-
-	public override void PhysicsProcess(double delta)
-	{
-		base.PhysicsProcess(delta);
-
-		if (Root == null) return;
-		if (Anchored || IsHidden) return;
-		if (!Root.IsLoaded) return;
-
-		// Only enable physics in client mode
-		if (Root.SessionType != World.SessionTypeEnum.Client) return;
-
-		// Kill player if fall off the map
-		if (Position.Y < Root.Environment.PartDestroyHeight)
-		{
-			Kill();
-		}
-
-		if (IsSitting)
-		{
-			if (!Root.Network.IsServer && SittingIn != null)
-			{
-				Velocity = Vector3.Zero;
-				Position = SittingIn.Position + SeatOffset.Y * Up;
-				if (!SittingIn.SitDirectionLocked)
-				{
-					Rotation = new Vector3(SittingIn.Rotation.X, Rotation.Y, SittingIn.Rotation.Z);
-				}
-				else
-				{
-					Rotation = SittingIn.Rotation;
-				}
-				Character?.PlayIdle();
-			}
-			return;
-		}
-
-		if (this is Player plr)
-		{
-			if (!plr.IsLocal)
-			{
-				return;
-			}
-			if (plr.MovementMode == Player.PlayerMovementModeEnum.Scripted)
-			{
-				return;
-			}
-		}
-
-		if (Root.Network.LocalPeerID != NetworkAuthority && ExistInNetwork) return;
-
-		if (CharBody3D != null)
-		{
-			bool isOnFloor = CharBody3D.IsOnFloor();
-
-			if (isOnFloor)
-			{
-				_timeSinceGrounded = 0f;
-			}
-			else
-			{
-				_timeSinceGrounded += (float)delta;
-			}
-
-			bool isOnCeiling = CharBody3D.IsOnCeiling();
-			bool playerNPCOverride = this is Player p && !p.CanMove;
-
-			CharacterModel.CharacterModelStateEnum finalState = CharacterModel.CharacterModelStateEnum.Idle;
-			Vector3? walkTarget = null;
-			float animSpeed = 1;
-
-			if (MoveTarget != null)
-			{
-				walkTarget = MoveTarget.GetGlobalPosition();
-			}
-
-			if (_navAgent != null)
-			{
-				walkTarget = _navAgent.GetNextPathPosition();
-
-				// Adjust Nav agent position in-case of unstable Y position changes
-				_navAgentContainer?.GlobalPosition = _navAgentContainer.GlobalPosition with { Y = walkTarget.Value.Y };
-			}
-
-			if (walkTarget.HasValue)
-			{
-				Vector3 velo = GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Position.Y });
-				CharacterVelocity = new(velo.X * WalkSpeed, CharacterVelocity.Y, velo.Z * WalkSpeed);
-				GDNode3D.GlobalRotationDegrees = new Vector3(Rotation.X, Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Rotation.Y), Mathf.Atan2(CharacterVelocity.X, CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, BodyRotateLerp))), Rotation.Z);
-
-				float distanceToTarget = GetGlobalPosition().DistanceTo(walkTarget.Value);
-
-				if (distanceToTarget > 0.5f)
-				{
-					finalState = CharacterModel.CharacterModelStateEnum.Walking;
-					animSpeed = WalkSpeed / 8;
-					TryStepUp();
-				}
-			}
-			else if (this is not Player || playerNPCOverride)
-			{
-				CharacterVelocity = new(0, CharacterVelocity.Y, 0);
-			}
-
-			if (!isOnFloor)
-			{
-				finalState = CharacterModel.CharacterModelStateEnum.Jumping;
-			}
-
-			if (this is not Player || playerNPCOverride)
-			{
-				Character?.SetState(finalState);
-				Character?.SetAnimSpeed(animSpeed);
-			}
-
-			// Apply gravity
-			if (!isOnFloor)
-			{
-				CharacterVelocity.Y += Root.Environment.Gravity.Y * (float)delta;
-			}
-			else if (isOnFloor && CharacterVelocity.Y < 0)
-			{
-				// Cancel downward velocity when on floor
-				CharacterVelocity.Y = 0;
-			}
-
-			// Prevent sticking
-			if (isOnCeiling && CharacterVelocity.Y > 0)
-			{
-				CharacterVelocity.Y = 0;
-			}
-
-			UpdateVelocityInternal(CharacterVelocity);
-			if (this is not Player)
-			{
-				CharBody3D.Velocity = Velocity;
-				CharBody3D.MoveAndSlide();
-			}
-
-			if (isOnFloor != _lastOnFloorState)
-			{
-				_lastOnFloorState = isOnFloor;
-
-				// On floor change
-				if (isOnFloor)
-				{
-					_coyoteUsed = false;
-					Landed.Invoke();
-				}
-			}
-		}
-	}
-
-	[ScriptMethod]
-	public void Move(Vector3 velo)
-	{
-		CharacterVelocity = velo;
-		UpdateVelocityInternal(CharacterVelocity);
-		CharBody3D.Velocity = Velocity;
-		CharBody3D.MoveAndSlide();
-		CharacterVelocity = CharBody3D.Velocity;
-		UpdateVelocityInternal(CharacterVelocity);
-	}
-
-	[ScriptMethod]
-	public void Kill()
-	{
-		Health = 0;
-		RpcId(1, nameof(NetKill));
-	}
-
-	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable)]
-	private void NetKill()
-	{
-		Health = 0;
-	}
-
-	private void TriggerNPCDead()
-	{
-		if (IsDead) return;
-		if (Root.SessionType != World.SessionTypeEnum.Client) return;
-		Anchored = true;
-		OverrideCanCollide = true;
-		OverrideCanCollideTo = false;
-		Unsit(false);
-		UpdateCollision();
-
-		Character?.Animator?.StopAnimation();
-		Character?.Animator?.StopOneShotAnimation();
-
-		if (Character is PolytorianModel ptmodel)
-		{
-			ptmodel.StartRagdoll(Velocity);
-		}
-		IsDead = true;
-		Died.Invoke();
-	}
-
-	[ScriptMethod]
-	public bool TryStepUp()
-	{
-		if (CharBody3D == null)
-		{
-			return false;
-		}
-
-		if (!CharBody3D.IsOnFloor())
-		{
-			return false;
-		}
-
-		int slideCount = CharBody3D.GetSlideCollisionCount();
-
-		if (slideCount <= 0)
-		{
-			return false;
-		}
-
-		Vector3 desiredVelocity = Velocity;
-		Vector3 desiredXZ = new(desiredVelocity.X, 0f, desiredVelocity.Z);
-		if (desiredXZ.LengthSquared() < 0.0001f)
-		{
-			return false;
-		}
-
-		float groundY;
-		{
-			var downHit = new KinematicCollision3D();
-			bool hasGround = CharBody3D.TestMove(CharBody3D.GlobalTransform, Vector3.Down * (StepHeight + 0.05f), downHit, 0.001f, true);
-			if (!hasGround)
-			{
-				return false;
-			}
-
-			groundY = downHit.GetPosition().Y;
-		}
-
-		const float stepSearchOvershoot = 0.05f;
-
-		var spaceState = World.Current!.World3D.DirectSpaceState;
-
-		for (int i = 0; i < slideCount; i++)
-		{
-			KinematicCollision3D stepTest = CharBody3D.GetSlideCollision(i);
-			Vector3 n = stepTest.GetNormal();
-			Vector3 p = stepTest.GetPosition();
-
-			if (Mathf.Abs(n.Y) >= 0.01f)
-			{
-				continue;
-			}
-
-			if (!(p.Y - groundY < StepHeight))
-			{
-				continue;
-			}
-
-			float stepHeight = p.Y + StepHeight + 0.0001f;
-			Vector3 stepTestInvDir = new Vector3(-n.X, 0, -n.Z).Normalized();
-			Vector3 origin = new Vector3(p.X, stepHeight, p.Z) + (stepTestInvDir * stepSearchOvershoot);
-			Vector3 direction = Vector3.Down * StepHeight;
-
-			Dictionary result = spaceState.IntersectRay(new PhysicsRayQueryParameters3D()
-			{
-				From = origin,
-				To = origin + direction,
-				Exclude = [CharBody3D.GetRid()],
-				CollideWithAreas = false,
-				CollideWithBodies = true,
-			});
-
-			if (result.Count == 0)
-			{
-				continue;
-			}
-
-			Vector3 hitPos = result["position"].AsVector3();
-
-			Vector3 stepUpPoint = new Vector3(p.X, hitPos.Y + 0.01f, p.Z) + (stepTestInvDir * stepSearchOvershoot);
-			Vector3 stepUpPointOffset = stepUpPoint - new Vector3(p.X, groundY, p.Z);
-
-			CharBody3D.GlobalPosition += stepUpPointOffset;
-			CharBody3D.Velocity = desiredVelocity;
-
-			return true;
-		}
-
-		return false;
-	}
-
-	[ScriptMethod]
-	public virtual void Jump()
-	{
-		bool canJump = (CharBody3D.IsOnFloor() || (!_coyoteUsed && _timeSinceGrounded <= CoyoteTime)) && JumpPower > 0;
-		bool playJumpSound = false;
-		if (canJump)
-		{
-			_coyoteUsed = true;
-			CharacterVelocity.Y = JumpPower;
-			playJumpSound = true;
-		}
-		if (IsSitting)
-		{
-			playJumpSound = true;
-			Unsit();
-		}
-		if (playJumpSound && JumpSound != null && !JumpSound.Playing)
-		{
-			JumpSound?.Play();
-		}
-	}
-
-	[ScriptMethod]
-	public void Sit(Seat seat)
-	{
-		Rpc(nameof(NetSit), seat.NetworkedObjectID);
-	}
-
-	[ScriptMethod]
-	public void Unsit(bool addForce = true)
-	{
-		Rpc(nameof(NetJumpFromSeat));
-
-		// Reset rotation
-		Rotation = new(0, Rotation.Y, 0);
-
-		if (addForce)
-		{
-			Position += SeatOffset * 2;
-		}
-	}
-
-	[NetRpc(AuthorityMode.Server, TransferMode = TransferMode.Reliable, CallLocal = true)]
-	private async void NetSit(string seatID)
-	{
-		Seat? seat = (Seat?)await Root.WaitForNetObjectAsync(seatID);
-
-		if (seat != null)
-		{
-			InternalSit(seat);
-		}
-	}
-
-	private void InternalSit(Seat seat)
-	{
-		IsSitting = true;
-		OverrideNetworkTransform = true;
-		SittingIn = seat;
-		seat.Occupant = this;
-		seat.InvokeSat(this);
-		Character?.SetBlendValue(CharacterModel.CharacterModelBlendEnum.Sitting, 1);
-	}
-
-	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, CallLocal = true)]
-	private void NetJumpFromSeat()
-	{
-		if (IsSitting)
-		{
-			// Unsit the NPC
-			IsSitting = false;
-			OverrideNetworkTransform = false;
-
-			if (SittingIn != null)
-			{
-				SittingIn.Occupant = null;
-				SittingIn.InvokeVacated(this);
-				SittingIn = null;
-			}
-
-			Character?.SetBlendValue(CharacterModel.CharacterModelBlendEnum.Sitting, 0);
-		}
-	}
-
-	[ScriptMethod]
-	public void EquipTool(Tool tool)
-	{
-		if (IsDead) return;
-		// Check if tool is already held
-		if (HoldingTool != null)
-		{
-			if (this is Player plr)
-			{
-				plr.UnequipTool();
-			}
-			else
-			{
-				DropTool();
-			}
-		}
-
-		Rpc(nameof(NetEquipTool), tool.NetworkedObjectID);
-	}
-
-	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, CallLocal = true)]
-	private async void NetEquipTool(string networkID)
-	{
-		NetworkedObject? netObj = await Root.WaitForNetObjectAsync(networkID);
-
-		if (netObj == null) { return; }
-
-		Tool tool = (Tool)netObj;
-
-		if (tool != null)
-		{
-			HoldingTool = tool;
-
-			// If is authority, attach the tool
-			if (HasAuthority)
-			{
-				tool.Holder = this;
-				tool.Parent = this;
-			}
-
-			tool.InvokeEquipped();
-		}
-	}
-
-	/// <summary>
-	/// Attach tool to hand
-	/// </summary>
-	/// <param name="tool"></param>
-	private async void InternalAttachTool(Tool tool)
-	{
-		tool.Holder = this;
-
-		if (_toolRemoteTransform != null && Node.IsInstanceValid(_toolRemoteTransform))
-		{
-			_toolRemoteTransform.QueueFree();
-		}
-
-		_toolRemoteTransform = new()
-		{
-			UpdatePosition = true,
-			UpdateRotation = true,
-			UpdateScale = false
-		};
-
-		if (Character != null)
-		{
-			Dynamic attachment = Character.GetAttachment(CharacterModel.CharacterAttachmentEnum.HandRight);
-			attachment.GDNode.AddChild(_toolRemoteTransform, @internal: Node.InternalMode.Back);
-		}
-
-		// stick and stones
-		// this is needed because GetPath doesn't update when it entered tree
-		await Globals.Singleton.WaitFrame();
-		_toolRemoteTransform.Position = new Vector3(0, 0, 0);
-		_toolRemoteTransform.RotationDegrees = new Vector3(0, -90, -90);
-		_toolRemoteTransform.UpdateScale = false;
-		_toolRemoteTransform.RemotePath = _toolRemoteTransform.GetPathTo(tool.GDNode);
-	}
-
-	internal void InternalDetachTool()
-	{
-		if (_toolRemoteTransform != null && Node.IsInstanceValid(_toolRemoteTransform))
-		{
-			_toolRemoteTransform?.QueueFree();
-		}
-
-		Character?.SetBlendValue(CharacterModel.CharacterModelBlendEnum.ToolHoldRight, 0);
-	}
-
-	[ScriptMethod, ScriptLegacyMethod("DropTools")]
-	public void DropTool()
-	{
-		if (HoldingTool != null)
-		{
-			Tool tool = HoldingTool;
-			if (this is Player plr)
-			{
-				plr.UnequipTool();
-			}
-			Rpc(nameof(NetDropTool), tool.NetworkedObjectID);
-		}
-	}
-
-	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, CallLocal = true)]
-	private async void NetDropTool(string id)
-	{
-		Tool? tool = (Tool?)await Root.WaitForNetObjectAsync(id);
-
-		if (tool != null && tool.Droppable)
-		{
-			tool.Reparent(Root.Environment);
-			InternalDetachTool();
-			tool.InvokeDropped();
-		}
-	}
-
-	[ScriptMethod]
-	public void LoadAppearance(int userID)
-	{
-		if (Character is PolytorianModel ptm)
-		{
-			ptm.LoadAppearance(userID, Root.PlayerDefaults.LoadAppearanceTools);
-		}
-	}
-
-	[ScriptMethod]
-	public void ClearAppearance()
-	{
-		if (Character is PolytorianModel ptm)
-		{
-			ptm.ClearAppearance();
-		}
-	}
 
 	[ScriptMethod]
 	public void SetNavDestination(Vector3 pos)
@@ -1105,34 +380,5 @@ public partial class NPC : Physical
 		_navAgent = null;
 		NavDestinationReached = true;
 		NavFinished.Invoke();
-	}
-
-	[ScriptMethod]
-	public void Respawn()
-	{
-		Health = MaxHealth;
-		Anchored = false;
-		IsDead = false;
-
-		if (Character is PolytorianModel ptmodel)
-		{
-			ptmodel.StopRagdoll();
-		}
-		CharacterVelocity = Vector3.Zero;
-
-		OverrideCanCollide = false;
-		UpdateCollision();
-	}
-
-	[ScriptMethod]
-	public void TakeDamage(float dmg)
-	{
-		Health -= dmg;
-	}
-
-	[ScriptMethod]
-	public void Heal(float amount)
-	{
-		Health += amount;
 	}
 }

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -399,12 +399,12 @@ public partial class NPC : Instance
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.NametagVisibleRadius instead"), CloneIgnore]
-	public float? NametagVisibleRadius
+	public float NametagVisibleRadius
 	{
 		get => Character?.NametagVisibleRadius ?? 0;
 		set
 		{
-			Character?.NametagVisibleRadius = value ?? 0;
+			Character?.NametagVisibleRadius = value;
 		}
 	}
 
@@ -734,34 +734,34 @@ public partial class NPC : Instance
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.SprintSpeed instead"), CloneIgnore]
-	public float? SprintSpeed
+	public float SprintSpeed
 	{
 		get => Character?.SprintSpeed ?? 0;
 		set
 		{
-			Character?.SprintSpeed = value ?? 0;
+			Character?.SprintSpeed = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Stamina instead"), CloneIgnore]
-	public float? Stamina
+	public float Stamina
 	{
 		get => Character?.Stamina ?? 0;
 		set
 		{
-			Character?.Stamina = value ?? 0;
+			Character?.Stamina = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.MaxStamina instead"), CloneIgnore]
-	public float? MaxStamina
+	public float MaxStamina
 	{
 		get => Character?.MaxStamina ?? 0;
 		set
 		{
-			Character?.MaxStamina = value ?? 0;
+			Character?.MaxStamina = value;
 		}
 	}
 
@@ -778,23 +778,23 @@ public partial class NPC : Instance
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.StaminaRegen instead"), CloneIgnore]
-	public float? StaminaRegen
+	public float StaminaRegen
 	{
 		get => Character?.StaminaRegen ?? 0;
 		set
 		{
-			Character?.StaminaRegen = value ?? 0;
+			Character?.StaminaRegen = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.StaminaBurn instead"), CloneIgnore]
-	public float? StaminaBurn
+	public float StaminaBurn
 	{
 		get => Character?.StaminaBurn ?? 0;
 		set
 		{
-			Character?.StaminaBurn = value ?? 0;
+			Character?.StaminaBurn = value;
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -184,10 +184,36 @@ public partial class NPC : Instance
 		}
 		set
 		{
-			_character?._controller = null;
+			bool isServer = Root.Network.IsServer;
+			CharacterModel? oldChar = Character;
+			if (isServer)
+			{
+				if (this is Player plr)
+				{
+					oldChar?.SetNetworkAuthority(null);
+					oldChar?.SetNetworkAuthority(1, true);
+					value?.SetNetworkAuthority(plr);
+					value?.SetNetworkAuthority(plr.PeerID, true);
+					value?.SetPhysicsProcess(true);
+				}
+				else if (((value?.NetworkAuthority ?? 1) != 1))
+				{
+					value?.SetNetworkAuthority(null);
+					value?.SetNetworkAuthority(1, true);
+				}
+			}
+			Character?._controller = null;
+			Character?.OnPropertyChanged();
 			_character = value;
-			value?._controller = this;
 			OnPropertyChanged();
+			value?.Controller?._character = null;
+			value?.Controller?.OnPropertyChanged();
+			value?._controller = this;
+			value?.OnPropertyChanged();
+			if (this is Player mplr)
+			{
+				mplr.OnCharacterChange(oldChar);
+			}
 		}
 	}
 
@@ -248,7 +274,7 @@ public partial class NPC : Instance
 
 		if (walkTarget.HasValue)
 		{
-			Vector3 velo = Character.GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Character.Position.Y });
+			Vector3 velo = Character!.GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Character.Position.Y });
 			Character.CharacterVelocity = new(velo.X * Character.WalkSpeed, Character.CharacterVelocity.Y, velo.Z * Character.WalkSpeed);
 			Character.GDNode3D.GlobalRotationDegrees = new Vector3(Character.Rotation.X, Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Character.Rotation.Y), Mathf.Atan2(Character.CharacterVelocity.X, Character.CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, BodyRotateLerp))), Character.Rotation.Z);
 
@@ -263,7 +289,7 @@ public partial class NPC : Instance
 		}
 		else if (this is not Player || playerNPCOverride)
 		{
-			Character.CharacterVelocity = new(0, Character.CharacterVelocity.Y, 0);
+			Character!.CharacterVelocity = new(0, Character.CharacterVelocity.Y, 0);
 		}
 
 		if (!isOnFloor)
@@ -273,8 +299,8 @@ public partial class NPC : Instance
 
 		if (this is not Player || playerNPCOverride)
 		{
-			Character.SetState(finalState);
-			Character.SetAnimSpeed(animSpeed);
+			Character!.SetState(finalState);
+			Character!.SetAnimSpeed(animSpeed);
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -456,17 +456,23 @@ public partial class NPC : Instance
 	}
 
 
-	[ScriptMethod, Attributes.Obsolete("Use Character.LoadAppearance() instead")]
+	[ScriptMethod, Attributes.Obsolete("Use Character.LoadAppearance() instead, only if it's a PolytorianModel")]
 	public void LoadAppearance(int value)
 	{
-		Character?.LoadAppearance(value);
+		if (Character is PolytorianModel ptm)
+		{
+			ptm.LoadAppearance();
+		}
 	}
 
 
-	[ScriptMethod, Attributes.Obsolete("Use Character.ClearAppearance() instead")]
+	[ScriptMethod, Attributes.Obsolete("Use Character.ClearAppearance() instead, only if it's a PolytorianModel")]
 	public void ClearAppearance()
 	{
-		Character?.ClearAppearance();
+		if (Character is PolytorianModel ptm)
+		{
+			ptm.ClearAppearance();
+		}
 	}
 
 

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -161,92 +161,92 @@ public partial class NPC : Instance
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.SeatOffset instead"), CloneIgnore]
-	public int SeatOffset
+	public Vector3 SeatOffset
 	{
-		get => Character?.SeatOffset ?? Vector3.Zero
+		get => Character?.SeatOffset ?? Vector3.Zero;
 		set
 		{
-			Character?.SeatOffset = value
+			Character?.SeatOffset = value;
 		}
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Health instead"), CloneIgnore]
 	public float Health
 	{
-		get => Character?.Health ?? 0
+		get => Character?.Health ?? 0;
 		set
 		{
-			Character?.Health = value
+			Character?.Health = value;
 		}
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.MaxHealth instead"), CloneIgnore]
 	public float MaxHealth
 	{
-		get => Character?.MaxHealth ?? 0
+		get => Character?.MaxHealth ?? 0;
 		set
 		{
-			Character?.MaxHealth = value
+			Character?.MaxHealth = value;
 		}
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.JumpPower instead"), CloneIgnore]
 	public float JumpPower
 	{
-		get => Character?.JumpPower ?? 0
+		get => Character?.JumpPower ?? 0;
 		set
 		{
-			Character?.JumpPower = value
+			Character?.JumpPower = value;
 		}
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.WalkSpeed instead"), CloneIgnore]
 	public float WalkSpeed
 	{
-		get => Character?.WalkSpeed ?? 0
+		get => Character?.WalkSpeed ?? 0;
 		set
 		{
-			Character?.WalkSpeed = value
+			Character?.WalkSpeed = value;
 		}
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.JumpSound instead"), CloneIgnore]
 	public Sound? JumpSound
 	{
-		get => Character?.JumpSound
+		get => Character?.JumpSound;
 		set
 		{
-			Character?.JumpSound = value
+			Character?.JumpSound = value;
 		}
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsDead instead"), CloneIgnore]
 	public bool IsDead
 	{
-		get => Character?.IsDead ?? true
+		get => Character?.IsDead ?? true;
 		set
 		{
-			Character?.IsDead = value
+			Character?.IsDead = value;
 		}
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.SittingIn instead"), CloneIgnore]
 	public Seat? SittingIn
 	{
-		get => Character?.SittingIn
+		get => Character?.SittingIn;
 		set
 		{
-			Character?.SittingIn = value
+			Character?.SittingIn = value;
 		}
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.HoldingTool instead"), CloneIgnore]
 	public Tool? HoldingTool
 	{
-		get => Character?.HoldingTool
+		get => Character?.HoldingTool;
 		set
 		{
-			Character?.HoldingTool = value
+			Character?.HoldingTool = value;
 		}
 	}
 
@@ -257,7 +257,7 @@ public partial class NPC : Instance
 	}
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.Unsit() instead")]
-	public void Unsit(bool? value)
+	public void Unsit(bool value = true)
 	{
 		Character?.Unsit(value);
 	}
@@ -319,31 +319,31 @@ public partial class NPC : Instance
 	}
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.AddForce() instead")]
-	public void AddForce(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
+	public void AddForce(Vector3 force, Physical.ForceModeEnum mode = Physical.ForceModeEnum.Force)
 	{
 		Character?.AddForce(force, mode);
 	}
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.AddTorque() instead")]
-	public void AddTorque(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
+	public void AddTorque(Vector3 force, Physical.ForceModeEnum mode = Physical.ForceModeEnum.Force)
 	{
 		Character?.AddTorque(force, mode);
 	}
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.AddForceAtPosition() instead")]
-	public void AddForceAtPosition(Vector3 force, Vector3 position, ForceModeEnum mode = ForceModeEnum.Force)
+	public void AddForceAtPosition(Vector3 force, Vector3 position, Physical.ForceModeEnum mode = Physical.ForceModeEnum.Force)
 	{
 		Character?.AddForceAtPosition(force, position, mode);
 	}
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.AddRelativeForce() instead")]
-	public void AddRelativeForce(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
+	public void AddRelativeForce(Vector3 force, Physical.ForceModeEnum mode = Physical.ForceModeEnum.Force)
 	{
 		Character?.AddRelativeForce(force, mode);
 	}
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.AddRelativeTorque() instead")]
-	public void AddRelativeTorque(Vector3 torque, ForceModeEnum mode = ForceModeEnum.Force)
+	public void AddRelativeTorque(Vector3 torque, Physical.ForceModeEnum mode = Physical.ForceModeEnum.Force)
 	{
 		Character?.AddRelativeTorque(torque, mode);
 	}
@@ -382,7 +382,7 @@ public partial class NPC : Instance
 		get => Character?.UseNametag ?? false;
 		set
 		{
-			Character?.UseNametag = value
+			Character?.UseNametag = value ?? false;
 		}
 	}
 
@@ -393,7 +393,7 @@ public partial class NPC : Instance
 		get => Character?.NametagOffset ?? Vector3.Zero;
 		set
 		{
-			Character?.NametagOffset = value
+			Character?.NametagOffset = value ?? Vector3.Zero;
 		}
 	}
 
@@ -404,7 +404,7 @@ public partial class NPC : Instance
 		get => Character?.NametagVisibleRadius ?? 0;
 		set
 		{
-			Character?.NametagVisibleRadius = value
+			Character?.NametagVisibleRadius = value ?? 0;
 		}
 	}
 
@@ -415,42 +415,17 @@ public partial class NPC : Instance
 		get => Character?.IsSitting ?? false;
 		set
 		{
-			Character?.IsSitting = value
-		}
-	}
-
-
-	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Position instead"), CloneIgnore]
-	public Vector3? Position
-	{
-		get => Character?.Position ?? Vector3.Zero;
-		set
-		{
-			Character?.Position = value
+			Character?.IsSitting = value ?? false;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsOnGround instead"), CloneIgnore]
-	public bool? IsOnGround
-	{
-		get => Character?.IsOnGround ?? false;
-		set
-		{
-			Character?.IsOnGround = value
-		}
-	}
+	public bool IsOnGround => Character?.IsOnGround ?? false;
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsOnCeiling instead"), CloneIgnore]
-	public bool? IsOnCeiling
-	{
-		get => Character?.IsOnCeiling ?? false;
-		set
-		{
-			Character?.IsOnCeiling = value
-		}
-	}
+	public bool IsOnCeiling => Character?.IsOnCeiling ?? false;
 
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.Kill() instead")]
@@ -538,7 +513,7 @@ public partial class NPC : Instance
 		get => Character?.Anchored ?? false;
 		set
 		{
-			Character?.Anchored = value
+			Character?.Anchored = value ?? false;
 		}
 	}
 
@@ -549,7 +524,7 @@ public partial class NPC : Instance
 		get => Character?.CanCollide ?? false;
 		set
 		{
-			Character?.CanCollide = value
+			Character?.CanCollide = value ?? false;
 		}
 	}
 
@@ -560,7 +535,7 @@ public partial class NPC : Instance
 		get => Character?.Velocity ?? Vector3.Zero;
 		set
 		{
-			Character?.Velocity = value
+			Character?.Velocity = value ?? Vector3.Zero;
 		}
 	}
 
@@ -571,7 +546,7 @@ public partial class NPC : Instance
 		get => Character?.AngularVelocity ?? Vector3.Zero;
 		set
 		{
-			Character?.AngularVelocity = value
+			Character?.AngularVelocity = value ?? Vector3.Zero;
 		}
 	}
 
@@ -636,7 +611,7 @@ public partial class NPC : Instance
 		get => Character?.Position ?? Vector3.Zero;
 		set
 		{
-			Character?.Position = value
+			Character?.Position = value ?? Vector3.Zero;
 		}
 	}
 
@@ -647,7 +622,7 @@ public partial class NPC : Instance
 		get => Character?.Rotation ?? Vector3.Zero;
 		set
 		{
-			Character?.Rotation = value
+			Character?.Rotation = value ?? Vector3.Zero;
 		}
 	}
 
@@ -658,7 +633,7 @@ public partial class NPC : Instance
 		get => Character?.Size ?? Vector3.Zero;
 		set
 		{
-			Character?.Size = value
+			Character?.Size = value ?? Vector3.Zero;
 		}
 	}
 
@@ -669,7 +644,7 @@ public partial class NPC : Instance
 		get => Character?.LocalPosition ?? Vector3.Zero;
 		set
 		{
-			Character?.LocalPosition = value
+			Character?.LocalPosition = value ?? Vector3.Zero;
 		}
 	}
 
@@ -680,7 +655,7 @@ public partial class NPC : Instance
 		get => Character?.LocalRotation ?? Vector3.Zero;
 		set
 		{
-			Character?.LocalRotation = value
+			Character?.LocalRotation = value ?? Vector3.Zero;
 		}
 	}
 
@@ -691,7 +666,7 @@ public partial class NPC : Instance
 		get => Character?.LocalSize ?? Vector3.Zero;
 		set
 		{
-			Character?.LocalSize = value
+			Character?.LocalSize = value ?? Vector3.Zero;
 		}
 	}
 
@@ -699,10 +674,10 @@ public partial class NPC : Instance
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Quaternion instead"), CloneIgnore]
 	public Quaternion? Quaternion
 	{
-		get => Character?.Quaternion ?? Quaternion.Identity;
+		get => Character?.Quaternion ?? Godot.Quaternion.Identity;
 		set
 		{
-			Character?.Quaternion = value
+			Character?.Quaternion = value ?? Godot.Quaternion.Identity;
 		}
 	}
 
@@ -710,21 +685,10 @@ public partial class NPC : Instance
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalQuaternion instead"), CloneIgnore]
 	public Quaternion? LocalQuaternion
 	{
-		get => Character?.LocalQuaternion ?? Quaternion.Identity;
+		get => Character?.LocalQuaternion ?? Godot.Quaternion.Identity;
 		set
 		{
-			Character?.LocalQuaternion = value
-		}
-	}
-
-
-	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalQuaternion instead"), CloneIgnore]
-	public Quaternion? LocalQuaternion
-	{
-		get => Character?.LocalQuaternion ?? Quaternion.Identity;
-		set
-		{
-			Character?.LocalQuaternion = value
+			Character?.LocalQuaternion = value ?? Godot.Quaternion.Identity;
 		}
 	}
 
@@ -735,10 +699,15 @@ public partial class NPC : Instance
 		get => Character?.Locked ?? false;
 		set
 		{
-			Character?.Locked = value
+			Character?.Locked = value ?? false;
 		}
 	}
 
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsClimbing instead"), CloneIgnore]
+	public bool IsClimbing => Character?.IsClimbing ?? false;
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.ClimbingTruss instead"), CloneIgnore]
+	public Truss? ClimbingTruss => Character?.ClimbingTruss;
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.Translate() instead")]
 	public void Translate(Vector3 value)
@@ -751,6 +720,129 @@ public partial class NPC : Instance
 	public void Rotate(Vector3 value)
 	{
 		Character?.Rotate(value);
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.CanMove instead"), CloneIgnore]
+	public bool? CanMove
+	{
+		get => Character?.CanMove ?? false;
+		set
+		{
+			Character?.CanMove = value ?? false;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.SprintSpeed instead"), CloneIgnore]
+	public float? SprintSpeed
+	{
+		get => Character?.SprintSpeed ?? 0;
+		set
+		{
+			Character?.SprintSpeed = value ?? 0;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Stamina instead"), CloneIgnore]
+	public float? Stamina
+	{
+		get => Character?.Stamina ?? 0;
+		set
+		{
+			Character?.Stamina = value ?? 0;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.MaxStamina instead"), CloneIgnore]
+	public float? MaxStamina
+	{
+		get => Character?.MaxStamina ?? 0;
+		set
+		{
+			Character?.MaxStamina = value ?? 0;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.UseStamina instead"), CloneIgnore]
+	public bool? UseStamina
+	{
+		get => Character?.UseStamina ?? false;
+		set
+		{
+			Character?.UseStamina = value ?? false;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.StaminaRegen instead"), CloneIgnore]
+	public float? StaminaRegen
+	{
+		get => Character?.StaminaRegen ?? 0;
+		set
+		{
+			Character?.StaminaRegen = value ?? 0;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.StaminaBurn instead"), CloneIgnore]
+	public float? StaminaBurn
+	{
+		get => Character?.StaminaBurn ?? 0;
+		set
+		{
+			Character?.StaminaBurn = value ?? 0;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.KeepInventory instead"), CloneIgnore]
+	public bool? KeepInventory
+	{
+		get => Character?.KeepInventory ?? false;
+		set
+		{
+			Character?.KeepInventory = value ?? false;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.UseHeadTurning instead"), CloneIgnore]
+	public bool? UseHeadTurning
+	{
+		get => Character?.UseHeadTurning ?? false;
+		set
+		{
+			Character?.UseHeadTurning = value ?? false;
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.AllowAnimationWhileMoving instead"), CloneIgnore]
+	public bool? AllowAnimationWhileMoving
+	{
+		get => Character?.AllowAnimationWhileMoving ?? false;
+		set
+		{
+			Character?.AllowAnimationWhileMoving = value ?? false;
+		}
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.UnequipTool() instead")]
+	public void UnequipTool()
+	{
+		Character?.UnequipTool();
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.ResetAppearance() instead")]
+	public void ResetAppearance()
+	{
+		Character?.ResetAppearance();
 	}
 
 	[Editable, ScriptProperty]

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -160,6 +160,56 @@ public partial class NPC : Instance
 		}
 	}
 
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.SeatOffset instead"), CloneIgnore]
+	public int SeatOffset
+	{
+		get => Character?.SeatOffset ?? Vector3.Zero
+		set
+		{
+			Character?.SeatOffset = value
+		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Health instead"), CloneIgnore]
+	public float Health
+	{
+		get => Character?.Health ?? 9
+		set
+		{
+			Character?.Health = value
+		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.MaxHealth instead"), CloneIgnore]
+	public float MaxHealth
+	{
+		get => Character?.MaxHealth ?? 9
+		set
+		{
+			Character?.MaxHealth = value
+		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.JumpPower instead"), CloneIgnore]
+	public float JumpPower
+	{
+		get => Character?.JumpPower ?? 9
+		set
+		{
+			Character?.JumpPower = value
+		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.WalkSpeed instead"), CloneIgnore]
+	public float WalkSpeed
+	{
+		get => Character?.WalkSpeed ?? 9
+		set
+		{
+			Character?.WalkSpeed = value
+		}
+	}
+
 	[Editable, ScriptProperty]
 	public string DisplayName
 	{

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -18,7 +18,7 @@ public partial class NPC : Instance
 {
 	private const float NavigationDistance = 2f;
 	public const float BodyRotateLerp = 10f;
-	private CharacterModel? _character;
+	internal CharacterModel? _character;
 	private Dynamic? _moveTarget;
 
 	private string _displayName = "";
@@ -184,9 +184,9 @@ public partial class NPC : Instance
 		}
 		set
 		{
-			_character?.Controller = null;
+			_character?._controller = null;
 			_character = value;
-			value?.Controller = this;
+			value?._controller = this;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -1040,14 +1040,6 @@ public partial class NPC : Instance
 		base.Ready();
 	}
 
-#if CREATOR
-	public override void CreatorInserted()
-	{
-		Root.Insert.InitializeDefaultNPC(this);
-		base.CreatorInserted();
-	}
-#endif
-
 	[ScriptMethod]
 	public void SetNavDestination(Vector3 pos)
 	{

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -173,7 +173,7 @@ public partial class NPC : Instance
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Health instead"), CloneIgnore]
 	public float Health
 	{
-		get => Character?.Health ?? 9
+		get => Character?.Health ?? 0
 		set
 		{
 			Character?.Health = value
@@ -183,7 +183,7 @@ public partial class NPC : Instance
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.MaxHealth instead"), CloneIgnore]
 	public float MaxHealth
 	{
-		get => Character?.MaxHealth ?? 9
+		get => Character?.MaxHealth ?? 0
 		set
 		{
 			Character?.MaxHealth = value
@@ -193,7 +193,7 @@ public partial class NPC : Instance
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.JumpPower instead"), CloneIgnore]
 	public float JumpPower
 	{
-		get => Character?.JumpPower ?? 9
+		get => Character?.JumpPower ?? 0
 		set
 		{
 			Character?.JumpPower = value
@@ -203,11 +203,554 @@ public partial class NPC : Instance
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.WalkSpeed instead"), CloneIgnore]
 	public float WalkSpeed
 	{
-		get => Character?.WalkSpeed ?? 9
+		get => Character?.WalkSpeed ?? 0
 		set
 		{
 			Character?.WalkSpeed = value
 		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.JumpSound instead"), CloneIgnore]
+	public Sound? JumpSound
+	{
+		get => Character?.JumpSound
+		set
+		{
+			Character?.JumpSound = value
+		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsDead instead"), CloneIgnore]
+	public bool IsDead
+	{
+		get => Character?.IsDead ?? true
+		set
+		{
+			Character?.IsDead = value
+		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.SittingIn instead"), CloneIgnore]
+	public Seat? SittingIn
+	{
+		get => Character?.SittingIn
+		set
+		{
+			Character?.SittingIn = value
+		}
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.HoldingTool instead"), CloneIgnore]
+	public Tool? HoldingTool
+	{
+		get => Character?.HoldingTool
+		set
+		{
+			Character?.HoldingTool = value
+		}
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.Sit() instead")]
+	public void Sit(Seat value)
+	{
+		Character?.Sit(value);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.Unsit() instead")]
+	public void Unsit(bool? value)
+	{
+		Character?.Unsit(value);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.EquipTool() instead")]
+	public void EquipTool(Tool value)
+	{
+		Character?.EquipTool(value);
+	}
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.CollisionLayers instead")]
+	public uint CollisionLayers
+	{
+		get => Character?.CollisionLayers ?? 0;
+		set
+		{
+			Character?.CollisionLayers = value;
+		}
+	}
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.CollisionMask instead")]
+	public uint CollisionMask
+	{
+		get => Character?.CollisionMask ?? 0;
+		set
+		{
+			Character?.CollisionMask = value;
+		}
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.SetCollisionLayer() instead")]
+	public void SetCollisionLayer(int layer, bool value)
+	{
+		Character?.SetCollisionLayer(layer, value);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.SetCollisionMask() instead")]
+	public void SetCollisionMask(int layer, bool value)
+	{
+		Character?.SetCollisionMask(layer, value);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.GetCollisionLayer() instead")]
+	public bool GetCollisionLayer(int layer)
+	{
+		return Character?.GetCollisionLayer(layer) ?? false;
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.GetCollisionMask() instead")]
+	public bool GetCollisionMask(int layer)
+	{
+		return Character?.GetCollisionMask(layer) ?? false;
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.GetTouching() instead")]
+	public Physical[] GetTouching()
+	{
+		return Character?.GetTouching() ?? [];
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.AddForce() instead")]
+	public void AddForce(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
+	{
+		Character?.AddForce(force, mode);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.AddTorque() instead")]
+	public void AddTorque(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
+	{
+		Character?.AddTorque(force, mode);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.AddForceAtPosition() instead")]
+	public void AddForceAtPosition(Vector3 force, Vector3 position, ForceModeEnum mode = ForceModeEnum.Force)
+	{
+		Character?.AddForceAtPosition(force, position, mode);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.AddRelativeForce() instead")]
+	public void AddRelativeForce(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
+	{
+		Character?.AddRelativeForce(force, mode);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.AddRelativeTorque() instead")]
+	public void AddRelativeTorque(Vector3 torque, ForceModeEnum mode = ForceModeEnum.Force)
+	{
+		Character?.AddRelativeTorque(torque, mode);
+	}
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.Forward instead")] public Vector3 Forward => Character?.Forward ?? Vector3.Zero;
+	[ScriptProperty, Attributes.Obsolete("Use Character.Right instead")] public Vector3 Right => Character?.Right ?? Vector3.Zero;
+	[ScriptProperty, Attributes.Obsolete("Use Character.Up instead")] public Vector3 Up => Character?.Up ?? Vector3.Zero;
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.GetBounds() instead")]
+	public Aabb? GetBounds()
+	{
+		return Character?.GetBounds();
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.RotateAround() instead")]
+	public void RotateAround(Vector3 point, Vector3 axis, float angle)
+	{
+		Character?.RotateAround(point, axis, angle);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.LookAt() instead")]
+	public void LookAt(object target)
+	{
+		Character?.LookAt(target);
+	}
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.LookAt() instead")]
+	public void LookAt(object target, Vector3 up)
+	{
+		Character?.LookAt(target, up);
+	}
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.UseNametag instead"), CloneIgnore]
+	public bool? UseNametag
+	{
+		get => Character?.UseNametag ?? false;
+		set
+		{
+			Character?.UseNametag = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.NametagOffset instead"), CloneIgnore]
+	public Vector3? NametagOffset
+	{
+		get => Character?.NametagOffset ?? Vector3.Zero;
+		set
+		{
+			Character?.NametagOffset = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.NametagVisibleRadius instead"), CloneIgnore]
+	public float? NametagVisibleRadius
+	{
+		get => Character?.NametagVisibleRadius ?? 0;
+		set
+		{
+			Character?.NametagVisibleRadius = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsSitting instead"), CloneIgnore]
+	public bool? IsSitting
+	{
+		get => Character?.IsSitting ?? false;
+		set
+		{
+			Character?.IsSitting = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Position instead"), CloneIgnore]
+	public Vector3? Position
+	{
+		get => Character?.Position ?? Vector3.Zero;
+		set
+		{
+			Character?.Position = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsOnGround instead"), CloneIgnore]
+	public bool? IsOnGround
+	{
+		get => Character?.IsOnGround ?? false;
+		set
+		{
+			Character?.IsOnGround = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsOnCeiling instead"), CloneIgnore]
+	public bool? IsOnCeiling
+	{
+		get => Character?.IsOnCeiling ?? false;
+		set
+		{
+			Character?.IsOnCeiling = value
+		}
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.Kill() instead")]
+	public void Kill()
+	{
+		Character?.Kill();
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.TryStepUp() instead")]
+	public bool? TryStepUp()
+	{
+		return Character?.TryStepUp() ?? false;
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.Jump() instead")]
+	public void Jump()
+	{
+		Character?.Jump();
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.DropTool() instead")]
+	public void DropTool()
+	{
+		Character?.DropTool();
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.LoadAppearance() instead")]
+	public void LoadAppearance(int value)
+	{
+		Character?.LoadAppearance(value);
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.ClearAppearance() instead")]
+	public void ClearAppearance()
+	{
+		Character?.ClearAppearance();
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.Respawn() instead")]
+	public void Respawn()
+	{
+		Character?.Respawn();
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.TakeDamage() instead")]
+	public void TakeDamage(float value)
+	{
+		Character?.TakeDamage(value);
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.Heal() instead")]
+	public void Heal(float value)
+	{
+		Character?.Heal(value);
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.Died instead")]
+	public PTSignal? Died
+	{
+		get => Character?.Died;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.Landed instead")]
+	public PTSignal? Landed
+	{
+		get => Character?.Landed;
+		private set;
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Anchored instead"), CloneIgnore]
+	public bool? Anchored
+	{
+		get => Character?.Anchored ?? false;
+		set
+		{
+			Character?.Anchored = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.CanCollide instead"), CloneIgnore]
+	public bool? CanCollide
+	{
+		get => Character?.CanCollide ?? false;
+		set
+		{
+			Character?.CanCollide = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Velocity instead"), CloneIgnore]
+	public Vector3? Velocity
+	{
+		get => Character?.Velocity ?? Vector3.Zero;
+		set
+		{
+			Character?.Velocity = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.AngularVelocity instead"), CloneIgnore]
+	public Vector3? AngularVelocity
+	{
+		get => Character?.AngularVelocity ?? Vector3.Zero;
+		set
+		{
+			Character?.AngularVelocity = value
+		}
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.MovePosition() instead")]
+	public void MovePosition(Vector3 value)
+	{
+		Character?.MovePosition(value);
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.MoveRotation() instead")]
+	public void MoveRotation(Vector3 value)
+	{
+		Character?.MoveRotation(value);
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.Touched instead")]
+	public PTSignal<Physical>? Touched
+	{
+		get => Character?.Touched;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.TouchEnded instead")]
+	public PTSignal<Physical>? TouchEnded
+	{
+		get => Character?.TouchEnded;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.Clicked instead")]
+	public PTSignal<Player>? Clicked
+	{
+		get => Character?.Clicked;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.MouseEnter instead")]
+	public PTSignal? MouseEnter
+	{
+		get => Character?.MouseEnter;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.MouseExit instead")]
+	public PTSignal? MouseExit
+	{
+		get => Character?.MouseExit;
+		private set;
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Position instead"), CloneIgnore]
+	public Vector3? Position
+	{
+		get => Character?.Position ?? Vector3.Zero;
+		set
+		{
+			Character?.Position = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Rotation instead"), CloneIgnore]
+	public Vector3? Rotation
+	{
+		get => Character?.Rotation ?? Vector3.Zero;
+		set
+		{
+			Character?.Rotation = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Size instead"), CloneIgnore]
+	public Vector3? Size
+	{
+		get => Character?.Size ?? Vector3.Zero;
+		set
+		{
+			Character?.Size = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalPosition instead"), CloneIgnore]
+	public Vector3? LocalPosition
+	{
+		get => Character?.LocalPosition ?? Vector3.Zero;
+		set
+		{
+			Character?.LocalPosition = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalRotation instead"), CloneIgnore]
+	public Vector3? LocalRotation
+	{
+		get => Character?.LocalRotation ?? Vector3.Zero;
+		set
+		{
+			Character?.LocalRotation = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalSize instead"), CloneIgnore]
+	public Vector3? LocalSize
+	{
+		get => Character?.LocalSize ?? Vector3.Zero;
+		set
+		{
+			Character?.LocalSize = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Quaternion instead"), CloneIgnore]
+	public Quaternion? Quaternion
+	{
+		get => Character?.Quaternion ?? Quaternion.Identity;
+		set
+		{
+			Character?.Quaternion = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalQuaternion instead"), CloneIgnore]
+	public Quaternion? LocalQuaternion
+	{
+		get => Character?.LocalQuaternion ?? Quaternion.Identity;
+		set
+		{
+			Character?.LocalQuaternion = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalQuaternion instead"), CloneIgnore]
+	public Quaternion? LocalQuaternion
+	{
+		get => Character?.LocalQuaternion ?? Quaternion.Identity;
+		set
+		{
+			Character?.LocalQuaternion = value
+		}
+	}
+
+
+	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Locked instead"), CloneIgnore]
+	public bool? Locked
+	{
+		get => Character?.Locked ?? false;
+		set
+		{
+			Character?.Locked = value
+		}
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.Translate() instead")]
+	public void Translate(Vector3 value)
+	{
+		Character?.Translate(value);
+	}
+
+
+	[ScriptMethod, Attributes.Obsolete("Use Character.Rotate() instead")]
+	public void Rotate(Vector3 value)
+	{
+		Character?.Rotate(value);
 	}
 
 	[Editable, ScriptProperty]

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -377,23 +377,23 @@ public partial class NPC : Instance
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.UseNametag instead"), CloneIgnore]
-	public bool? UseNametag
+	public bool UseNametag
 	{
 		get => Character?.UseNametag ?? false;
 		set
 		{
-			Character?.UseNametag = value ?? false;
+			Character?.UseNametag = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.NametagOffset instead"), CloneIgnore]
-	public Vector3? NametagOffset
+	public Vector3 NametagOffset
 	{
 		get => Character?.NametagOffset ?? Vector3.Zero;
 		set
 		{
-			Character?.NametagOffset = value ?? Vector3.Zero;
+			Character?.NametagOffset = value;
 		}
 	}
 
@@ -410,12 +410,12 @@ public partial class NPC : Instance
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.IsSitting instead"), CloneIgnore]
-	public bool? IsSitting
+	public bool IsSitting
 	{
 		get => Character?.IsSitting ?? false;
 		set
 		{
-			Character?.IsSitting = value ?? false;
+			Character?.IsSitting = value;
 		}
 	}
 
@@ -436,7 +436,7 @@ public partial class NPC : Instance
 
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.TryStepUp() instead")]
-	public bool? TryStepUp()
+	public bool TryStepUp()
 	{
 		return Character?.TryStepUp() ?? false;
 	}
@@ -508,45 +508,45 @@ public partial class NPC : Instance
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Anchored instead"), CloneIgnore]
-	public bool? Anchored
+	public bool Anchored
 	{
 		get => Character?.Anchored ?? false;
 		set
 		{
-			Character?.Anchored = value ?? false;
+			Character?.Anchored = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.CanCollide instead"), CloneIgnore]
-	public bool? CanCollide
+	public bool CanCollide
 	{
 		get => Character?.CanCollide ?? false;
 		set
 		{
-			Character?.CanCollide = value ?? false;
+			Character?.CanCollide = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Velocity instead"), CloneIgnore]
-	public Vector3? Velocity
+	public Vector3 Velocity
 	{
 		get => Character?.Velocity ?? Vector3.Zero;
 		set
 		{
-			Character?.Velocity = value ?? Vector3.Zero;
+			Character?.Velocity = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.AngularVelocity instead"), CloneIgnore]
-	public Vector3? AngularVelocity
+	public Vector3 AngularVelocity
 	{
 		get => Character?.AngularVelocity ?? Vector3.Zero;
 		set
 		{
-			Character?.AngularVelocity = value ?? Vector3.Zero;
+			Character?.AngularVelocity = value;
 		}
 	}
 
@@ -606,100 +606,100 @@ public partial class NPC : Instance
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Position instead"), CloneIgnore]
-	public Vector3? Position
+	public Vector3 Position
 	{
 		get => Character?.Position ?? Vector3.Zero;
 		set
 		{
-			Character?.Position = value ?? Vector3.Zero;
+			Character?.Position = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Rotation instead"), CloneIgnore]
-	public Vector3? Rotation
+	public Vector3 Rotation
 	{
 		get => Character?.Rotation ?? Vector3.Zero;
 		set
 		{
-			Character?.Rotation = value ?? Vector3.Zero;
+			Character?.Rotation = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Size instead"), CloneIgnore]
-	public Vector3? Size
+	public Vector3 Size
 	{
 		get => Character?.Size ?? Vector3.Zero;
 		set
 		{
-			Character?.Size = value ?? Vector3.Zero;
+			Character?.Size = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalPosition instead"), CloneIgnore]
-	public Vector3? LocalPosition
+	public Vector3 LocalPosition
 	{
 		get => Character?.LocalPosition ?? Vector3.Zero;
 		set
 		{
-			Character?.LocalPosition = value ?? Vector3.Zero;
+			Character?.LocalPosition = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalRotation instead"), CloneIgnore]
-	public Vector3? LocalRotation
+	public Vector3 LocalRotation
 	{
 		get => Character?.LocalRotation ?? Vector3.Zero;
 		set
 		{
-			Character?.LocalRotation = value ?? Vector3.Zero;
+			Character?.LocalRotation = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalSize instead"), CloneIgnore]
-	public Vector3? LocalSize
+	public Vector3 LocalSize
 	{
 		get => Character?.LocalSize ?? Vector3.Zero;
 		set
 		{
-			Character?.LocalSize = value ?? Vector3.Zero;
+			Character?.LocalSize = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Quaternion instead"), CloneIgnore]
-	public Quaternion? Quaternion
+	public Quaternion Quaternion
 	{
 		get => Character?.Quaternion ?? Godot.Quaternion.Identity;
 		set
 		{
-			Character?.Quaternion = value ?? Godot.Quaternion.Identity;
+			Character?.Quaternion = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.LocalQuaternion instead"), CloneIgnore]
-	public Quaternion? LocalQuaternion
+	public Quaternion LocalQuaternion
 	{
 		get => Character?.LocalQuaternion ?? Godot.Quaternion.Identity;
 		set
 		{
-			Character?.LocalQuaternion = value ?? Godot.Quaternion.Identity;
+			Character?.LocalQuaternion = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Locked instead"), CloneIgnore]
-	public bool? Locked
+	public bool Locked
 	{
 		get => Character?.Locked ?? false;
 		set
 		{
-			Character?.Locked = value ?? false;
+			Character?.Locked = value;
 		}
 	}
 
@@ -723,12 +723,12 @@ public partial class NPC : Instance
 	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.CanMove instead"), CloneIgnore]
-	public bool? CanMove
+	public bool CanMove
 	{
 		get => Character?.CanMove ?? false;
 		set
 		{
-			Character?.CanMove = value ?? false;
+			Character?.CanMove = value;
 		}
 	}
 
@@ -767,12 +767,12 @@ public partial class NPC : Instance
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.UseStamina instead"), CloneIgnore]
-	public bool? UseStamina
+	public bool UseStamina
 	{
 		get => Character?.UseStamina ?? false;
 		set
 		{
-			Character?.UseStamina = value ?? false;
+			Character?.UseStamina = value;
 		}
 	}
 
@@ -800,34 +800,34 @@ public partial class NPC : Instance
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.KeepInventory instead"), CloneIgnore]
-	public bool? KeepInventory
+	public bool KeepInventory
 	{
 		get => Character?.KeepInventory ?? false;
 		set
 		{
-			Character?.KeepInventory = value ?? false;
+			Character?.KeepInventory = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.UseHeadTurning instead"), CloneIgnore]
-	public bool? UseHeadTurning
+	public bool UseHeadTurning
 	{
 		get => Character?.UseHeadTurning ?? false;
 		set
 		{
-			Character?.UseHeadTurning = value ?? false;
+			Character?.UseHeadTurning = value;
 		}
 	}
 
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.AllowAnimationWhileMoving instead"), CloneIgnore]
-	public bool? AllowAnimationWhileMoving
+	public bool AllowAnimationWhileMoving
 	{
 		get => Character?.AllowAnimationWhileMoving ?? false;
 		set
 		{
-			Character?.AllowAnimationWhileMoving = value ?? false;
+			Character?.AllowAnimationWhileMoving = value;
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -212,7 +212,7 @@ public partial class NPC : Instance
 			value?.OnPropertyChanged();
 			if (this is Player mplr)
 			{
-				mplr.OnCharacterChange(oldChar);
+				mplr.CharacterChanged.Invoke(oldChar);
 			}
 		}
 	}

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -215,11 +215,6 @@ public partial class NPC : Instance
 	[ScriptProperty]
 	public PTSignal NavFinished { get; private set; } = new();
 
-	public override Node CreateGDNode()
-	{
-		return new CharacterBody3D() { FloorMaxAngle = Mathf.DegToRad(80f) };
-	}
-
 	public override void PreDelete()
 	{
 		_navAgent?.NavigationFinished -= OnNavFinished;

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -24,6 +24,7 @@ public partial class NPC : Instance
 	private string _displayName = "";
 	private Node3D? _navAgentContainer;
 	private NavigationAgent3D? _navAgent;
+	private Physical? _grabbing;
 
 	// Pending properties to apply to character
 	private Color? _pendingHeadColor;
@@ -33,6 +34,27 @@ public partial class NPC : Instance
 	private Color? _pendingLeftLegColor;
 	private Color? _pendingRightLegColor;
 	private int? _pendingFaceID;
+
+	[ScriptProperty]
+	public PTSignal<Physical> Grabbed { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal<Physical> Ungrabbed { get; private set; } = new();
+
+	[ScriptProperty]
+	public Physical? Grabbing => _grabbing;
+
+	public void SetGrabbing(Physical phy)
+	{
+		_grabbing = phy;
+		Grabbed.Invoke(phy);
+	}
+
+	public void ReleaseGrabbing()
+	{
+		Ungrabbed.Invoke(_grabbing);
+		_grabbing = null;
+	}
 
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Apply them to Character"), CloneIgnore]
 	public Color HeadColor

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -477,7 +477,7 @@ public partial class NPC : Instance
 
 
 	[ScriptMethod, Attributes.Obsolete("Use Character.Respawn() instead")]
-	public void Respawn()
+	public virtual void Respawn()
 	{
 		Character?.Respawn();
 	}

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -611,6 +611,46 @@ public partial class NPC : Instance
 	}
 
 
+	[ScriptProperty, Attributes.Obsolete("Use Character.HealthChanged instead")]
+	public PTSignal<float, float> HealthChanged
+	{
+		get => Character?.HealthChanged;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.Jumped instead")]
+	public PTSignal Jumped
+	{
+		get => Character?.Jumped;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.LeftGround instead")]
+	public PTSignal LeftGround
+	{
+		get => Character?.LeftGround;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.Seated instead")]
+	public PTSignal<Seat> Seated
+	{
+		get => Character?.Seated;
+		private set;
+	}
+
+
+	[ScriptProperty, Attributes.Obsolete("Use Character.Unseated instead")]
+	public PTSignal<Seat> Unseated
+	{
+		get => Character?.Unseated;
+		private set;
+	}
+
+
 	[Editable, ScriptProperty, NoSync, Attributes.Obsolete("Use Character.Position instead"), CloneIgnore]
 	public Vector3 Position
 	{

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -1071,7 +1071,7 @@ public partial class NetworkedObject : IScriptObject
 		return IsA(XmlFormat.ConvertClassName(className));
 	}
 
-	protected void OnPropertyChanged([CallerMemberName] string propertyName = "", bool syncToNet = true)
+	internal void OnPropertyChanged([CallerMemberName] string propertyName = "", bool syncToNet = true)
 	{
 		PropertyChanged.Invoke(propertyName);
 		if (syncToNet)

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -211,7 +211,7 @@ public partial class Physical : Dynamic
 		if (Root != null && Root.Network != null)
 		{
 			// Ignore player
-			if (Root.Network.IsServer && !(this is CharacterModel charModel && charModel._controller is Player))
+			if (Root.Network.IsServer && !(this is CharacterModel charModel && charModel.Controller is Player))
 			{
 				AutoUpdateNetTransform = finalVal;
 			}
@@ -241,7 +241,7 @@ public partial class Physical : Dynamic
 		if (!IsHidden)
 		{
 			// Stop collision override if player's not ready
-			if (this is CharacterModel charModel && charModel._controller is Player plr && !plr.IsReady) { return; }
+			if (this is CharacterModel charModel && charModel.Controller is Player plr && !plr.IsReady) { return; }
 			bool setTo = !_canCollide;
 
 #if CREATOR
@@ -298,7 +298,7 @@ public partial class Physical : Dynamic
 
 			if (this is CharacterModel charModel)
 			{
-				NPC? controller = charModel._controller;
+				NPC? controller = charModel.Controller;
 				if (controller is Player plr)
 				{
 					charModel.LastVelocity = _velocity;
@@ -1091,7 +1091,7 @@ public partial class Physical : Dynamic
 		NetworkedObject? hit = Root.GetNetObjectFromID(touchedBy);
 
 		// Only allow player hit invoke
-		if (hit != null && hit is CharacterModel charModel && charModel._controller is Player plr)
+		if (hit != null && hit is CharacterModel charModel && charModel.Controller is Player plr)
 		{
 			InternalInvokeClicked(plr);
 		}
@@ -1105,7 +1105,7 @@ public partial class Physical : Dynamic
 			// Ignore dead characters, their position could be inaccurate
 			if (charModel.IsDead) return;
 			// Ignore player that's not ready
-			if (charModel._controller is Player plr && !plr.IsReady) return;
+			if (charModel.Controller is Player plr && !plr.IsReady) return;
 		}
 
 		if (_touchContacts.TryGetValue(physical, out int count))
@@ -1121,7 +1121,7 @@ public partial class Physical : Dynamic
 	private void InternalInvokeTouchEnded(Physical physical)
 	{
 		// Ignore player that's not ready
-		if (physical is CharacterModel charModel && charModel._controller is Player plr && !plr.IsReady) return;
+		if (physical is CharacterModel charModel && charModel.Controller is Player plr && !plr.IsReady) return;
 
 		if (!_touchContacts.TryGetValue(physical, out int count))
 			return;

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -211,7 +211,7 @@ public partial class Physical : Dynamic
 		if (Root != null && Root.Network != null)
 		{
 			// Ignore player
-			if (Root.Network.IsServer && this is not Player)
+			if (Root.Network.IsServer && !(this is CharacterModel charModel && charModel._controller is Player))
 			{
 				AutoUpdateNetTransform = finalVal;
 			}
@@ -241,7 +241,7 @@ public partial class Physical : Dynamic
 		if (!IsHidden)
 		{
 			// Stop collision override if player's not ready
-			if (this is Player plr && !plr.IsReady) { return; }
+			if (this is CharacterModel charModel && charModel._controller is Player plr && !plr.IsReady) { return; }
 			bool setTo = !_canCollide;
 
 #if CREATOR
@@ -283,9 +283,9 @@ public partial class Physical : Dynamic
 	{
 		get
 		{
-			if (this is NPC npc)
+			if (this is CharacterModel charModel)
 			{
-				return npc.CharacterVelocity;
+				return charModel.CharacterVelocity;
 			}
 
 			return _velocity;
@@ -296,14 +296,17 @@ public partial class Physical : Dynamic
 
 			var setto = _velocity;
 
-			if (this is Player plr)
+			if (this is CharacterModel charModel)
 			{
-				plr.LastVelocity = _velocity;
-			}
-
-			if (this is NPC npc)
-			{
-				npc.CharacterVelocity = setto;
+				NPC? controller = charModel._controller;
+				if (controller is Player plr)
+				{
+					charModel.LastVelocity = _velocity;
+				}
+				else
+				{
+					charModel.CharacterVelocity = setto;
+				}
 			}
 
 			OnPropertyChanged();
@@ -1055,12 +1058,12 @@ public partial class Physical : Dynamic
 		NetworkedObject? hit = Root.GetNetObjectFromID(touchedBy);
 
 		// Only allow player hit invoke
-		if (hit != null && hit is Player plr && !plr.IsDead)
+		if (hit != null && hit is CharacterModel charModel && !charModel.IsDead)
 		{
 			// Ignore invalid touches (touches that are out of range)
-			if (!IsTouchedValid(plr)) return;
+			if (!IsTouchedValid(charModel)) return;
 
-			InternalInvokeTouched(plr);
+			InternalInvokeTouched(charModel);
 		}
 	}
 
@@ -1070,16 +1073,16 @@ public partial class Physical : Dynamic
 		NetworkedObject? hit = Root.GetNetObjectFromID(touchedBy);
 
 		// Only allow player hit invoke
-		if (hit != null && hit is Player plr)
+		if (hit != null && hit is CharacterModel charModel)
 		{
-			InternalInvokeTouchEnded(plr);
+			InternalInvokeTouchEnded(charModel);
 		}
 	}
 
-	private bool IsTouchedValid(Player plr)
+	private bool IsTouchedValid(CharacterModel charModel)
 	{
 		// Check if player position is in vaild range
-		return GetSelfBound().Grow(TouchedGapCheck).HasPoint(plr.GetGlobalPosition());
+		return GetSelfBound().Grow(TouchedGapCheck).HasPoint(charModel.GetGlobalPosition());
 	}
 
 	[NetRpc(AuthorityMode.Any, TransferMode = TransferMode.Reliable)]
@@ -1088,7 +1091,7 @@ public partial class Physical : Dynamic
 		NetworkedObject? hit = Root.GetNetObjectFromID(touchedBy);
 
 		// Only allow player hit invoke
-		if (hit != null && hit is Player plr)
+		if (hit != null && hit is CharacterModel charModel && charModel._controller is Player plr)
 		{
 			InternalInvokeClicked(plr);
 		}
@@ -1097,11 +1100,13 @@ public partial class Physical : Dynamic
 	private void InternalInvokeTouched(Physical physical)
 	{
 		if (physical == this) return;
-		// Ignore dead NPCs, their position could be inaccurate
-		if (physical is NPC npc && npc.IsDead) return;
-
-		// Ignore player that's not ready
-		if (physical is Player plr && !plr.IsReady) return;
+		if (physical is CharacterModel charModel)
+		{
+			// Ignore dead characters, their position could be inaccurate
+			if (charModel.IsDead) return;
+			// Ignore player that's not ready
+			if (charModel._controller is Player plr && !plr.IsReady) return;
+		}
 
 		if (_touchContacts.TryGetValue(physical, out int count))
 		{
@@ -1116,7 +1121,7 @@ public partial class Physical : Dynamic
 	private void InternalInvokeTouchEnded(Physical physical)
 	{
 		// Ignore player that's not ready
-		if (physical is Player plr && !plr.IsReady) return;
+		if (physical is CharacterModel charModel && charModel._controller is Player plr && !plr.IsReady) return;
 
 		if (!_touchContacts.TryGetValue(physical, out int count))
 			return;

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -25,7 +25,6 @@ namespace Polytoria.Datamodel;
 public sealed partial class Player : NPC
 {
 	private const double MaxAFKTime = 60 * 15;
-	private const float CameraHeight = 2f;
 	public const string CreatorHeadScene = "res://scenes/creator/livecollab/head.tscn";
 	public const string BadgeImageDirPath = "res://assets/textures/client/ui/playerlist/badges/";
 	private static readonly Dictionary<string, string> _badgePathCache = [];
@@ -337,14 +336,7 @@ public sealed partial class Player : NPC
 
 	private void UpdatePlayerCollision()
 	{
-		if (Root.Players.PlayerCollisionEnabled)
-		{
-			Character?.SetCollisionMask(2, true);
-		}
-		else
-		{
-			Character?.SetCollisionMask(2, false);
-		}
+		Character?.SetCollisionMask(2, Root.Players.PlayerCollisionEnabled);
 	}
 
 	public override void Process(double delta)
@@ -545,7 +537,6 @@ public sealed partial class Player : NPC
 		if (Root.PlayerDefaults.AutoCameraFollow && curcam.Mode == Camera.CameraModeEnum.Follow)
 		{
 			curcam.Parent = Character;
-			curcam.PositionOffset = new Vector3(0, CameraHeight, 0);
 		}
 
 		Camera? cam = Root.Environment.CurrentCamera;
@@ -750,15 +741,7 @@ public sealed partial class Player : NPC
 			(Root.PlayerDefaults.AutoCameraFollow || curcam.Parent == oldChar)
 		)
 		{
-			if (Character is null)
-			{
-				curcam.Parent = Root.Environment;
-			}
-			else
-			{
-				curcam.Parent = Character;
-				curcam.PositionOffset = new Vector3(0, CameraHeight, 0);
-			}
+			curcam.Parent = Character is null ? Root.Environment : Character.Head;
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -353,14 +353,6 @@ public sealed partial class Player : NPC
 		}
 	}
 
-	private void UpdateCamera(double delta)
-	{
-		if (Root.Environment.CurrentCamera?.Mode != Camera.CameraModeEnum.Scripted)
-		{
-			Root.Environment.CurrentCamera?.CameraProcess(delta);
-		}
-	}
-
 	private void AfkTick(double delta)
 	{
 		// Disable AFK kick if local test

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -50,7 +50,7 @@ public sealed partial class Player : NPC
 	internal bool teleporting = false;
 
 	private RemoteTransform3D _remoteCamAttach = null!;
-	internal Dynamic CamAttach = null!;
+	private bool _useRemoteCamAttach = false;
 	private Physical? _mouseHoveringOn;
 
 	public Vector3 DefaultSpawnLocation = new(0, 5, 0);
@@ -321,11 +321,24 @@ public sealed partial class Player : NPC
 
 	private void SetCamRemoteAttachEnabled(bool enabled)
 	{
+		if (enabled == _useRemoteCamAttach) return;
+
 		_remoteCamAttach.UpdatePosition = enabled;
 		_remoteCamAttach.UpdateRotation = enabled;
-		if (enabled == false)
+		_useRemoteCamAttach = enabled;
+
+		Camera curcam = Root.Environment.CurrentCamera;
+		if (enabled)
 		{
-			CamAttach.LocalPosition = new Vector3(0, CameraHeight, 0);
+			if (curcam.Parent == Character && curcam.Mode == Camera.CameraModeEnum.Follow) curcam.Parent = Root.Environment;
+		}
+		else
+		{
+			if (Root.PlayerDefaults.AutoCameraFollow && curcam.Mode == Camera.CameraModeEnum.Follow)
+			{
+				curcam.Parent = Character;
+				curcam.PositionOffset = new Vector3(0, CameraHeight, 0);
+			}
 		}
 	}
 
@@ -441,7 +454,7 @@ public sealed partial class Player : NPC
 		Camera? cam = Root.Environment.CurrentCamera;
 
 		// Apply camera modifier if enabled
-		if (Character.UseHeadTurning && cam != null && cam.Mode == Camera.CameraModeEnum.Follow && cam.Target == CamAttach)
+		if (Character.UseHeadTurning && cam != null && cam.Mode == Camera.CameraModeEnum.Follow && cam.Parent == Character)
 		{
 			Character.ApplyCameraModifier(cam);
 		}
@@ -540,6 +553,7 @@ public sealed partial class Player : NPC
 	{
 		if (!Root.Network.IsServer) return; // Respawn on server only
 
+		if (!Root.PlayerDefaults.AutomaticSpawn) return;
 		// Respawn on client
 		await Globals.Singleton.WaitAsync(RespawnTime);
 		Respawn();
@@ -551,20 +565,21 @@ public sealed partial class Player : NPC
 		IsLocal = true;
 		SendPing();
 
-		CamAttach = Globals.LoadInstance<Dynamic>(Root);
-		CamAttach.Name = "CameraAttachment";
-		CamAttach.Parent = Character;
-		CamAttach.AutoUpdateNetTransform = false;
+		Camera curcam = Root.Environment.CurrentCamera;
+		if (Root.PlayerDefaults.AutoCameraFollow && curcam.Mode == Camera.CameraModeEnum.Follow)
+		{
+			curcam.Parent = Character;
+			curcam.PositionOffset = new Vector3(0, CameraHeight, 0);
+		}
 
 		_remoteCamAttach = new();
 		Character?.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).GDNode.AddChild(_remoteCamAttach, @internal: Node.InternalMode.Back);
-		_remoteCamAttach.RemotePath = _remoteCamAttach.GetPathTo(CamAttach.GDNode3D);
+		_remoteCamAttach.RemotePath = _remoteCamAttach.GetPathTo(curcam.GDNode3D);
 
 		SetCamRemoteAttachEnabled(false);
 
 		Camera? cam = Root.Environment.CurrentCamera;
 		if (cam == null) return;
-		cam.Target = CamAttach;
 		cam.UpdateCameraSelf = false;
 		cam.FirstPersonEntered.Connect(OnFirstPersonEntered);
 		cam.FirstPersonExited.Connect(OnFirstPersonExited);
@@ -652,7 +667,13 @@ public sealed partial class Player : NPC
 	[ScriptMethod]
 	public void Respawn()
 	{
+		CharacterModel? oldChar = Character;
 		InternalSpawn();
+		if (Root.PlayerDefaults.CorpseDecay && !Root.PlayerDefaults.ReuseCharacter)
+		{
+			// Remove would-be corpse
+			oldChar?.Destroy();
+		}
 	}
 
 	private void InternalSpawn()
@@ -681,6 +702,12 @@ public sealed partial class Player : NPC
 					}
 				}
 			}
+		}
+		else
+		{
+			CharacterModel oldChar = Character;
+			Character = null;
+			Character = oldChar;
 		}
 
 		// Apply playerdefaults
@@ -754,29 +781,6 @@ public sealed partial class Player : NPC
 		Character?.OverrideCanCollide = false;
 		Character?.UpdateCollision();
 		Character?.IsDead = false;
-
-		UpdateCamAttach();
-	}
-
-	internal void UpdateCamAttach()
-	{
-		if (CamAttach == null || CamAttach.DeletedAsChild)
-		{
-			CamAttach = Globals.LoadInstance<Dynamic>(Root);
-			CamAttach.Name = "CameraAttachment";
-			CamAttach.AutoUpdateNetTransform = false;
-		}
-		CamAttach.Parent = Character;
-		CamAttach.LocalPosition = new Vector3(0, CameraHeight, 0);
-
-		if (_remoteCamAttach == null)
-		{
-			_remoteCamAttach = new();
-		}
-		Character?.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).GDNode.AddChild(_remoteCamAttach, @internal: Node.InternalMode.Back);
-		_remoteCamAttach.RemotePath = _remoteCamAttach.GetPathTo(CamAttach.GDNode3D);
-
-		SetCamRemoteAttachEnabled(false);
 	}
 
 	internal void OnCharacterChanged(CharacterModel? oldChar = null)
@@ -791,11 +795,31 @@ public sealed partial class Player : NPC
 			ptc.RagdollStarted.Connect(OnRagdollStarted);
 			ptc.RagdollStopped.Connect(OnRagdollStopped);
 		}
-		UpdateCamAttach();
 		oldChar?.AutoUpdateNetTransform = true;
 		// Disable auto update, this will be updated manually
 		Character?.AutoUpdateNetTransform = false;
 		UpdatePlayerCollision();
+
+		Camera curcam = Root.Environment.CurrentCamera;
+		if (
+			curcam.Mode == Camera.CameraModeEnum.Follow &&
+			(Root.PlayerDefaults.AutoCameraFollow || curcam.Parent == oldChar)
+		)
+		{
+			if (Character is null)
+			{
+				curcam.Parent = Root.Environment;
+			}
+			else
+			{
+				curcam.Parent = Character;
+				curcam.PositionOffset = new Vector3(0, CameraHeight, 0);
+			}
+		}
+		if (Character is null)
+		{
+			OnPlayerDied();
+		}
 	}
 
 	internal void AdminKick()

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -297,14 +297,6 @@ public sealed partial class Player : NPC
 
 		Root.Input.GodotInputEvent += OnInput;
 
-		if (Root.SessionType == World.SessionTypeEnum.Client && Root.Network.IsServer && Character is not null)
-		{
-			Inventory inventory = Globals.LoadInstance<Inventory>(Root);
-			inventory.NameOverride = "Inventory";
-			inventory.NetworkParent = this;
-			Character.Inventory = inventory;
-		}
-
 		Root.Players.PropertyChanged.Connect(OnPlayersPropertyChanged);
 	}
 
@@ -665,20 +657,32 @@ public sealed partial class Player : NPC
 
 	private void InternalSpawn()
 	{
-		// Clear & Re-copy inventory
-		CopyInventory();
-
 		// Create character if absent
-		if (Character is null)
+		if (Character is null || !Root.PlayerDefaults.ReuseCharacter)
 		{
 			// Insert default character on client
 			if (Root.Network.NetworkMode == NetworkService.NetworkModeEnum.Client)
 			{
-				Root.Insert.InitializeDefaultNPC(this);
+				Character = Root.Insert.DefaultNPCCharacter();
+				// Create inventory
+				if (Root.Network.IsServer && Character is not null)
+				{
+					Inventory? inv = this.FindChild<Inventory>("Inventory");
+					if (inv is null)
+					{
+						Inventory inventory = Globals.LoadInstance<Inventory>(Root);
+						inventory.NameOverride = "Inventory";
+						inventory.NetworkParent = this;
+						Character.Inventory = inventory;
+					}
+					else
+					{
+						Character.Inventory = inv;
+					}
+				}
 			}
-
-			CharacterChanged.Invoke();
 		}
+
 		// Apply playerdefaults
 		if (Character != null)
 		{
@@ -707,6 +711,9 @@ public sealed partial class Player : NPC
 		RespawnTime = Root.PlayerDefaults.RespawnTime;
 		AutoLoadAppearance = Root.PlayerDefaults.AutoLoadAppearance;
 		MovementMode = Root.PlayerDefaults.MovementMode;
+
+		// Clear & Re-copy inventory
+		CopyInventory();
 
 		Rpc(nameof(NetRespawned));
 	}
@@ -760,6 +767,7 @@ public sealed partial class Player : NPC
 			CamAttach.AutoUpdateNetTransform = false;
 		}
 		CamAttach.Parent = Character;
+		CamAttach.LocalPosition = new Vector3(0, CameraHeight, 0);
 
 		if (_remoteCamAttach == null)
 		{

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -422,7 +422,7 @@ public sealed partial class Player : NPC
 		Camera? cam = Root.Environment.CurrentCamera;
 
 		// Apply camera modifier if enabled
-		if (Character.UseHeadTurning && cam != null && cam.Mode == Camera.CameraModeEnum.Follow && cam.Parent == Character)
+		if (Character.UseHeadTurning && cam != null && cam.Mode == Camera.CameraModeEnum.Follow && cam.Target == Character)
 		{
 			Character.ApplyCameraModifier(cam);
 		}
@@ -536,7 +536,7 @@ public sealed partial class Player : NPC
 		Camera curcam = Root.Environment.CurrentCamera;
 		if (Root.PlayerDefaults.AutoCameraFollow && curcam.Mode == Camera.CameraModeEnum.Follow)
 		{
-			curcam.Parent = Character;
+			curcam.Target = Character;
 		}
 
 		Camera? cam = Root.Environment.CurrentCamera;
@@ -737,10 +737,10 @@ public sealed partial class Player : NPC
 		Camera curcam = Root.Environment.CurrentCamera;
 		if (
 			curcam.Mode == Camera.CameraModeEnum.Follow &&
-			(Root.PlayerDefaults.AutoCameraFollow || curcam.Parent == oldChar)
+			(Root.PlayerDefaults.AutoCameraFollow || curcam.Target == oldChar)
 		)
 		{
-			curcam.Parent = Character is null ? Root.Environment : Character.Head;
+			curcam.Target = Character?.Head;
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -760,10 +760,6 @@ public sealed partial class Player : NPC
 				curcam.PositionOffset = new Vector3(0, CameraHeight, 0);
 			}
 		}
-		if (Character is null)
-		{
-			OnPlayerDied();
-		}
 	}
 
 	internal void AdminKick()

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -48,7 +48,6 @@ public sealed partial class Player : NPC
 
 	internal bool teleporting = false;
 
-	private bool _useRemoteCamAttach = false;
 	private Physical? _mouseHoveringOn;
 
 	public Vector3 DefaultSpawnLocation = new(0, 5, 0);
@@ -516,12 +515,6 @@ public sealed partial class Player : NPC
 		IsLocal = true;
 		SendPing();
 
-		Camera curcam = Root.Environment.CurrentCamera;
-		if (Root.PlayerDefaults.AutoCameraFollow && curcam.Mode == Camera.CameraModeEnum.Follow)
-		{
-			curcam.Target = Character;
-		}
-
 		Camera? cam = Root.Environment.CurrentCamera;
 		if (cam == null) return;
 		cam.FirstPersonEntered.Connect(OnFirstPersonEntered);
@@ -717,13 +710,10 @@ public sealed partial class Player : NPC
 		Character?.AutoUpdateNetTransform = false;
 		UpdatePlayerCollision();
 
-		Camera curcam = Root.Environment.CurrentCamera;
-		if (
-			curcam.Mode == Camera.CameraModeEnum.Follow &&
-			(Root.PlayerDefaults.AutoCameraFollow || curcam.Target == oldChar)
-		)
+		Camera? curcam = Root.Environment.CurrentCamera;
+		if (curcam is not null && curcam.Mode == Camera.CameraModeEnum.Follow && Root.PlayerDefaults.AutoCameraFollow)
 		{
-			curcam.Target = Character?.Head;
+			curcam.Target = Character?.Head ?? Character;
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -49,7 +49,6 @@ public sealed partial class Player : NPC
 
 	internal bool teleporting = false;
 
-	private RemoteTransform3D _remoteCamAttach = null!;
 	private bool _useRemoteCamAttach = false;
 	private Physical? _mouseHoveringOn;
 
@@ -319,29 +318,6 @@ public sealed partial class Player : NPC
 		Character?.GDNode3D?.Visible = _isReady;
 	}
 
-	private void SetCamRemoteAttachEnabled(bool enabled)
-	{
-		if (enabled == _useRemoteCamAttach) return;
-
-		_remoteCamAttach.UpdatePosition = enabled;
-		_remoteCamAttach.UpdateRotation = enabled;
-		_useRemoteCamAttach = enabled;
-
-		Camera curcam = Root.Environment.CurrentCamera;
-		if (enabled)
-		{
-			if (curcam.Parent == Character && curcam.Mode == Camera.CameraModeEnum.Follow) curcam.Parent = Root.Environment;
-		}
-		else
-		{
-			if (Root.PlayerDefaults.AutoCameraFollow && curcam.Mode == Camera.CameraModeEnum.Follow)
-			{
-				curcam.Parent = Character;
-				curcam.PositionOffset = new Vector3(0, CameraHeight, 0);
-			}
-		}
-	}
-
 	private void OnPlayersPropertyChanged(string propName)
 	{
 		if (propName == "PlayerCollisionEnabled")
@@ -572,12 +548,6 @@ public sealed partial class Player : NPC
 			curcam.PositionOffset = new Vector3(0, CameraHeight, 0);
 		}
 
-		_remoteCamAttach = new();
-		Character?.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).GDNode.AddChild(_remoteCamAttach, @internal: Node.InternalMode.Back);
-		_remoteCamAttach.RemotePath = _remoteCamAttach.GetPathTo(curcam.GDNode3D);
-
-		SetCamRemoteAttachEnabled(false);
-
 		Camera? cam = Root.Environment.CurrentCamera;
 		if (cam == null) return;
 		cam.UpdateCameraSelf = false;
@@ -587,12 +557,6 @@ public sealed partial class Player : NPC
 
 		// Disable auto update, this will be updated manually
 		Character?.AutoUpdateNetTransform = false;
-
-		if (Character is PolytorianModel ptc)
-		{
-			ptc.RagdollStarted.Connect(OnRagdollStarted);
-			ptc.RagdollStopped.Connect(OnRagdollStopped);
-		}
 	}
 
 	// Emit when this player is ready, fired for everyone
@@ -601,16 +565,6 @@ public sealed partial class Player : NPC
 		SetNetworkAuthority(PeerID);
 		UpdatePlayerCollision();
 		UpdatePlrReady();
-	}
-
-	private void OnRagdollStarted()
-	{
-		SetCamRemoteAttachEnabled(true);
-	}
-
-	private void OnRagdollStopped()
-	{
-		SetCamRemoteAttachEnabled(false);
 	}
 
 	internal void InvokeChatted(string msg)
@@ -785,16 +739,6 @@ public sealed partial class Player : NPC
 
 	internal void OnCharacterChanged(CharacterModel? oldChar = null)
 	{
-		if (oldChar is PolytorianModel optc)
-		{
-			optc.RagdollStarted.Disconnect(OnRagdollStarted);
-			optc.RagdollStopped.Disconnect(OnRagdollStopped);
-		}
-		if (Character is PolytorianModel ptc)
-		{
-			ptc.RagdollStarted.Connect(OnRagdollStarted);
-			ptc.RagdollStopped.Connect(OnRagdollStopped);
-		}
 		oldChar?.AutoUpdateNetTransform = true;
 		// Disable auto update, this will be updated manually
 		Character?.AutoUpdateNetTransform = false;

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -287,15 +287,19 @@ public sealed partial class Player : NPC
 
 	public override void Init()
 	{
+		// Force these to always be on
+		SetProcess(true);
+		SetPhysicsProcess(true);
 		base.Init();
 
 		Root.Input.GodotInputEvent += OnInput;
 
-		if (Root.SessionType == World.SessionTypeEnum.Client && Root.Network.IsServer)
+		if (Root.SessionType == World.SessionTypeEnum.Client && Root.Network.IsServer && Character is not null)
 		{
 			Inventory inventory = Globals.LoadInstance<Inventory>(Root);
 			inventory.NameOverride = "Inventory";
 			inventory.NetworkParent = this;
+			Character.Inventory = inventory;
 		}
 
 		Root.Players.PropertyChanged.Connect(OnPlayersPropertyChanged);
@@ -403,6 +407,10 @@ public sealed partial class Player : NPC
 	public override void PhysicsProcess(double delta)
 	{
 		if (Root.SessionType != World.SessionTypeEnum.Client || !IsLocal || !IsReady || Character == null) { return; }
+
+		// not ideal TODO: have this only run when needed
+		Character.SetPhysicsProcess(true);
+		Character.NetworkAuthority = Root.Network.LocalPeerID;
 
 		if (Character is PolytorianModel pt && pt.Ragdolling)
 		{
@@ -550,7 +558,7 @@ public sealed partial class Player : NPC
 
 		CamAttach = Globals.LoadInstance<Dynamic>(Root);
 		CamAttach.Name = "CameraAttachment";
-		CamAttach.Parent = this;
+		CamAttach.Parent = Character;
 		CamAttach.AutoUpdateNetTransform = false;
 
 		_remoteCamAttach = new();
@@ -695,7 +703,7 @@ public sealed partial class Player : NPC
 		if (Character == null) return;
 		if (Character.Inventory == null) return;
 
-		if (Character.KeepInventory)
+		if (!Character.KeepInventory)
 		{
 			foreach (Instance item in Character.Inventory.GetChildren())
 			{
@@ -724,6 +732,47 @@ public sealed partial class Player : NPC
 		Character?.OverrideCanCollide = false;
 		Character?.UpdateCollision();
 		Character?.IsDead = false;
+
+		UpdateCamAttach();
+	}
+
+	internal void UpdateCamAttach()
+	{
+		if (CamAttach == null || CamAttach.DeletedAsChild)
+		{
+			CamAttach = Globals.LoadInstance<Dynamic>(Root);
+			CamAttach.Name = "CameraAttachment";
+			CamAttach.AutoUpdateNetTransform = false;
+		}
+		CamAttach.Parent = Character;
+
+		if (_remoteCamAttach == null)
+		{
+			_remoteCamAttach = new();
+			Character?.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).GDNode.AddChild(_remoteCamAttach, @internal: Node.InternalMode.Back);
+		}
+		_remoteCamAttach.RemotePath = _remoteCamAttach.GetPathTo(CamAttach.GDNode3D);
+
+		SetCamRemoteAttachEnabled(false);
+	}
+
+	internal void OnCharacterChange(CharacterModel? oldChar = null)
+	{
+		if (oldChar is PolytorianModel optc)
+		{
+			optc.RagdollStarted.Disconnect(OnRagdollStarted);
+			optc.RagdollStopped.Disconnect(OnRagdollStopped);
+		}
+		if (Character is PolytorianModel ptc)
+		{
+			ptc.RagdollStarted.Connect(OnRagdollStarted);
+			ptc.RagdollStopped.Connect(OnRagdollStopped);
+		}
+		UpdateCamAttach();
+		oldChar?.AutoUpdateNetTransform = true;
+		// Disable auto update, this will be updated manually
+		Character?.AutoUpdateNetTransform = false;
+		UpdatePlayerCollision();
 	}
 
 	internal void AdminKick()

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -648,9 +648,9 @@ public sealed partial class Player : NPC
 			if (Character is PolytorianModel ptmodel)
 			{
 				ptmodel.StopRagdoll();
+				ptmodel.ResetAppearance();
 			}
 			Character.Velocity = Vector3.Zero;
-			Character.ResetAppearance();
 			Character.WrapToSpawnPoint();
 			Character.Health = Character.MaxHealth;
 			Character.Anchored = false;

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -27,31 +27,15 @@ public sealed partial class Player : NPC
 	private const double MaxAFKTime = 60 * 15;
 	private const float CameraHeight = 2f;
 	public const string CreatorHeadScene = "res://scenes/creator/livecollab/head.tscn";
-	public const string BubbleChatScene = "res://scenes/client/spatial/chat/bubble_chat.tscn";
 	public const string BadgeImageDirPath = "res://assets/textures/client/ui/playerlist/badges/";
 	private static readonly Dictionary<string, string> _badgePathCache = [];
 	private bool _isReady = false;
-	internal bool ClimbDebounce = false;
-	internal bool JustFinishedClimbing = false;
 	internal bool IsMoving = false;
 	internal IPlayerMovement? PlayerMovement;
-	internal Vector3 LastVelocity;
-	internal Vector3 ExternalVelocity;
 
 	private float _respawnTime = 5.0f;
-	private bool _canMove = true;
-	private float _sprintSpeed;
-	private float _stamina = 0;
-	private float _maxStamina = 3;
-	private bool _useStamina = true;
-	private float _staminaRegen = 1.2f;
-	private float _staminaBurn = 1.2f;
-	private bool _keepInventory = false;
-	private bool _useHeadTurning = false;
 	private int _userID;
-	private bool _useBubbleChat = true;
 	private bool _autoLoadAppearance = true;
-	private bool _allowAnimationWhileMoving = false;
 	private PlayerMovementModeEnum _movementMode = PlayerMovementModeEnum.Default;
 	private PlayerRotationModeEnum _rotationMode = PlayerRotationModeEnum.Automatic;
 	private Team? _team;
@@ -65,16 +49,15 @@ public sealed partial class Player : NPC
 
 	internal bool teleporting = false;
 
-	private BubbleChat _bubbleChat = null!;
 	private RemoteTransform3D _remoteCamAttach = null!;
 	internal Dynamic CamAttach = null!;
 	private Physical? _mouseHoveringOn;
 
-	private Vector3 DefaultSpawnLocation = new(0, 5, 0);
+	public Vector3 DefaultSpawnLocation = new(0, 5, 0);
 	internal event Action<APIUserInfo>? UserInfoReady;
 
 #if CREATOR
-	private bool _spawnedAtCreatorPos = false;
+	internal bool _spawnedAtCreatorPos = false;
 #endif
 
 	// internal peer ID
@@ -116,83 +99,6 @@ public sealed partial class Player : NPC
 	}
 
 	[Editable, ScriptProperty]
-	public bool CanMove
-	{
-		get => _canMove;
-		set
-		{
-			_canMove = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float SprintSpeed
-	{
-		get => _sprintSpeed;
-		set
-		{
-			_sprintSpeed = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty, SyncVar(Unreliable = true, AllowAuthorWrite = true)]
-	public float Stamina
-	{
-		get => _stamina;
-		set
-		{
-			_stamina = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float MaxStamina
-	{
-		get => _maxStamina;
-		set
-		{
-			_maxStamina = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty, ScriptLegacyProperty("StaminaEnabled")]
-	public bool UseStamina
-	{
-		get => _useStamina;
-		set
-		{
-			_useStamina = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float StaminaRegen
-	{
-		get => _staminaRegen;
-		set
-		{
-			_staminaRegen = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public float StaminaBurn
-	{
-		get => _staminaBurn;
-		set
-		{
-			_staminaBurn = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
 	public float RespawnTime
 	{
 		get => _respawnTime;
@@ -204,57 +110,12 @@ public sealed partial class Player : NPC
 	}
 
 	[Editable, ScriptProperty]
-	public bool KeepInventory
-	{
-		get => _keepInventory;
-		set
-		{
-			_keepInventory = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public bool UseHeadTurning
-	{
-		get => _useHeadTurning;
-		set
-		{
-			_useHeadTurning = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public bool UseBubbleChat
-	{
-		get => _useBubbleChat;
-		set
-		{
-			_useBubbleChat = value;
-			_bubbleChat?.Visible = _useBubbleChat;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
 	public bool AutoLoadAppearance
 	{
 		get => _autoLoadAppearance;
 		set
 		{
 			_autoLoadAppearance = value;
-			OnPropertyChanged();
-		}
-	}
-
-	[Editable, ScriptProperty]
-	public bool AllowAnimationWhileMoving
-	{
-		get => _allowAnimationWhileMoving;
-		set
-		{
-			_allowAnimationWhileMoving = value;
 			OnPropertyChanged();
 		}
 	}
@@ -385,12 +246,6 @@ public sealed partial class Player : NPC
 	[ScriptProperty]
 	public bool IsLocal { get; private set; }
 
-	[SyncVar(AllowAuthorWrite = true), ScriptProperty]
-	public bool IsClimbing { get; internal set; }
-
-	[SyncVar(AllowAuthorWrite = true), ScriptProperty]
-	public Truss? ClimbingTruss { get; internal set; }
-
 	[SyncVar(ServerOnly = true)]
 	public bool IsReady
 	{
@@ -412,11 +267,11 @@ public sealed partial class Player : NPC
 	[ScriptProperty, SyncVar]
 	public NetworkService.ClientPlatformEnum UserPlatform { get; internal set; }
 
-	[ScriptProperty]
-	public Inventory Inventory => FindChild<Inventory>("Inventory")!;
+	[Attributes.Obsolete("Use Character.Inventory instead"), ScriptProperty]
+	public Inventory? Inventory => Character?.Inventory;
 
-	[Attributes.Obsolete("Use Inventory instead"), ScriptProperty]
-	public Inventory Backpack => Inventory;
+	[Attributes.Obsolete("Use Character.Inventory instead"), ScriptProperty]
+	public Inventory? Backpack => Character?.Inventory;
 
 	// Emotes visible in emote wheel
 	public static readonly string[] EmoteWheelList =
@@ -429,39 +284,6 @@ public sealed partial class Player : NPC
 		"agree",
 		"disagree",
 	];
-
-	// List of all emotes
-	public static readonly string[] EmoteList =
-	[
-		"wave",
-		"dance",
-		"helicopter",
-		"sit",
-		"point",
-		"agree",
-		"disagree",
-		"scream",
-		"dance2",
-		"disappointed",
-	];
-
-	// Oneshot emotes
-	public static readonly string[] OneShotEmoteList =
-	[
-		"wave",
-		"point",
-		"disagree",
-		"agree",
-		"scream",
-		"disappointed",
-	];
-
-	public override void InitGDNode()
-	{
-		base.InitGDNode();
-		CollisionLayers = 2;
-		CollisionMask = 3;
-	}
 
 	public override void Init()
 	{
@@ -476,32 +298,14 @@ public sealed partial class Player : NPC
 			inventory.NetworkParent = this;
 		}
 
-		Died.Connect(OnPlayerDied);
 		Root.Players.PropertyChanged.Connect(OnPlayersPropertyChanged);
-
-		_bubbleChat = Globals.CreateInstanceFromScene<BubbleChat>(BubbleChatScene);
-		_bubbleChat.TargetPlayer = this;
-		_bubbleChat.Visible = _useBubbleChat;
-		GDNode.AddChild(_bubbleChat, @internal: Node.InternalMode.Back);
-		excludedBoundNodes.Add(_bubbleChat);
 	}
 
 	public override void PreDelete()
 	{
 		Root.Input.GodotInputEvent -= OnInput;
-		Died.Disconnect(OnPlayerDied);
 		PlayerMovement = null!;
 		base.PreDelete();
-	}
-
-	private void OnPlayerTouched(Physical obj)
-	{
-		obj.InvokeTouched(this);
-	}
-
-	private void OnPlayerTouchEnded(Physical obj)
-	{
-		obj.InvokeTouchEnded(this);
 	}
 
 	public override void Ready()
@@ -512,7 +316,7 @@ public sealed partial class Player : NPC
 
 	private void UpdatePlrReady()
 	{
-		SetCollisionDisabled(!_isReady);
+		Character?.SetCollisionDisabled(!_isReady);
 		GDNode3D?.Visible = _isReady;
 	}
 
@@ -547,11 +351,11 @@ public sealed partial class Player : NPC
 	{
 		if (Root.Players.PlayerCollisionEnabled)
 		{
-			SetCollisionMask(2, true);
+			Character?.SetCollisionMask(2, true);
 		}
 		else
 		{
-			SetCollisionMask(2, false);
+			Character?.SetCollisionMask(2, false);
 		}
 	}
 
@@ -565,13 +369,6 @@ public sealed partial class Player : NPC
 		if (!IsLocal)
 		{
 			UpdateTransformTick(delta);
-			if (Root.Network.IsServer && !IsSitting)
-			{
-				CharBody3D.Velocity = LastVelocity;
-				CharBody3D.MoveAndSlide();
-				LastVelocity = Vector3.Zero;
-				ApplyPushForce();
-			}
 		}
 
 		if (!IsLocal || !IsReady)
@@ -585,26 +382,6 @@ public sealed partial class Player : NPC
 		if (Root.Environment.CurrentCamera?.Mode != Camera.CameraModeEnum.Scripted)
 		{
 			Root.Environment.CurrentCamera?.CameraProcess(delta);
-		}
-	}
-
-	internal void AddStaminaTick(double delta)
-	{
-		if (!UseStamina) { return; }
-		Stamina += (float)(delta * StaminaRegen);
-		if (Stamina > MaxStamina)
-		{
-			Stamina = MaxStamina;
-		}
-	}
-
-	internal void RemoveStaminaTick(double delta)
-	{
-		if (!UseStamina) { return; }
-		Stamina -= (float)(delta * StaminaBurn);
-		if (Stamina < 0)
-		{
-			Stamina = 0;
 		}
 	}
 
@@ -627,25 +404,9 @@ public sealed partial class Player : NPC
 		}
 	}
 
-	internal void ApplyPushForce()
-	{
-		for (int i = 0; i < CharBody3D.GetSlideCollisionCount(); i++)
-		{
-			KinematicCollision3D collision = CharBody3D.GetSlideCollision(i);
-
-			if (GetNetObjFromProxy((Node)collision.GetCollider()) is Physical body)
-			{
-				// Push the rigidbody
-				body.ApplyForceFromPlayer(-collision.GetNormal());
-			}
-		}
-	}
-
 	public override void PhysicsProcess(double delta)
 	{
-		base.PhysicsProcess(delta);
-
-		if (Root.SessionType != World.SessionTypeEnum.Client || !IsLocal || !IsReady) { return; }
+		if (Root.SessionType != World.SessionTypeEnum.Client || !IsLocal || !IsReady || Character == null) { return; }
 
 		if (Character is PolytorianModel pt && pt.Ragdolling)
 		{
@@ -665,33 +426,7 @@ public sealed partial class Player : NPC
 			_mouseHoveringOn.MouseEnter.Invoke();
 		}
 
-		if (FootFwdRaycast.IsColliding())
-		{
-			Node collider = (Node)FootFwdRaycast.GetCollider();
-			if (collider != null && GetNetObjFromProxy(collider) is Truss truss)
-			{
-				if (!IsClimbing)
-				{
-					if (!ClimbDebounce)
-					{
-						ClimbingTruss = truss;
-						IsClimbing = true;
-						Character?.PlayClimb();
-					}
-
-				}
-			}
-			else
-			{
-				EndClimb();
-			}
-		}
-		else
-		{
-			EndClimb();
-		}
-
-		if (Anchored)
+		if (Character.Anchored)
 		{
 			// just in case it's anchored cuz ragdoll
 			if (Character is PolytorianModel pt2 && pt2.Ragdolling == false)
@@ -702,20 +437,14 @@ public sealed partial class Player : NPC
 			return;
 		}
 
+		if (Character.IsSitting) UpdateCamera(delta);
+
 		Camera? cam = Root.Environment.CurrentCamera;
 
 		// Apply camera modifier if enabled
-		if (UseHeadTurning && cam != null && cam.Mode == Camera.CameraModeEnum.Follow && cam.Target == CamAttach)
+		if (Character.UseHeadTurning && cam != null && cam.Mode == Camera.CameraModeEnum.Follow && cam.Target == CamAttach)
 		{
-			Character?.ApplyCameraModifier(cam);
-		}
-
-		if (IsSitting)
-		{
-			// Add stamina while sitting
-			AddStaminaTick(delta);
-			UpdateCamera(delta);
-			return;
+			Character.ApplyCameraModifier(cam);
 		}
 
 		if (PlayerMovement != null)
@@ -725,27 +454,18 @@ public sealed partial class Player : NPC
 		}
 		else
 		{
-			IsMoving = Velocity.Length() > 0.01f;
+			IsMoving = Character.Velocity.Length() > 0.01f;
 		}
 
 		// Stop animation on move
-		if (IsMoving && !AllowAnimationWhileMoving)
+		if (IsMoving && !Character.AllowAnimationWhileMoving)
 		{
-			Character?.Animator?.StopAnimation();
+			Character.Animator?.StopAnimation();
 		}
 
 		AfkTick(delta);
 
-		ApplyPushForce();
-	}
-
-	internal void EndClimb()
-	{
-		if (!IsClimbing) { return; }
-		IsClimbing = false;
-		JustFinishedClimbing = true;
-		ClimbingTruss = null;
-		Character?.SetAnimSpeed(1);
+		Character.ApplyPushForce();
 	}
 
 	private void SendPing()
@@ -787,23 +507,25 @@ public sealed partial class Player : NPC
 			if (Root.Environment.CurrentCamera?.Mode == Camera.CameraModeEnum.Free)
 			{
 				Root.Environment.CurrentCamera.Mode = Camera.CameraModeEnum.Follow;
-				CanMove = true;
+				Character?.CanMove = true;
 			}
 			else
 			{
 				Root.Environment.CurrentCamera?.Mode = Camera.CameraModeEnum.Free;
-				CanMove = false;
+				Character?.CanMove = false;
 			}
 		}
 
-		if (IsDead) { return; }
+		if (Character == null) return;
+
+		if (Character.IsDead) { return; }
 
 		if (@event.IsActionPressed("jump"))
 		{
 			// Ignore jump command if is custom
 			if (MovementMode == PlayerMovementModeEnum.Scripted) return;
-			if (!CanMove) return;
-			Jump();
+			if (!Character.CanMove) return;
+			Character.Jump();
 		}
 		else if (@event.IsActionPressed("toggle_sprint"))
 		{
@@ -811,17 +533,12 @@ public sealed partial class Player : NPC
 		}
 		else if (@event.IsActionPressed("drop_tool"))
 		{
-			DropTool();
+			Character?.DropTool();
 		}
 	}
 
-	private async void OnPlayerDied()
+	internal async void OnPlayerDied()
 	{
-		if (IsLocal)
-		{
-			UnequipTool();
-		}
-		Velocity = Vector3.Zero;
 		if (!Root.Network.IsServer) return; // Respawn on server only
 
 		// Respawn on client
@@ -853,11 +570,6 @@ public sealed partial class Player : NPC
 		cam.FirstPersonEntered.Connect(OnFirstPersonEntered);
 		cam.FirstPersonExited.Connect(OnFirstPersonExited);
 
-		// Listen to touch events
-		Touched.Connect(OnPlayerTouched);
-		TouchEnded.Connect(OnPlayerTouchEnded);
-		EnableCanTouch();
-
 		// Disable auto update, this will be updated manually
 		AutoUpdateNetTransform = false;
 
@@ -886,85 +598,23 @@ public sealed partial class Player : NPC
 		SetCamRemoteAttachEnabled(false);
 	}
 
-	internal void PlayEmote(string emoteName)
-	{
-		if (IsSitting || IsDead) return;
-		if (!EmoteList.Contains(emoteName)) return;
-		bool isOneShot = false;
-		if (OneShotEmoteList.Contains(emoteName))
-		{
-			isOneShot = true;
-		}
-
-		Character?.Animator?.StopAnimation();
-		Character?.Animator?.StopOneShotAnimation();
-
-		if (isOneShot)
-		{
-			Character?.Animator?.PlayOneShotAnimation("emote_" + emoteName);
-		}
-		else
-		{
-			Character?.Animator?.PlayAnimation("emote_" + emoteName);
-		}
-	}
-
 	internal void InvokeChatted(string msg)
 	{
 		Chatted.Invoke(msg);
-	}
-
-	public override void Jump()
-	{
-		base.Jump();
-		if (IsClimbing)
-		{
-			EndClimb();
-			ClimbDebounce = true;
-		}
 	}
 
 	private void OnFirstPersonEntered()
 	{
 		if (Character == null) return;
 		Character.GDNode3D.Visible = false;
-		_bubbleChat.Visible = false;
+		Character._bubbleChat.Visible = false;
 	}
 
 	private void OnFirstPersonExited()
 	{
 		if (Character == null) return;
 		Character.GDNode3D.Visible = true;
-		_bubbleChat.Visible = true;
-	}
-
-	public void WrapToSpawnPoint()
-	{
-		if (Root.Environment.SpawnPoints.Count > 0)
-		{
-			Entity spawnpoint = ArrayUtils.GetRandom(Root.Environment.SpawnPoints);
-			Position = spawnpoint.Position + new Vector3(0, spawnpoint.Size.Y + 2.0f, 0);
-			Rotation = new(0, spawnpoint.Rotation.Y, 0);
-		}
-		else
-		{
-			Position = DefaultSpawnLocation;
-			Rotation = new(0, 0, 0);
-		}
-
-		// Spawn at custom position
-#if CREATOR
-		if (Root.Entry != null && Root.Entry.DebugSpawnPos != null)
-		{
-			if (!_spawnedAtCreatorPos)
-			{
-				_spawnedAtCreatorPos = true;
-				Position = Root.Entry.DebugSpawnPos.Value;
-				Rotation = Vector3.Zero;
-			}
-		}
-#endif
-		SendNetTransformReliable();
+		Character._bubbleChat.Visible = true;
 	}
 
 	[ScriptMethod]
@@ -1000,29 +650,6 @@ public sealed partial class Player : NPC
 	}
 
 	[ScriptMethod]
-	public void UnequipTool()
-	{
-		if (HoldingTool == null) return;
-		Rpc(nameof(NetUnequipTool), HoldingTool.NetworkedObjectID);
-	}
-
-	[NetRpc(AuthorityMode.Authority, CallLocal = true, TransferMode = TransferMode.Reliable)]
-	private async void NetUnequipTool(string networkID)
-	{
-		NetworkedObject? netObj = await Root.WaitForNetObjectAsync(networkID);
-
-		if (netObj == null) { return; }
-
-		Tool tool = (Tool)netObj;
-
-		Character?.SetBlendValue(CharacterModel.CharacterModelBlendEnum.ToolHoldRight, 0);
-		tool.Parent = Inventory;
-		HoldingTool = null;
-		tool.InvokeUnequipped();
-		InternalDetachTool();
-	}
-
-	[ScriptMethod]
 	public new void Respawn()
 	{
 		InternalSpawn();
@@ -1034,33 +661,33 @@ public sealed partial class Player : NPC
 		CopyInventory();
 
 		// Apply playerdefaults
-		MaxHealth = Root.PlayerDefaults.MaxHealth;
-		WalkSpeed = Root.PlayerDefaults.WalkSpeed;
-		SprintSpeed = Root.PlayerDefaults.SprintSpeed;
-		UseStamina = Root.PlayerDefaults.UseStamina;
-		Stamina = Root.PlayerDefaults.Stamina;
-		MaxStamina = Root.PlayerDefaults.MaxStamina;
-		StaminaRegen = Root.PlayerDefaults.StaminaRegen;
-		StaminaBurn = Root.PlayerDefaults.StaminaBurn;
-		JumpPower = Root.PlayerDefaults.JumpPower;
+		if (Character != null)
+		{
+			Character.MaxHealth = Root.PlayerDefaults.MaxHealth;
+			Character.WalkSpeed = Root.PlayerDefaults.WalkSpeed;
+			Character.SprintSpeed = Root.PlayerDefaults.SprintSpeed;
+			Character.UseStamina = Root.PlayerDefaults.UseStamina;
+			Character.Stamina = Root.PlayerDefaults.Stamina;
+			Character.MaxStamina = Root.PlayerDefaults.MaxStamina;
+			Character.StaminaRegen = Root.PlayerDefaults.StaminaRegen;
+			Character.StaminaBurn = Root.PlayerDefaults.StaminaBurn;
+			Character.JumpPower = Root.PlayerDefaults.JumpPower;
+			Character.KeepInventory = Root.PlayerDefaults.KeepInventory;
+			Character.UseHeadTurning = Root.PlayerDefaults.UseHeadTurning;
+			Character.UseBubbleChat = Root.PlayerDefaults.UseBubbleChat;
+			if (Character is PolytorianModel ptmodel)
+			{
+				ptmodel.StopRagdoll();
+			}
+			Character.Velocity = Vector3.Zero;
+			Character.ResetAppearance();
+			Character.WrapToSpawnPoint();
+			Character.Health = Character.MaxHealth;
+			Character.Anchored = false;
+		}
 		RespawnTime = Root.PlayerDefaults.RespawnTime;
-		KeepInventory = Root.PlayerDefaults.KeepInventory;
-		UseHeadTurning = Root.PlayerDefaults.UseHeadTurning;
-		UseBubbleChat = Root.PlayerDefaults.UseBubbleChat;
 		AutoLoadAppearance = Root.PlayerDefaults.AutoLoadAppearance;
 		MovementMode = Root.PlayerDefaults.MovementMode;
-
-		if (Character is PolytorianModel ptmodel)
-		{
-			ptmodel.StopRagdoll();
-		}
-		Velocity = Vector3.Zero;
-
-		ResetAppearance();
-		WrapToSpawnPoint();
-
-		Health = MaxHealth;
-		Anchored = false;
 
 		Rpc(nameof(NetRespawned));
 	}
@@ -1069,10 +696,12 @@ public sealed partial class Player : NPC
 	{
 		// Only allow this operation in server
 		if (!Root.Network.IsServer) return;
+		if (Character == null) return;
+		if (Character.Inventory == null) return;
 
-		if (!KeepInventory)
+		if (Character.KeepInventory)
 		{
-			foreach (Instance item in Inventory.GetChildren())
+			foreach (Instance item in Character.Inventory.GetChildren())
 			{
 				item.Delete();
 			}
@@ -1085,7 +714,7 @@ public sealed partial class Player : NPC
 				NetworkedObject a = item.Clone();
 				if (a is Instance i)
 				{
-					i.Parent = Inventory;
+					i.Parent = Character.Inventory;
 				}
 			}
 		}
@@ -1096,26 +725,9 @@ public sealed partial class Player : NPC
 	{
 		Respawned?.Invoke();
 
-		OverrideCanCollide = false;
-		UpdateCollision();
-		IsDead = false;
-	}
-
-	[ScriptMethod]
-	public void ResetAppearance()
-	{
-		ClearAppearance();
-		if (AutoLoadAppearance)
-		{
-			if (Root.Entry != null && Root.Entry.IsSoloTest)
-			{
-				LoadAppearance(1144);
-			}
-			else
-			{
-				LoadAppearance(UserID);
-			}
-		}
+		Character?.OverrideCanCollide = false;
+		Character?.UpdateCollision();
+		Character?.IsDead = false;
 	}
 
 	internal override bool TransformNetworkCheck(TransformPayloadDto newTransform)

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -342,10 +342,6 @@ public sealed partial class Player : NPC
 	public override void Process(double delta)
 	{
 		base.Process(delta);
-		if (!Root.Network.IsServer)
-		{
-			UpdateCamera(delta);
-		}
 
 		if (!IsLocal || !IsReady)
 		{
@@ -382,8 +378,6 @@ public sealed partial class Player : NPC
 
 		if (Character is PolytorianModel pt && pt.Ragdolling)
 		{
-			// ragdoll camera update
-			UpdateCamera(delta);
 			return;
 		}
 
@@ -403,13 +397,10 @@ public sealed partial class Player : NPC
 			// just in case it's anchored cuz ragdoll
 			if (Character is PolytorianModel pt2 && pt2.Ragdolling == false)
 			{
-				UpdateCamera(delta);
 			}
 			AfkTick(delta);
 			return;
 		}
-
-		if (Character.IsSitting) UpdateCamera(delta);
 
 		Camera? cam = Root.Environment.CurrentCamera;
 

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -317,7 +317,7 @@ public sealed partial class Player : NPC
 	private void UpdatePlrReady()
 	{
 		Character?.SetCollisionDisabled(!_isReady);
-		GDNode3D?.Visible = _isReady;
+		Character?.GDNode3D?.Visible = _isReady;
 	}
 
 	private void SetCamRemoteAttachEnabled(bool enabled)
@@ -365,10 +365,6 @@ public sealed partial class Player : NPC
 		if (!Root.Network.IsServer)
 		{
 			UpdateCamera(delta);
-		}
-		if (!IsLocal)
-		{
-			UpdateTransformTick(delta);
 		}
 
 		if (!IsLocal || !IsReady)
@@ -571,7 +567,7 @@ public sealed partial class Player : NPC
 		cam.FirstPersonExited.Connect(OnFirstPersonExited);
 
 		// Disable auto update, this will be updated manually
-		AutoUpdateNetTransform = false;
+		Character?.AutoUpdateNetTransform = false;
 
 		if (Character is PolytorianModel ptc)
 		{
@@ -728,12 +724,6 @@ public sealed partial class Player : NPC
 		Character?.OverrideCanCollide = false;
 		Character?.UpdateCollision();
 		Character?.IsDead = false;
-	}
-
-	internal override bool TransformNetworkCheck(TransformPayloadDto newTransform)
-	{
-		// TODO: Make sanity checks here
-		return true;
 	}
 
 	internal void AdminKick()

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -84,6 +84,9 @@ public sealed partial class Player : NPC
 	[ScriptProperty]
 	public PTSignal Respawned { get; private set; } = new();
 
+	[ScriptProperty]
+	public PTSignal<CharacterModel?> CharacterChanged { get; private set; } = new();
+
 	[SyncVar, ScriptProperty]
 	public int UserID
 	{
@@ -573,6 +576,7 @@ public sealed partial class Player : NPC
 		cam.UpdateCameraSelf = false;
 		cam.FirstPersonEntered.Connect(OnFirstPersonEntered);
 		cam.FirstPersonExited.Connect(OnFirstPersonExited);
+		CharacterChanged.Connect(OnCharacterChanged);
 
 		// Disable auto update, this will be updated manually
 		Character?.AutoUpdateNetTransform = false;
@@ -654,7 +658,7 @@ public sealed partial class Player : NPC
 	}
 
 	[ScriptMethod]
-	public new void Respawn()
+	public void Respawn()
 	{
 		InternalSpawn();
 	}
@@ -664,6 +668,17 @@ public sealed partial class Player : NPC
 		// Clear & Re-copy inventory
 		CopyInventory();
 
+		// Create character if absent
+		if (Character is null)
+		{
+			// Insert default character on client
+			if (Root.Network.NetworkMode == NetworkService.NetworkModeEnum.Client)
+			{
+				Root.Insert.InitializeDefaultNPC(this);
+			}
+
+			CharacterChanged.Invoke();
+		}
 		// Apply playerdefaults
 		if (Character != null)
 		{
@@ -749,14 +764,14 @@ public sealed partial class Player : NPC
 		if (_remoteCamAttach == null)
 		{
 			_remoteCamAttach = new();
-			Character?.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).GDNode.AddChild(_remoteCamAttach, @internal: Node.InternalMode.Back);
 		}
+		Character?.GetAttachment(CharacterModel.CharacterAttachmentEnum.Head).GDNode.AddChild(_remoteCamAttach, @internal: Node.InternalMode.Back);
 		_remoteCamAttach.RemotePath = _remoteCamAttach.GetPathTo(CamAttach.GDNode3D);
 
 		SetCamRemoteAttachEnabled(false);
 	}
 
-	internal void OnCharacterChange(CharacterModel? oldChar = null)
+	internal void OnCharacterChanged(CharacterModel? oldChar = null)
 	{
 		if (oldChar is PolytorianModel optc)
 		{

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -585,7 +585,7 @@ public sealed partial class Player : NPC
 	}
 
 	[ScriptMethod]
-	public void Respawn()
+	public new void Respawn()
 	{
 		CharacterModel? oldChar = Character;
 		InternalSpawn();

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -541,7 +541,6 @@ public sealed partial class Player : NPC
 
 		Camera? cam = Root.Environment.CurrentCamera;
 		if (cam == null) return;
-		cam.UpdateCameraSelf = false;
 		cam.FirstPersonEntered.Connect(OnFirstPersonEntered);
 		cam.FirstPersonExited.Connect(OnFirstPersonExited);
 		CharacterChanged.Connect(OnCharacterChanged);

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -585,7 +585,7 @@ public sealed partial class Player : NPC
 	}
 
 	[ScriptMethod]
-	public new void Respawn()
+	public override void Respawn()
 	{
 		CharacterModel? oldChar = Character;
 		InternalSpawn();

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -49,7 +49,6 @@ public sealed partial class Player : NPC
 	internal bool teleporting = false;
 
 	private Physical? _mouseHoveringOn;
-	private Physical? _grabbing;
 
 	public Vector3 DefaultSpawnLocation = new(0, 5, 0);
 	internal event Action<APIUserInfo>? UserInfoReady;
@@ -172,21 +171,6 @@ public sealed partial class Player : NPC
 			_rotationMode = value;
 			OnPropertyChanged();
 		}
-	}
-
-	[ScriptProperty]
-	public Physical? Grabbing => _grabbing;
-
-	public void SetGrabbing(Physical phy)
-	{
-		_grabbing = phy;
-		Grabbed.Invoke(phy);
-	}
-
-	public void ReleaseGrabbing()
-	{
-		Ungrabbed.Invoke(_grabbing);
-		_grabbing = null;
 	}
 
 	[ScriptProperty]

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -487,6 +487,7 @@ public sealed partial class Player : NPC
 			// Ignore jump command if is custom
 			if (MovementMode == PlayerMovementModeEnum.Scripted) return;
 			if (!Character.CanMove) return;
+			Character._canJumpWhileClimbing = true;
 			Character.Jump();
 		}
 		else if (@event.IsActionPressed("toggle_sprint"))

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -651,7 +651,7 @@ public sealed partial class Player : NPC
 				ptmodel.ResetAppearance();
 			}
 			Character.Velocity = Vector3.Zero;
-			Character.WrapToSpawnPoint();
+			Character.WarpToSpawnPoint();
 			Character.Health = Character.MaxHealth;
 			Character.Anchored = false;
 		}

--- a/Polytoria/scripts/datamodel/PlayerDefaults.cs
+++ b/Polytoria/scripts/datamodel/PlayerDefaults.cs
@@ -24,6 +24,9 @@ public sealed partial class PlayerDefaults : HiddenBase
 	private float _staminaRegen;
 	private float _staminaBurn;
 	private bool _reuseCharacter;
+	private bool _corpseDecay;
+	private bool _automaticSpawn;
+	private bool _cameraFollow;
 	private bool _keepInventory;
 	private bool _useHeadTurning;
 	private bool _useBubbleChat;
@@ -195,6 +198,42 @@ public sealed partial class PlayerDefaults : HiddenBase
 
 
 	[Editable, ScriptProperty]
+	public bool CorpseDecay
+	{
+		get => _corpseDecay;
+		set
+		{
+			_corpseDecay = value;
+			OnPropertyChanged();
+		}
+	}
+
+
+	[Editable, ScriptProperty]
+	public bool AutomaticSpawn
+	{
+		get => _automaticSpawn;
+		set
+		{
+			_automaticSpawn = value;
+			OnPropertyChanged();
+		}
+	}
+
+
+	[Editable, ScriptProperty]
+	public bool AutoCameraFollow
+	{
+		get => _cameraFollow;
+		set
+		{
+			_cameraFollow = value;
+			OnPropertyChanged();
+		}
+	}
+
+
+	[Editable, ScriptProperty]
 	public bool KeepInventory
 	{
 		get => _keepInventory;
@@ -290,6 +329,9 @@ public sealed partial class PlayerDefaults : HiddenBase
 		AutoLoadAppearance = true;
 		LoadAppearanceTools = true;
 		ReuseCharacter = true;
+		CorpseDecay = true;
+		AutomaticSpawn = true;
+		AutoCameraFollow = true;
 		MovementMode = Player.PlayerMovementModeEnum.Default;
 	}
 }

--- a/Polytoria/scripts/datamodel/PlayerDefaults.cs
+++ b/Polytoria/scripts/datamodel/PlayerDefaults.cs
@@ -23,6 +23,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 	private bool _useStamina;
 	private float _staminaRegen;
 	private float _staminaBurn;
+	private bool _reuseCharacter;
 	private bool _keepInventory;
 	private bool _useHeadTurning;
 	private bool _useBubbleChat;
@@ -182,6 +183,18 @@ public sealed partial class PlayerDefaults : HiddenBase
 
 
 	[Editable, ScriptProperty]
+	public bool ReuseCharacter
+	{
+		get => _reuseCharacter;
+		set
+		{
+			_reuseCharacter = value;
+			OnPropertyChanged();
+		}
+	}
+
+
+	[Editable, ScriptProperty]
 	public bool KeepInventory
 	{
 		get => _keepInventory;
@@ -276,6 +289,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 		UseBubbleChat = true;
 		AutoLoadAppearance = true;
 		LoadAppearanceTools = true;
+		ReuseCharacter = true;
 		MovementMode = Player.PlayerMovementModeEnum.Default;
 	}
 }

--- a/Polytoria/scripts/datamodel/PlayerDefaults.cs
+++ b/Polytoria/scripts/datamodel/PlayerDefaults.cs
@@ -100,13 +100,13 @@ public sealed partial class PlayerDefaults : HiddenBase
 		}
 	}
 
-
 	[Editable, ScriptProperty]
 	public bool ChatColorsEnabled
 	{
 		get => _chatColorsEnabled;
 		set { _chatColorsEnabled = value; OnPropertyChanged(); }
 	}
+
 	[Editable, ScriptProperty]
 	public bool CanMove
 	{

--- a/Polytoria/scripts/datamodel/Players.cs
+++ b/Polytoria/scripts/datamodel/Players.cs
@@ -62,7 +62,7 @@ public sealed partial class Players : Instance
 	public readonly Dictionary<int, Player> _idToPlayer = [];
 
 	/// <summary>
-	/// Get Player from Peer ID. This should only be called on server, as peer is not guaranteed to be available on clients. 
+	/// Get Player from Peer ID. This should only be called on server, as peer is not guaranteed to be available on clients.
 	/// </summary>
 	/// <param name="peerID"></param>
 	/// <returns></returns>

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -710,6 +710,23 @@ public sealed partial class PolytorianModel : CharacterModel
 	}
 
 	[ScriptMethod]
+	public void ResetAppearance()
+	{
+		ClearAppearance();
+		if (Controller is Player plr && plr.AutoLoadAppearance)
+		{
+			if (Root.Entry != null && Root.Entry.IsSoloTest)
+			{
+				LoadAppearance(1144);
+			}
+			else
+			{
+				LoadAppearance(plr.UserID);
+			}
+		}
+	}
+
+	[ScriptMethod]
 	public void ClearAppearance()
 	{
 		HeadColor = _defaultBodyColor;

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -398,7 +398,7 @@ public sealed partial class PolytorianModel : CharacterModel
 	{
 		base.Process(delta);
 
-		if (Ragdolling)
+		if (Ragdolling && VelocityPhysicalBone is not null)
 		{
 			Position = VelocityPhysicalBone.GetGlobalPosition();
 		}

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -77,8 +77,6 @@ public sealed partial class PolytorianModel : CharacterModel
 
 	public PhysicalBone3D? VelocityPhysicalBone;
 
-	public override Dynamic Head => GetAttachment(CharacterAttachmentEnum.Head);
-
 	[Editable, ScriptProperty, Export, SyncVar]
 	public Color HeadColor
 	{
@@ -274,6 +272,10 @@ public sealed partial class PolytorianModel : CharacterModel
 		AnimTree.Active = true;
 
 		base.Init();
+
+		Head = GetAttachment(CharacterAttachmentEnum.Head);
+		ToolAttachment = GetAttachment(CharacterAttachmentEnum.HandRight); // TODO: lefthanded representation
+
 		SetProcess(true);
 	}
 
@@ -591,7 +593,7 @@ public sealed partial class PolytorianModel : CharacterModel
 	}
 
 	[ScriptMethod]
-	public override Dynamic GetAttachment(CharacterAttachmentEnum attachmentEnum)
+	public Dynamic GetAttachment(CharacterAttachmentEnum attachmentEnum)
 	{
 		if (!_attachmentEnumToDyn.TryGetValue(attachmentEnum, out Dynamic? dyn))
 		{

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -301,28 +301,25 @@ public sealed partial class PolytorianModel : CharacterModel
 
 	public override void EnterTree()
 	{
-		if (this is Physical phy)
+		_oldPhyParent = this;
+
+		// Configure default collision shape for PolytorianModel
+		CollisionPivot = new()
 		{
-			_oldPhyParent = phy;
+			Scale = NodeSize
+		};
+		CollisionShape = new()
+		{
+			Shape = _collisionBox
+		};
+		Physical.SetRemoteLinkOffset(CollisionShape, new(0, 3f - 0.1f, 0));
+		Physical.SetRemoteLinkTarget(CollisionShape, CollisionPivot);
+		GDNode.AddChild(CollisionPivot);
+		CollisionPivot.Position = new(0, -3f, 0);
 
-			// Configure default collision shape for PolytorianModel
-			CollisionPivot = new()
-			{
-				Scale = NodeSize
-			};
-			CollisionShape = new()
-			{
-				Shape = _collisionBox
-			};
-			Physical.SetRemoteLinkOffset(CollisionShape, new(0, 3f - 0.1f, 0));
-			Physical.SetRemoteLinkTarget(CollisionShape, CollisionPivot);
-			GDNode.AddChild(CollisionPivot);
-			CollisionPivot.Position = new(0, -3f, 0);
-
-			phy.GDNode.AddChild(CollisionShape);
-			phy.AddCollisionShape(CollisionShape);
-			phy.UpdateCollision();
-		}
+		GDNode.AddChild(CollisionShape);
+		AddCollisionShape(CollisionShape);
+		UpdateCollision();
 		base.EnterTree();
 	}
 

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -797,7 +797,7 @@ public sealed partial class PolytorianModel : CharacterModel
 			}
 			else if (asset.Type == "tool")
 			{
-				if (Parent is Player plr && loadTool)
+				if (loadTool && this.Inventory != null)
 				{
 					hasTool = true;
 					try
@@ -809,14 +809,14 @@ public sealed partial class PolytorianModel : CharacterModel
 							tool?.Delete();
 							throw new OperationCanceledException("The avatar is deleted");
 						}
-						tool?.Parent = plr.Inventory;
+						tool?.Parent = this.Inventory;
 					}
 					catch (Exception ex)
 					{
 						PT.PrintErr(ex);
 					}
 				}
-				else if (Parent is NPC npc && loadToolNpc)
+				else if (loadToolNpc)
 				{
 					hasTool = true;
 					try
@@ -829,7 +829,7 @@ public sealed partial class PolytorianModel : CharacterModel
 							throw new OperationCanceledException("The avatar is deleted");
 						}
 						if (tool != null)
-							npc.EquipTool(tool);
+							this.EquipTool(tool);
 					}
 					catch (Exception ex)
 					{
@@ -856,12 +856,6 @@ public sealed partial class PolytorianModel : CharacterModel
 		}
 
 		Instance checkOn = this;
-
-		// Check on NPC for loading tools
-		if (Parent is NPC)
-		{
-			checkOn = Parent;
-		}
 
 		foreach (var item in checkOn.GetDescendants())
 		{

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -290,12 +290,18 @@ public sealed partial class PolytorianModel : CharacterModel
 
 	public override Node CreateGDNode()
 	{
-		return Globals.LoadNetworkedObjectScene(ClassName)!;
+		if (GDNode != null) return GDNode;
+		Node? node = Globals.LoadNetworkedObjectScene(ClassName);
+		if (node != null)
+		{
+			return node;
+		}
+		return new();
 	}
 
 	public override void EnterTree()
 	{
-		if (Parent is Physical phy)
+		if (this is Physical phy)
 		{
 			_oldPhyParent = phy;
 

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -77,6 +77,8 @@ public sealed partial class PolytorianModel : CharacterModel
 
 	public PhysicalBone3D? VelocityPhysicalBone;
 
+	public override Dynamic Head => GetAttachment(CharacterAttachmentEnum.Head);
+
 	[Editable, ScriptProperty, Export, SyncVar]
 	public Color HeadColor
 	{

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -394,6 +394,11 @@ public sealed partial class PolytorianModel : CharacterModel
 	{
 		base.Process(delta);
 
+		if (Ragdolling)
+		{
+			Position = VelocityPhysicalBone.GetGlobalPosition();
+		}
+
 		if (_updateClothDirty)
 		{
 			_updateClothDirty = false;

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -814,53 +814,20 @@ public sealed partial class PolytorianModel : CharacterModel
 					{
 						Root.Insert.CreateAccessory(asset.ID, asset.Name, asset.AccessoryType).Parent = this;
 					}
-					accessory?.Parent = this;
+					else if (Controller is Player plr && loadTool)
+					{
+						hasTool = true;
+						Root.Insert.CreateTool(asset.ID, asset.Name).Parent = Inventory;
+					}
+					else if (loadToolNpc)
+					{
+						hasTool = true;
+						EquipTool(Root.Insert.CreateTool(asset.ID, asset.Name));
+					}
 				}
 				catch (Exception ex)
 				{
 					PT.PrintErr(ex);
-				}
-			}
-			else if (asset.Type == "tool")
-			{
-				if (loadTool && this.Inventory != null)
-				{
-					hasTool = true;
-					try
-					{
-						Tool? tool = await Root.Insert.ToolAsync(asset.ID);
-						if (myCount != _loadAppearanceCount) { tool?.Delete(); throw new OperationCanceledException("The avatar is cancelled"); }
-						if (IsDeleted)
-						{
-							tool?.Delete();
-							throw new OperationCanceledException("The avatar is deleted");
-						}
-						tool?.Parent = this.Inventory;
-					}
-					catch (Exception ex)
-					{
-						PT.PrintErr(ex);
-					}
-				}
-				else if (loadToolNpc)
-				{
-					hasTool = true;
-					try
-					{
-						Tool? tool = await Root.Insert.ToolAsync(asset.ID);
-						if (myCount != _loadAppearanceCount) { tool?.Delete(); throw new OperationCanceledException("The avatar is cancelled"); }
-						if (IsDeleted)
-						{
-							tool?.Delete();
-							throw new OperationCanceledException("The avatar is deleted");
-						}
-						if (tool != null)
-							this.EquipTool(tool);
-					}
-					catch (Exception ex)
-					{
-						PT.PrintErr(ex);
-					}
 				}
 			}
 		}

--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -14,10 +14,10 @@ public partial class Seat : Part
 	private bool _canNPCSit;
 	private bool _sitDirectionLocked;
 
-	private NPC? _occupant = null;
+	private CharacterModel? _occupant = null;
 
 	[SyncVar, ScriptProperty]
-	public NPC? Occupant
+	public CharacterModel? Occupant
 	{
 		get
 		{
@@ -62,8 +62,8 @@ public partial class Seat : Part
 		}
 	}
 
-	[ScriptProperty] public PTSignal<NPC> Sat { get; private set; } = new();
-	[ScriptProperty] public PTSignal<NPC> Vacated { get; private set; } = new();
+	[ScriptProperty] public PTSignal<CharacterModel> Sat { get; private set; } = new();
+	[ScriptProperty] public PTSignal<CharacterModel> Vacated { get; private set; } = new();
 
 	public override void Init()
 	{
@@ -74,14 +74,14 @@ public partial class Seat : Part
 		}
 	}
 
-	internal void InvokeSat(NPC npc)
+	internal void InvokeSat(CharacterModel charModel)
 	{
-		Sat.Invoke(npc);
+		Sat.Invoke(charModel);
 	}
 
-	internal void InvokeVacated(NPC npc)
+	internal void InvokeVacated(CharacterModel charModel)
 	{
-		Vacated.Invoke(npc);
+		Vacated.Invoke(charModel);
 	}
 
 	private void OnSeatTouched(Physical hit)
@@ -90,17 +90,11 @@ public partial class Seat : Part
 		{
 			return;
 		}
-		if (hit is Player plr)
+		if (hit is CharacterModel charModel)
 		{
-			if (!CanPlayerSit) { return; }
-			if (plr.IsSitting) { return; }
-			plr.Sit(this);
-		}
-		else if (hit is NPC npc)
-		{
-			if (!CanNPCSit) { return; }
-			if (npc.IsSitting) { return; }
-			npc.Sit(this);
+			if (!(charModel._controller is Player ? CanPlayerSit : CanNPCSit)) { return; }
+			if (charModel.IsSitting) { return; }
+			charModel.Sit(this);
 		}
 	}
 }

--- a/Polytoria/scripts/datamodel/Seat.cs
+++ b/Polytoria/scripts/datamodel/Seat.cs
@@ -92,7 +92,7 @@ public partial class Seat : Part
 		}
 		if (hit is CharacterModel charModel)
 		{
-			if (!(charModel._controller is Player ? CanPlayerSit : CanNPCSit)) { return; }
+			if (!(charModel.Controller is Player ? CanPlayerSit : CanNPCSit)) { return; }
 			if (charModel.IsSitting) { return; }
 			charModel.Sit(this);
 		}

--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -250,13 +250,13 @@ public sealed partial class Tool : RigidBody
 	private void NetRecvActivate()
 	{
 		if (Holder == null) return;
-		if (Holder._controller == null) return;
+		if (Holder.Controller == null) return;
 
 		// Only allow from the holder
-		if (Holder._controller is Player plr && RemoteSenderId != plr.PeerID) return;
+		if (Holder.Controller is Player plr && RemoteSenderId != plr.PeerID) return;
 
 		// Only allow from server if is NPC
-		if (Holder._controller is not Player && RemoteSenderId != 1) return;
+		if (Holder.Controller is not Player && RemoteSenderId != 1) return;
 		Activated.Invoke();
 	}
 
@@ -264,13 +264,13 @@ public sealed partial class Tool : RigidBody
 	private void NetRecvDeactivate()
 	{
 		if (Holder == null) return;
-		if (Holder._controller == null) return;
+		if (Holder.Controller == null) return;
 
 		// Only allow from the holder
-		if (Holder._controller is Player plr && RemoteSenderId != plr.PeerID) return;
+		if (Holder.Controller is Player plr && RemoteSenderId != plr.PeerID) return;
 
 		// Only allow from server if is NPC
-		if (Holder._controller is not Player && RemoteSenderId != 1) return;
+		if (Holder.Controller is not Player && RemoteSenderId != 1) return;
 		Deactivated.Invoke();
 	}
 

--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -19,7 +19,7 @@ public sealed partial class Tool : RigidBody
 {
 	private bool _droppable = true;
 	private ImageAsset? _iconImage;
-	private NPC? _holder = null;
+	private CharacterModel? _holder = null;
 
 	private double _dropEquipCooldown;
 	private Timer _equipTimer = null!;
@@ -79,7 +79,7 @@ public sealed partial class Tool : RigidBody
 	}
 
 	[SyncVar, ScriptProperty]
-	public NPC? Holder
+	public CharacterModel? Holder
 	{
 		get
 		{
@@ -124,9 +124,9 @@ public sealed partial class Tool : RigidBody
 
 	private void OnToolTouched(Physical physical)
 	{
-		if (physical is NPC npc && _holder == null && Parent is not (Inventory or Player) && _equipTimer.IsStopped())
+		if (physical is CharacterModel charModel && _holder == null && Parent is not (Inventory or Player) && _equipTimer.IsStopped())
 		{
-			npc.EquipTool(this);
+			charModel.EquipTool(this);
 		}
 	}
 
@@ -139,7 +139,7 @@ public sealed partial class Tool : RigidBody
 	public override void EnterTree()
 	{
 		base.EnterTree();
-		if (Parent is not (Inventory or NPC))
+		if (Parent is not (Inventory or CharacterModel))
 		{
 			CanCollide = true;
 			Anchored = false;
@@ -159,7 +159,7 @@ public sealed partial class Tool : RigidBody
 		Root.Input.GodotInputEvent += OnInput;
 
 		// Just in case it were reparented while still having a holder
-		if (Parent is not NPC && Holder != null)
+		if (Parent is not CharacterModel && Holder != null)
 		{
 			Holder.InternalDetachTool();
 			Holder = null;
@@ -201,9 +201,9 @@ public sealed partial class Tool : RigidBody
 	private void UpdateHandHold()
 	{
 		_hasDynChild = Children.Any(i => i is Dynamic);
-		if (Holder != null && Holder.Character != null)
+		if (Holder != null)
 		{
-			Holder.Character.SetBlendValue(CharacterModel.CharacterModelBlendEnum.ToolHoldRight, _hasDynChild ? 1 : 0);
+			Holder.SetBlendValue(CharacterModel.CharacterModelBlendEnum.ToolHoldRight, _hasDynChild ? 1 : 0);
 		}
 	}
 
@@ -215,7 +215,7 @@ public sealed partial class Tool : RigidBody
 
 	public void OnInput(InputEvent @event)
 	{
-		if (Holder != Root.Players.LocalPlayer) return;
+		if (Holder != Root.Players.LocalPlayer.Character) return;
 		if (@event.IsActionPressed("activate"))
 		{
 			Activate();
@@ -250,12 +250,13 @@ public sealed partial class Tool : RigidBody
 	private void NetRecvActivate()
 	{
 		if (Holder == null) return;
+		if (Holder._controller == null) return;
 
 		// Only allow from the holder
-		if (Holder is Player plr && RemoteSenderId != plr.PeerID) return;
+		if (Holder._controller is Player plr && RemoteSenderId != plr.PeerID) return;
 
 		// Only allow from server if is NPC
-		if (Holder is not Player && Holder is not null && RemoteSenderId != 1) return;
+		if (Holder._controller is not Player && RemoteSenderId != 1) return;
 		Activated.Invoke();
 	}
 
@@ -263,12 +264,13 @@ public sealed partial class Tool : RigidBody
 	private void NetRecvDeactivate()
 	{
 		if (Holder == null) return;
+		if (Holder._controller == null) return;
 
 		// Only allow from the holder
-		if (Holder is Player plr && RemoteSenderId != plr.PeerID) return;
+		if (Holder._controller is Player plr && RemoteSenderId != plr.PeerID) return;
 
 		// Only allow from server if is NPC
-		if (Holder is not Player && Holder is not null && RemoteSenderId != 1) return;
+		if (Holder._controller is not Player && RemoteSenderId != 1) return;
 		Deactivated.Invoke();
 	}
 
@@ -326,7 +328,7 @@ public sealed partial class Tool : RigidBody
 	[ScriptMethod, ScriptLegacyMethod("Play")]
 	public void PlayAnimation(string animationName)
 	{
-		Holder?.Character?.Animator?.PlayOneShotAnimation(animationName);
+		Holder?.Animator?.PlayOneShotAnimation(animationName);
 	}
 
 	internal void InvokeEquipped()

--- a/Polytoria/scripts/datamodel/Tool.cs
+++ b/Polytoria/scripts/datamodel/Tool.cs
@@ -124,7 +124,7 @@ public sealed partial class Tool : RigidBody
 
 	private void OnToolTouched(Physical physical)
 	{
-		if (physical is CharacterModel charModel && _holder == null && Parent is not (Inventory or Player) && _equipTimer.IsStopped())
+		if (physical is CharacterModel charModel && _holder == null && Parent is not (Inventory or CharacterModel) && _equipTimer.IsStopped())
 		{
 			charModel.EquipTool(this);
 		}

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -88,25 +88,34 @@ public sealed partial class InsertService : Instance
 		ptm.LocalPosition = Vector3.Zero;
 		ptm.LocalRotation = Vector3.Zero;
 		ptm.LocalSize = Vector3.One;
-		ptm.SetNetworkAuthority(npc.NetworkAuthority, false);
+		ptm.SetNetworkAuthority(owner, false);
 		ptm.Animator?.SetNetworkAuthority(owner, false);
 		ptm.Parent = Root.Environment;
 		npc.Character = ptm;
+		ptm.JumpSound.SetNetworkAuthority(owner, false);
+	}
+
+	public void InitializeDefaultCharacter(CharacterModel charModel)
+	{
+		var animator = New<Animator>();
+		animator.AutoInit = false;
+		animator.Name = "Animator";
+		animator.Parent = charModel;
+		charModel.Animator = animator;
 
 		// Jump sound
 		BuiltInAudioAsset audio = New<BuiltInAudioAsset>();
 		audio.AudioPreset = BuiltInAudioAsset.BuiltInAudioPresetEnum.Jump;
 		var jumpSound = New<Sound>();
 		jumpSound.Name = "JumpSound";
-		jumpSound.Parent = ptm;
+		jumpSound.Parent = charModel;
 		jumpSound.Volume = 0.5f;
 		jumpSound.Audio = audio;
 		jumpSound.Autoplay = false;
 		jumpSound.Loop = false;
 		jumpSound.PlayInWorld = true;
-		jumpSound.SetNetworkAuthority(owner, false);
 
-		ptm.JumpSound = jumpSound;
+		charModel.JumpSound = jumpSound;
 
 		jumpSound.LocalPosition = Vector3.Zero;
 		jumpSound.LocalRotation = Vector3.Zero;
@@ -117,11 +126,7 @@ public sealed partial class InsertService : Instance
 	public PolytorianModel DefaultCharacter()
 	{
 		var ptm = New<PolytorianModel>();
-		var animator = New<Animator>();
-		animator.AutoInit = false;
-		animator.Name = "Animator";
-		animator.Parent = ptm;
-		ptm.Animator = animator;
+		InitializeDefaultCharacter(ptm);
 
 		return ptm;
 	}

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -51,14 +51,14 @@ public sealed partial class InsertService : Instance
 
 		// Default character
 		var ptm = DefaultCharacter();
-		npc.Character = ptm;
 		ptm.Name = "Character";
-		ptm.Parent = npc;
 		ptm.LocalPosition = Vector3.Zero;
 		ptm.LocalRotation = Vector3.Zero;
 		ptm.LocalSize = Vector3.One;
 		ptm.SetNetworkAuthority(npc.NetworkAuthority, false);
 		ptm.Animator?.SetNetworkAuthority(owner, false);
+		ptm.Parent = npc;
+		npc.Character = ptm;
 
 		// Jump sound
 		BuiltInAudioAsset audio = New<BuiltInAudioAsset>();

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -73,7 +73,7 @@ public sealed partial class InsertService : Instance
 		jumpSound.PlayInWorld = true;
 		jumpSound.SetNetworkAuthority(owner, false);
 
-		npc.JumpSound = jumpSound;
+		ptm.JumpSound = jumpSound;
 
 		jumpSound.LocalPosition = Vector3.Zero;
 		jumpSound.LocalRotation = Vector3.Zero;

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -51,28 +51,10 @@ public sealed partial class InsertService : Instance
 		// Default character
 		var ptm = DefaultCharacter();
 		ptm.Name = "Character";
+		ptm.Parent = Root.Environment;
 		ptm.LocalPosition = Vector3.Zero;
 		ptm.LocalRotation = Vector3.Zero;
 		ptm.LocalSize = Vector3.One;
-		ptm.Parent = Root.Environment;
-
-		// Jump sound
-		BuiltInAudioAsset audio = New<BuiltInAudioAsset>();
-		audio.AudioPreset = BuiltInAudioAsset.BuiltInAudioPresetEnum.Jump;
-		var jumpSound = New<Sound>();
-		jumpSound.Name = "JumpSound";
-		jumpSound.Parent = ptm;
-		jumpSound.Volume = 0.5f;
-		jumpSound.Audio = audio;
-		jumpSound.Autoplay = false;
-		jumpSound.Loop = false;
-		jumpSound.PlayInWorld = true;
-
-		ptm.JumpSound = jumpSound;
-
-		jumpSound.LocalPosition = Vector3.Zero;
-		jumpSound.LocalRotation = Vector3.Zero;
-		jumpSound.LocalSize = Vector3.One;
 
 		return ptm;
 	}

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -57,7 +57,7 @@ public sealed partial class InsertService : Instance
 		ptm.LocalSize = Vector3.One;
 		ptm.SetNetworkAuthority(npc.NetworkAuthority, false);
 		ptm.Animator?.SetNetworkAuthority(owner, false);
-		ptm.Parent = npc;
+		ptm.Parent = Root.Environment;
 		npc.Character = ptm;
 
 		// Jump sound
@@ -65,7 +65,7 @@ public sealed partial class InsertService : Instance
 		audio.AudioPreset = BuiltInAudioAsset.BuiltInAudioPresetEnum.Jump;
 		var jumpSound = New<Sound>();
 		jumpSound.Name = "JumpSound";
-		jumpSound.Parent = npc;
+		jumpSound.Parent = ptm;
 		jumpSound.Volume = 0.5f;
 		jumpSound.Audio = audio;
 		jumpSound.Autoplay = false;

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -92,7 +92,7 @@ public sealed partial class InsertService : Instance
 		ptm.Animator?.SetNetworkAuthority(owner, false);
 		ptm.Parent = Root.Environment;
 		npc.Character = ptm;
-		ptm.JumpSound.SetNetworkAuthority(owner, false);
+		ptm.JumpSound!.SetNetworkAuthority(owner, false);
 	}
 
 	public void InitializeDefaultCharacter(CharacterModel charModel)

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -45,6 +45,39 @@ public sealed partial class InsertService : Instance
 	}
 
 	[ScriptMethod]
+	public CharacterModel DefaultNPCCharacter()
+	{
+
+		// Default character
+		var ptm = DefaultCharacter();
+		ptm.Name = "Character";
+		ptm.LocalPosition = Vector3.Zero;
+		ptm.LocalRotation = Vector3.Zero;
+		ptm.LocalSize = Vector3.One;
+		ptm.Parent = Root.Environment;
+
+		// Jump sound
+		BuiltInAudioAsset audio = New<BuiltInAudioAsset>();
+		audio.AudioPreset = BuiltInAudioAsset.BuiltInAudioPresetEnum.Jump;
+		var jumpSound = New<Sound>();
+		jumpSound.Name = "JumpSound";
+		jumpSound.Parent = ptm;
+		jumpSound.Volume = 0.5f;
+		jumpSound.Audio = audio;
+		jumpSound.Autoplay = false;
+		jumpSound.Loop = false;
+		jumpSound.PlayInWorld = true;
+
+		ptm.JumpSound = jumpSound;
+
+		jumpSound.LocalPosition = Vector3.Zero;
+		jumpSound.LocalRotation = Vector3.Zero;
+		jumpSound.LocalSize = Vector3.One;
+
+		return ptm;
+	}
+
+	[ScriptMethod]
 	public void InitializeDefaultNPC(NPC npc)
 	{
 		int owner = npc.NetworkAuthority;

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -45,7 +45,7 @@ public sealed partial class InsertService : Instance
 	}
 
 	[ScriptMethod]
-	public CharacterModel DefaultNPCCharacter()
+	public PolytorianModel DefaultNPCCharacter()
 	{
 
 		// Default character

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -888,9 +888,9 @@ public sealed partial class NetworkService : Instance
 			if (IsServer)
 			{
 				plr.IsReady = true;
-				plr.Respawn();
 				Root.Players.InvokePlayerAdded(plr);
 				RpcId(peerID, nameof(NetRecvReportReady));
+				if (Root.PlayerDefaults.AutomaticSpawn) plr.Respawn();
 			}
 		}
 	}

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -686,7 +686,7 @@ public sealed partial class NetworkService : Instance
 
 		// Assign network authorties
 		plr.SetNetworkAuthority(peerID, true);
-		plr.NetTransformAuthority = peerID;
+		plr?.Character.NetTransformAuthority = peerID;
 		if (!_players.UseServerAuthority)
 		{
 			// Assign property ownership if server authority mode is off

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -684,26 +684,16 @@ public sealed partial class NetworkService : Instance
 			plr.ChatColor = Root.PlayerDefaults.ChatColor;
 		}
 
-		// Insert default character on client
-		if (NetworkMode == NetworkModeEnum.Client)
-		{
-			Root.Insert.InitializeDefaultNPC(plr);
-		}
-
-		// Assign network authorties
+		// Assign network authorities
 		plr.SetNetworkAuthority(peerID, true);
-		plr.Character?.SetNetworkAuthority(plr);
-		plr.Character?.SetNetworkAuthority(peerID, true);
 		if (!_players.UseServerAuthority)
 		{
 			// Assign property ownership if server authority mode is off
 			plr.NetPropAuthority = peerID;
-			plr.Character?.NetPropAuthority = peerID;
 		}
 
 		plr.Parent = _players;
 
-		plr.Character?.Anchored = true;
 		plr.IsReady = false;
 
 		// Copy instances from player default
@@ -898,7 +888,6 @@ public sealed partial class NetworkService : Instance
 			if (IsServer)
 			{
 				plr.IsReady = true;
-				plr.Character?.Anchored = true;
 				plr.Respawn();
 				Root.Players.InvokePlayerAdded(plr);
 				RpcId(peerID, nameof(NetRecvReportReady));

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -701,7 +701,10 @@ public sealed partial class NetworkService : Instance
 
 		plr.Parent = _players;
 
-		plr.Anchored = true;
+		if (plr.Character != null)
+		{
+			plr.Character.Anchored = true;
+		}
 		plr.IsReady = false;
 
 		// Copy instances from player default
@@ -896,7 +899,10 @@ public sealed partial class NetworkService : Instance
 			if (IsServer)
 			{
 				plr.IsReady = true;
-				plr.Anchored = false;
+				if (plr.Character != null)
+				{
+					plr.Character.Anchored = true;
+				}
 				plr.Respawn();
 				Root.Players.InvokePlayerAdded(plr);
 				RpcId(peerID, nameof(NetRecvReportReady));

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -684,27 +684,26 @@ public sealed partial class NetworkService : Instance
 			plr.ChatColor = Root.PlayerDefaults.ChatColor;
 		}
 
-		// Assign network authorties
-		plr.SetNetworkAuthority(peerID, true);
-		plr.Character?.NetTransformAuthority = peerID;
-		if (!_players.UseServerAuthority)
-		{
-			// Assign property ownership if server authority mode is off
-			plr.NetPropAuthority = peerID;
-		}
-
 		// Insert default character on client
 		if (NetworkMode == NetworkModeEnum.Client)
 		{
 			Root.Insert.InitializeDefaultNPC(plr);
 		}
 
+		// Assign network authorties
+		plr.SetNetworkAuthority(peerID, true);
+		plr.Character?.SetNetworkAuthority(plr);
+		plr.Character?.SetNetworkAuthority(peerID, true);
+		if (!_players.UseServerAuthority)
+		{
+			// Assign property ownership if server authority mode is off
+			plr.NetPropAuthority = peerID;
+			plr.Character?.NetPropAuthority = peerID;
+		}
+
 		plr.Parent = _players;
 
-		if (plr.Character != null)
-		{
-			plr.Character.Anchored = true;
-		}
+		plr.Character?.Anchored = true;
 		plr.IsReady = false;
 
 		// Copy instances from player default
@@ -899,10 +898,7 @@ public sealed partial class NetworkService : Instance
 			if (IsServer)
 			{
 				plr.IsReady = true;
-				if (plr.Character != null)
-				{
-					plr.Character.Anchored = true;
-				}
+				plr.Character?.Anchored = true;
 				plr.Respawn();
 				Root.Players.InvokePlayerAdded(plr);
 				RpcId(peerID, nameof(NetRecvReportReady));

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -686,7 +686,7 @@ public sealed partial class NetworkService : Instance
 
 		// Assign network authorties
 		plr.SetNetworkAuthority(peerID, true);
-		plr?.Character.NetTransformAuthority = peerID;
+		plr.Character?.NetTransformAuthority = peerID;
 		if (!_players.UseServerAuthority)
 		{
 			// Assign property ownership if server authority mode is off

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -77,8 +77,9 @@ public class DefaultMovement : IPlayerMovement
 
 	public void ProcessInput(InputSnapshot snapshot)
 	{
-		CharacterModel TargetCharacter = Target.Character;
 		if (Target == null) return;
+		CharacterModel TargetCharacter = Target.Character!;
+		if (TargetCharacter == null) return;
 
 		bool isOnFloor = TargetCharacter.CharBody3D.IsOnFloor();
 		CharacterModel.CharacterModelStateEnum finalState = CharacterModel.CharacterModelStateEnum.Idle;

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -20,7 +20,7 @@ public class DefaultMovement : IPlayerMovement
 		bool sprint = false;
 		bool camLocked = false;
 
-		if (cam != null && Root.Input.IsGameFocused && Target.CanMove && !Target.IsDead)
+		if (cam != null && Root.Input.IsGameFocused)
 		{
 			Vector3 facingRot = cam.Camera3D.GlobalRotation;
 			camRotation = facingRot;
@@ -77,17 +77,20 @@ public class DefaultMovement : IPlayerMovement
 
 	public void ProcessInput(InputSnapshot snapshot)
 	{
-		bool isOnFloor = Target.CharBody3D.IsOnFloor();
+		CharacterModel TargetCharacter = Target.Character;
+		if (Target == null) return;
+
+		bool isOnFloor = TargetCharacter.CharBody3D.IsOnFloor();
 		CharacterModel.CharacterModelStateEnum finalState = CharacterModel.CharacterModelStateEnum.Idle;
 
 		double delta = snapshot.Delta;
 
-		Vector3 externalVelocity = Target.ExternalVelocity;
+		Vector3 externalVelocity = TargetCharacter.ExternalVelocity;
 		bool hasExternalVelocity = externalVelocity.X != 0 || externalVelocity.Z != 0;
 
-		if (Target.CanMove && !Target.IsDead)
+		if (TargetCharacter.CanMove && !TargetCharacter.IsDead)
 		{
-			float gdWalkSpeed = Target.WalkSpeed;
+			float gdWalkSpeed = TargetCharacter.WalkSpeed;
 			bool sprinting = snapshot.Sprint;
 
 			Vector3 moveDirection = snapshot.MoveDirection;
@@ -96,15 +99,15 @@ public class DefaultMovement : IPlayerMovement
 			// Handle jump
 			if (snapshot.Jump)
 			{
-				Target.Jump();
+				TargetCharacter.Jump();
 			}
 
 			// Sprint/Stamina
 			if (sprinting && moveDirection != Vector3.Zero)
 			{
-				if (Target.Stamina > 0 || !Target.UseStamina)
+				if (TargetCharacter.Stamina > 0 || !TargetCharacter.UseStamina)
 				{
-					gdWalkSpeed = Target.SprintSpeed;
+					gdWalkSpeed = TargetCharacter.SprintSpeed;
 				}
 				else
 				{
@@ -112,131 +115,140 @@ public class DefaultMovement : IPlayerMovement
 					Target.SprintHoldAgain = true;
 				}
 
-				Target.RemoveStaminaTick(delta);
+				TargetCharacter.RemoveStaminaTick(delta);
 			}
 			else
 			{
-				Target.AddStaminaTick(delta);
+				TargetCharacter.AddStaminaTick(delta);
 			}
 
-			if (Target.IsClimbing)
+			if (TargetCharacter.IsClimbing)
 			{
 				// Reset all vectors, lock to Y only
-				Target.CharacterVelocity.X = 0;
-				Target.CharacterVelocity.Z = 0;
+				TargetCharacter.CharacterVelocity.X = 0;
+				TargetCharacter.CharacterVelocity.Z = 0;
 
-				float climbSpeed = forwardInput * gdWalkSpeed * Target.ClimbingTruss!.ClimbSpeed;
+				float climbSpeed = forwardInput * gdWalkSpeed * TargetCharacter.ClimbingTruss!.ClimbSpeed;
 
 				// Add y velocity
-				Target.CharacterVelocity.Y = climbSpeed;
+				TargetCharacter.CharacterVelocity.Y = climbSpeed;
 
 				finalState = CharacterModel.CharacterModelStateEnum.Climbing;
-				Target.Character?.SetAnimSpeed(climbSpeed / 8);
+				TargetCharacter.SetAnimSpeed(climbSpeed / 8);
 			}
-			else if (Target.JustFinishedClimbing)
+			else if (TargetCharacter.JustFinishedClimbing)
 			{
-				Target.JustFinishedClimbing = false;
-				Target.CharacterVelocity.Y = 0;
+				TargetCharacter.JustFinishedClimbing = false;
+				TargetCharacter.CharacterVelocity.Y = 0;
 			}
 
 			// Always rotate in first person
 			if (snapshot.CamLocked)
 			{
-				Target.Rotation = Target.Rotation with { Y = 180 + Mathf.RadToDeg(snapshot.CameraRotation.Y) };
+				TargetCharacter.Rotation = TargetCharacter.Rotation with { Y = 180 + Mathf.RadToDeg(snapshot.CameraRotation.Y) };
 			}
 
 			Vector3 pushVelocity = hasExternalVelocity
 				? externalVelocity with { Y = 0 }
 				: Vector3.Zero;
 
-			if (moveDirection != Vector3.Zero && !Target.IsClimbing)
+			if (moveDirection != Vector3.Zero && !TargetCharacter.IsClimbing)
 			{
 				Target.IsMoving = true;
 
-				Target.CharacterVelocity.X = (moveDirection.X * gdWalkSpeed) + pushVelocity.X;
-				Target.CharacterVelocity.Z = (moveDirection.Z * gdWalkSpeed) + pushVelocity.Z;
+				TargetCharacter.CharacterVelocity.X = (moveDirection.X * gdWalkSpeed) + pushVelocity.X;
+				TargetCharacter.CharacterVelocity.Z = (moveDirection.Z * gdWalkSpeed) + pushVelocity.Z;
 
 				if (!snapshot.CamLocked)
 				{
 					// Apply rotation by move direction
-					Target.Rotation = Target.Rotation with
+					TargetCharacter.Rotation = TargetCharacter.Rotation with
 					{
-						Y = Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Target.Rotation.Y), Mathf.Atan2(Target.CharacterVelocity.X, Target.CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, NPC.BodyRotateLerp)))
+						Y = Mathf.RadToDeg(
+							Mathf.LerpAngle(
+								Mathf.DegToRad(TargetCharacter.Rotation.Y),
+								Mathf.Atan2(
+									TargetCharacter.CharacterVelocity.X,
+									TargetCharacter.CharacterVelocity.Z
+								),
+								MathUtils.ExpDecay((float)delta, NPC.BodyRotateLerp)
+							)
+						)
 					};
 				}
 
 
 				float animMoveAmount = Mathf.Max(Mathf.Clamp(moveDirection.Length(), 0f, 1f), 0.15f);
-				if (sprinting && Target.SprintSpeed != Target.WalkSpeed)
+				if (sprinting && TargetCharacter.SprintSpeed != TargetCharacter.WalkSpeed)
 				{
 					finalState = CharacterModel.CharacterModelStateEnum.Running;
-					Target.Character?.SetAnimSpeed(gdWalkSpeed / 20 * animMoveAmount);
+					TargetCharacter.SetAnimSpeed(gdWalkSpeed / 20 * animMoveAmount);
 				}
 				else
 				{
 					finalState = CharacterModel.CharacterModelStateEnum.Walking;
-					Target.Character?.SetAnimSpeed(gdWalkSpeed / 8 * animMoveAmount);
+					TargetCharacter.SetAnimSpeed(gdWalkSpeed / 8 * animMoveAmount);
 				}
 			}
-			else if (!Target.IsClimbing)
+			else if (!TargetCharacter.IsClimbing)
 			{
 				Target.IsMoving = false;
 
 				if (hasExternalVelocity)
 				{
-					Target.CharacterVelocity.X = pushVelocity.X;
-					Target.CharacterVelocity.Z = pushVelocity.Z;
+					TargetCharacter.CharacterVelocity.X = pushVelocity.X;
+					TargetCharacter.CharacterVelocity.Z = pushVelocity.Z;
 				}
 				else
 				{
 					// Stop horizontal movement when no input
-					Target.CharacterVelocity.X = Mathf.MoveToward(Target.CharacterVelocity.X, 0, gdWalkSpeed);
-					Target.CharacterVelocity.Z = Mathf.MoveToward(Target.CharacterVelocity.Z, 0, gdWalkSpeed);
+					TargetCharacter.CharacterVelocity.X = Mathf.MoveToward(TargetCharacter.CharacterVelocity.X, 0, gdWalkSpeed);
+					TargetCharacter.CharacterVelocity.Z = Mathf.MoveToward(TargetCharacter.CharacterVelocity.Z, 0, gdWalkSpeed);
 				}
-				Target.Character?.SetAnimSpeed(1);
+				TargetCharacter.SetAnimSpeed(1);
 			}
 
-			if (!isOnFloor && !Target.IsClimbing)
+			if (!isOnFloor && !TargetCharacter.IsClimbing)
 			{
-				Target.Character?.SetAnimSpeed(1);
+				TargetCharacter.SetAnimSpeed(1);
 				finalState = CharacterModel.CharacterModelStateEnum.Jumping;
 			}
 
 			// Remove debounce if touched the ground
-			if (Target.ClimbDebounce && isOnFloor)
+			if (TargetCharacter.ClimbDebounce && isOnFloor)
 			{
-				Target.ClimbDebounce = false;
+				TargetCharacter.ClimbDebounce = false;
 			}
 
-			if (Target.IsClimbing && isOnFloor)
+			if (TargetCharacter.IsClimbing && isOnFloor)
 			{
-				Target.EndClimb();
+				TargetCharacter.EndClimb();
 			}
 		}
 		else
 		{
-			Target.CharacterVelocity = new Vector3(0, Target.CharacterVelocity.Y, 0);
+			TargetCharacter.CharacterVelocity = new Vector3(0, TargetCharacter.CharacterVelocity.Y, 0);
 		}
 
-		Target.Character?.SetState(finalState);
+		TargetCharacter.SetState(finalState);
 
 		if (hasExternalVelocity)
 		{
-			float decay = Target.WalkSpeed * 60f * (float)delta;
-			Target.ExternalVelocity = new Vector3(
+			float decay = TargetCharacter.WalkSpeed * 60f * (float)delta;
+			TargetCharacter.ExternalVelocity = new Vector3(
 				Mathf.MoveToward(externalVelocity.X, 0, decay),
 				externalVelocity.Y,
 				Mathf.MoveToward(externalVelocity.Z, 0, decay)
 			);
 		}
 
-		Target.ApplyInternalVelocity(Target.CharacterVelocity);
-		Target.CharBody3D.Velocity = Target.CharacterVelocity;
-		Target.CharBody3D.MoveAndSlide();
+		TargetCharacter.ApplyInternalVelocity(TargetCharacter.CharacterVelocity);
+		TargetCharacter.CharBody3D.Velocity = TargetCharacter.CharacterVelocity;
+		TargetCharacter.CharBody3D.MoveAndSlide();
 
-		if (isOnFloor && Target.IsMoving && !Target.IsClimbing && !Target.IsSitting)
+		if (isOnFloor && Target.IsMoving && !TargetCharacter.IsClimbing && !TargetCharacter.IsSitting)
 		{
-			Target.TryStepUp();
+			TargetCharacter.TryStepUp();
 		}
 	}
 }

--- a/Polytoria/scripts/renderer/RendererViewport.cs
+++ b/Polytoria/scripts/renderer/RendererViewport.cs
@@ -74,9 +74,9 @@ public partial class RendererViewport : SubViewport
 
 		NPC npc = Root.Insert.DefaultNPC();
 		npc.Parent = Root.Environment;
-		npc.UseNametag = false;
 		npc.GDNode3D.RotationDegrees = new(0, 15, 0);
 		PolytorianModel ptm = (PolytorianModel)npc.Character!;
+		ptm.UseNametag = false;
 
 		ptm.SetAnimationOverrideTo(true);
 		AnimationPlayer ply = ptm.AnimTree.GetNode<AnimationPlayer>(ptm.AnimTree.AnimPlayer);

--- a/Polytoria/scripts/renderer/RendererViewport.cs
+++ b/Polytoria/scripts/renderer/RendererViewport.cs
@@ -74,7 +74,7 @@ public partial class RendererViewport : SubViewport
 
 		NPC npc = Root.Insert.DefaultNPC();
 		npc.Parent = Root.Environment;
-		npc.GDNode3D.RotationDegrees = new(0, 15, 0);
+		npc.Character!.GDNode3D.RotationDegrees = new(0, 15, 0);
 		PolytorianModel ptm = (PolytorianModel)npc.Character!;
 		ptm.UseNametag = false;
 

--- a/Polytoria/scripts/renderer/RendererViewport.cs
+++ b/Polytoria/scripts/renderer/RendererViewport.cs
@@ -72,10 +72,9 @@ public partial class RendererViewport : SubViewport
 		Camera cam = Root.Environment.CurrentCamera!;
 		Camera3D c3d = cam.Camera3D;
 
-		NPC npc = Root.Insert.DefaultNPC();
-		npc.Parent = Root.Environment;
-		npc.Character!.GDNode3D.RotationDegrees = new(0, 15, 0);
-		PolytorianModel ptm = (PolytorianModel)npc.Character!;
+		PolytorianModel ptm = Root.Insert.DefaultNPCCharacter();
+		ptm.Parent = Root.Environment;
+		ptm.GDNode3D.RotationDegrees = new(0, 15, 0);
 		ptm.UseNametag = false;
 
 		ptm.SetAnimationOverrideTo(true);

--- a/dm-tests/main.poly
+++ b/dm-tests/main.poly
@@ -1,5 +1,5 @@
 {
-  "Version": "2.0.12\u002Bdev",
+  "Version": "2.0.19\u002Bdev",
   "FileType": 0,
   "Objects": [
     {
@@ -522,54 +522,8 @@
                   "ClassName": "NPC",
                   "ID": "297651b0-836e-4ebd-87c9-99363fcc1e6c",
                   "Properties": {
-                    "Velocity": [
-                      0,
-                      0,
-                      0
-                    ],
-                    "SeatOffset": [
-                      0,
-                      1.5,
-                      0
-                    ],
-                    "Health": 100,
-                    "MaxHealth": 100,
-                    "JumpPower": 36,
-                    "WalkSpeed": 16,
-                    "UseNametag": true,
-                    "NametagOffset": [
-                      0,
-                      0,
-                      0
-                    ],
-                    "NametagVisibleRadius": 40,
                     "DisplayName": "",
-                    "JumpSound": "ddc48a2c-a146-4bed-8bc1-f279e0e0e46f",
                     "Character": "c4f96fd9-aba4-4141-80e8-f4bb0086646d",
-                    "Anchored": false,
-                    "CanCollide": true,
-                    "CollisionLayers": 1,
-                    "CollisionMask": 3,
-                    "AngularVelocity": [
-                      0,
-                      -0,
-                      -0
-                    ],
-                    "LocalPosition": [
-                      0,
-                      3,
-                      2
-                    ],
-                    "LocalRotation": [
-                      -0,
-                      0,
-                      0
-                    ],
-                    "LocalSize": [
-                      1,
-                      1,
-                      1
-                    ],
                     "Tags": []
                   },
                   "Children": [
@@ -584,16 +538,59 @@
                         "RightArmColor": "ffffffff",
                         "LeftLegColor": "ffffffff",
                         "RightLegColor": "ffffffff",
-                        "Animator": "6ff8f25d-eec7-4398-a265-0a80f845247c",
-                        "LocalPosition": [
+                        "JumpSound": "ddc48a2c-a146-4bed-8bc1-f279e0e0e46f",
+                        "AllowAnimationWhileMoving": false,
+                        "KeepInventory": false,
+                        "UseHeadTurning": false,
+                        "SprintSpeed": 0,
+                        "Stamina": 0,
+                        "MaxStamina": 3,
+                        "UseStamina": true,
+                        "StaminaRegen": 1.2,
+                        "StaminaBurn": 1.2,
+                        "SeatOffset": [
+                          0,
+                          1.5,
+                          0
+                        ],
+                        "UseNametag": true,
+                        "NametagOffset": [
                           0,
                           0,
                           0
                         ],
-                        "LocalRotation": [
+                        "NametagVisibleRadius": 40,
+                        "CanMove": true,
+                        "Health": 100,
+                        "MaxHealth": 100,
+                        "JumpPower": 36,
+                        "WalkSpeed": 16,
+                        "UseBubbleChat": true,
+                        "Velocity": [
+                          0,
+                          0,
+                          0
+                        ],
+                        "Controller": "297651b0-836e-4ebd-87c9-99363fcc1e6c",
+                        "Animator": "6ff8f25d-eec7-4398-a265-0a80f845247c",
+                        "Anchored": false,
+                        "CanCollide": true,
+                        "CollisionLayers": 1,
+                        "CollisionMask": 3,
+                        "AngularVelocity": [
                           0,
                           -0,
                           -0
+                        ],
+                        "LocalPosition": [
+                          -11,
+                          3,
+                          -6
+                        ],
+                        "LocalRotation": [
+                          -0,
+                          0,
+                          0
                         ],
                         "LocalSize": [
                           1,
@@ -626,8 +623,10 @@
                         "Audio": "d3e89ca2-fdcb-40e4-b44b-dada777d3496",
                         "Volume": 0.5,
                         "Pitch": 1,
+                        "Pan": 0,
                         "Autoplay": false,
                         "Loop": false,
+                        "LoopStart": 0,
                         "PlayInWorld": true,
                         "Paused": false,
                         "MaxDistance": 60,
@@ -1076,6 +1075,8 @@
             "Stamina": 0,
             "MaxStamina": 3,
             "StaminaRegen": 1.2,
+            "ReuseCharacter": true,
+            "KeepInventory": false,
             "UseHeadTurning": true,
             "UseBubbleChat": true,
             "AutoLoadAppearance": true,
@@ -1129,6 +1130,7 @@
           "ID": "1e50f39e-881b-4444-b137-2b90385018a5",
           "Properties": {
             "CtrlLockCursor": 1,
+            "ChatBubbleRenderDistance": 40,
             "UseUserCard": true,
             "UseChat": true,
             "UseHealthBar": true,

--- a/dm-tests/scripts/server/tests/Raycast.server.luau
+++ b/dm-tests/scripts/server/tests/Raycast.server.luau
@@ -6,7 +6,7 @@ function Entry()
 	local npc: NPC = suite["NPC"]
 
 	local hit = Environment:Raycast(p1.Position, p1.Forward, 10, {})
-	assert(hit.Instance == npc)
+	assert(hit.Instance == npc.Character)
 
 	local hit2 = Environment:Raycast(p1.Position, p1.Forward, 10, { npc })
 	assert(hit2.Instance == p2)

--- a/dm-tests/scripts/server/tests/Raycast.server.luau
+++ b/dm-tests/scripts/server/tests/Raycast.server.luau
@@ -6,7 +6,7 @@ function Entry()
 	local char: CharacterModel = suite["NPC"].Character
 
 	local hit = Environment:Raycast(p1.Position, p1.Forward, 10, {})
-	assert(hit.Instance == npc.Character)
+	assert(hit.Instance == char)
 
 	local hit2 = Environment:Raycast(p1.Position, p1.Forward, 10, { char })
 	assert(hit2.Instance == p2)

--- a/dm-tests/scripts/server/tests/Raycast.server.luau
+++ b/dm-tests/scripts/server/tests/Raycast.server.luau
@@ -3,17 +3,17 @@ function Entry()
 	local p1: Part = suite["1"]
 	local p2: Part = suite["2"]
 	local p3: Part = suite["3"]
-	local npc: NPC = suite["NPC"]
+	local char: CharacterModel = suite["NPC"].Character
 
 	local hit = Environment:Raycast(p1.Position, p1.Forward, 10, {})
 	assert(hit.Instance == npc.Character)
 
-	local hit2 = Environment:Raycast(p1.Position, p1.Forward, 10, { npc })
+	local hit2 = Environment:Raycast(p1.Position, p1.Forward, 10, { char })
 	assert(hit2.Instance == p2)
 
-	local hit3 = Environment:Raycast(p1.Position, p1.Forward, 10, { p2, npc })
+	local hit3 = Environment:Raycast(p1.Position, p1.Forward, 10, { p2, char })
 	assert(hit3.Instance == p3)
 
-	local hit4 = Environment:Raycast(p1.Position, p1.Forward, 10, { p2, npc, p3 })
-	assert(hit4 == nil or hit3["Instance"] == nil)
+	local hit4 = Environment:Raycast(p1.Position, p1.Forward, 10, { p2, char, p3 })
+	assert(hit4 == nil or hit4["Instance"] == nil)
 end


### PR DESCRIPTION
## Summary

moves default-character-specific behavior from `Player` to `CharacterModel`, for games that don't work with the default character

### `NPC` → `CharacterModel`:
- (all `Physical` fields/methods/signals)
- (all `Dynamic` fields/methods/signals)
- `SeatOffset`
- `Health`
- `MaxHealth`
- `JumpPower`
- `WalkSpeed`
- `JumpSound`
- `UseNametag`
- `NametagOffset`
- `NametagVisibleRadius`
- `IsSitting`
- `IsDead`
- `HoldingTool`
- `IsOnGround`
- `IsOnCeiling`
- `Died`
- `Landed`
- `HealthChanged`
- `Jumped`
- `LeftGround`
- `Seated`
- `Unseated`
- `Jump()`
- `TryStepUp()`
- `Kill()`
- `Move()`
- `Sit()`
- `Unsit()`
- `EquipTool()`
- `DropTool()`
- `Respawn()` (still present in `Player`, for `PlayerDefaults` behavior)
- `TakeDamage()`
- `Heal()`
- many fields/arguments
- creator selection

### `NPC` → `PolytorianModel`:
- `LoadAppearance()`
- `ClearAppearance()`

### `Player` → `CharacterModel`:
- `ClimbingTruss`
- `IsClimbing`
- `AllowAnimationWhileMoving`
- `CanMove`
- `KeepInventory`
- `UseHeadTurning`
- `UseBubbleChat`
- `SprintSpeed`
- `Stamina`
- `MaxStamina`
- `UseStamina`
- `StaminaBurn`
- `StaminaRegen`
- `Inventory`

### `Player` → `Camera`:
- tracking behavior

### `CharacterModel*` → `PolytorianModel` (*was never implemented):
- `GetAttachment()`

### +`CharacterModel`
- `Controller` (inverse of `NPC.Character`)
- `Head` (head attachment, can be set by scripts)
- `ToolAttachment` (thing that holds tools (hands), can be set by scripts)

### +`PlayerDefaults`
- `ReuseCharacter`
- `CorpseDecay`
- `AutomaticSpawn`
- `AutoCameraFollow`

### +`InsertService`
- `DefaultNPCCharacter()`
- `InitializeDefaultCharacter()`

## Related issue or discussion

Related to and closes #880
closes #879
closes #910 by obviation

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed) (←unsure)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)
- [x] fix camera when direction-locked
- [x] fix lack of sliding
- [x] test character deletion
- [x] fix 1st death being different to the others
- [x] implement some simple logically implied helpers
- [x] successfully migrate fields and methods
- [x] backwards compatibility

## AI/LLM use

none