### PR TITLE
allow players to climb up trusses while initially holding the spacebar

### DIFF
--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -40,6 +40,7 @@ public sealed partial class Player : NPC
 
 	private float _respawnTime = 5.0f;
 	private bool _canMove = true;
+	private bool _canJumpWhileClimbing = true;
 	private float _sprintSpeed;
 	private float _stamina = 0;
 	private float _maxStamina = 3;
@@ -675,6 +676,7 @@ public sealed partial class Player : NPC
 					if (!ClimbDebounce)
 					{
 						ClimbingTruss = truss;
+						_canJumpWhileClimbing = false;
 						IsClimbing = true;
 						Character?.PlayClimb();
 					}
@@ -803,6 +805,7 @@ public sealed partial class Player : NPC
 			// Ignore jump command if is custom
 			if (MovementMode == PlayerMovementModeEnum.Scripted) return;
 			if (!CanMove) return;
+			_canJumpWhileClimbing = true;
 			Jump();
 		}
 		else if (@event.IsActionPressed("toggle_sprint"))
@@ -917,10 +920,13 @@ public sealed partial class Player : NPC
 	public override void Jump()
 	{
 		base.Jump();
-		if (IsClimbing)
+		if (_canJumpWhileClimbing)
 		{
-			EndClimb();
-			ClimbDebounce = true;
+			if (IsClimbing)
+			{
+				EndClimb();
+				ClimbDebounce = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

added a private bool value named `_canJumpWhileClimbing` defaulted to true. when a player jumps into a truss it goes false. jumping off of a truss is impossible while `_canJumpWhileClimbing` is set to false. the value is set back to true when the player unholds the spacebar and presses it again

## Related issue or discussion

Fixes #881 

although #881 may want to fix a different bug i assure you the bug reported in #881 technically doesnt exist and this pr changes the behavior of truss climbing to "fix" it. #881 only happens when the player holds both shift and spacebar and forgets to unhold spacebar while jumping into a truss causing that behavior.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video


## AI/LLM use
None