### PR TITLE
Use NetworkedObject's ID in Sound

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -22,7 +22,6 @@ public sealed partial class Sound : Dynamic
 	public const float SoundDistanceMultipler = 1.25f;
 	private const float MinPitch = 0.001f;
 	private const float MaxVolume = 2f;
-	private static int _counter = 0;
 	private AudioStreamPlayer? _audioPlayer;
 	private AudioStreamPlayer3D? _audioPlayer3D;
 	private bool _playAfterLoad = false;
@@ -30,7 +29,6 @@ public sealed partial class Sound : Dynamic
 	private Resource? _prevAsset;
 	private string _audioBusName = "Master";
 	private AudioEffectPanner? _efPanner;
-	private int _id = System.Threading.Interlocked.Increment(ref _counter);
 
 	private AudioAsset? _asset;
 	private int _soundID = 0;
@@ -306,7 +304,7 @@ public sealed partial class Sound : Dynamic
 
 		if (!PlayInWorld)
 		{
-			_audioBusName = $"Sound_{_id}";
+			_audioBusName = "Sound_" + ObjectID;
 			AudioServer.AddBus();
 			int idx = AudioServer.BusCount - 1;
 			AudioServer.SetBusName(idx, _audioBusName);


### PR DESCRIPTION
Instead of clever hack. Use what is already there and remove extra moving part.

## Summary

Small nitpick for Sound's audio bus name assignment.

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ x ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ x ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ x ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [ x ] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ x ] Added in-code documentation (where needed)
- [ x ] Ran `dotnet restore`
- [ x ] Ran `dotnet format`
- [ x ] Ran `dotnet build`
- [ x ] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [ x ] Tested the changes in a local environment
- [ x ] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None.