### PR TITLE
Fix TouchScrollContainer eating input while hidden

### DIFF
--- a/Polytoria/scripts/client/TouchScrollContainer.cs
+++ b/Polytoria/scripts/client/TouchScrollContainer.cs
@@ -15,7 +15,7 @@ public partial class TouchScrollContainer : ScrollContainer
 
 	public override void _Input(InputEvent @event)
 	{
-		if (!TouchDragScroll || !Visible || !IsInsideTree())
+		if (!TouchDragScroll || !IsInsideTree() || !IsVisibleInTree())
 			return;
 
 		if (@event is InputEventScreenTouch touch)


### PR DESCRIPTION
## Summary
TouchScrollContainer used to eat input on mobile when not visible, creating a dead zone in the middle of the screen.
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion

Fixes -
Related to #739

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
None
<!-- Describe AI use, or write "None" if not applicable -->