### PR TITLE
Truss.Climbable property

### DIFF
--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -670,15 +670,11 @@ public sealed partial class Player : NPC
 			Node collider = (Node)FootFwdRaycast.GetCollider();
 			if (collider != null && GetNetObjFromProxy(collider) is Truss truss)
 			{
-				if (!IsClimbing)
+				if (!IsClimbing && !ClimbDebounce && truss.Climbable)
 				{
-					if (!ClimbDebounce)
-					{
-						ClimbingTruss = truss;
-						IsClimbing = true;
-						Character?.PlayClimb();
-					}
-
+					ClimbingTruss = truss;
+					IsClimbing = true;
+					Character?.PlayClimb();
 				}
 			}
 			else

--- a/Polytoria/scripts/datamodel/Truss.cs
+++ b/Polytoria/scripts/datamodel/Truss.cs
@@ -10,6 +10,7 @@ namespace Polytoria.Datamodel;
 public sealed partial class Truss : Part
 {
 	private float _climbSpeed;
+	private bool _climbable;
 
 	[Editable, ScriptProperty, DefaultValue(1f)]
 	public float ClimbSpeed
@@ -18,6 +19,17 @@ public sealed partial class Truss : Part
 		set
 		{
 			_climbSpeed = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool Climbable
+	{
+		get => _climbable;
+		set
+		{
+			_climbable = value;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

property that allows you to set if a truss is climbable or not

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

none!