### PR TITLE
Add GUI.AvoidCoreUI

### DIFF
--- a/Polytoria/scenes/client/ui/core_ui.tscn
+++ b/Polytoria/scenes/client/ui/core_ui.tscn
@@ -298,6 +298,7 @@ metadata/_edit_vertical_guides_ = [1136.0]
 
 [node name="Control" type="Control" parent="." unique_id=968701468]
 layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2

--- a/Polytoria/scenes/client/ui/core_ui.tscn
+++ b/Polytoria/scenes/client/ui/core_ui.tscn
@@ -298,7 +298,6 @@ metadata/_edit_vertical_guides_ = [1136.0]
 
 [node name="Control" type="Control" parent="." unique_id=968701468]
 layout_mode = 3
-anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2

--- a/Polytoria/scripts/datamodel/GUI.cs
+++ b/Polytoria/scripts/datamodel/GUI.cs
@@ -6,6 +6,7 @@ using Godot;
 using Polytoria.Attributes;
 #if CREATOR
 using Polytoria.Datamodel.Creator;
+using Polytoria.Datamodel.Services;
 #endif
 
 namespace Polytoria.Datamodel;
@@ -17,9 +18,6 @@ public partial class GUI : Instance
 	private bool _visible = true;
 	private int _zIndex = 0;
 	private bool _avoidCoreUI = false;
-
-	[ScriptProperty]
-	public static float CoreUIInset { get; } = 80;
 
 	[Editable, ScriptProperty]
 	public bool Visible
@@ -55,7 +53,7 @@ public partial class GUI : Instance
 			_avoidCoreUI = value;
 			if (Root.SessionType != World.SessionTypeEnum.Creator)
 			{
-				_control.OffsetTop = value ? CoreUIInset : 0;
+				_control.OffsetTop = value ? CoreUIService.TopInset : 0;
 			}
 			OnPropertyChanged();
 		}

--- a/Polytoria/scripts/datamodel/GUI.cs
+++ b/Polytoria/scripts/datamodel/GUI.cs
@@ -16,6 +16,10 @@ public partial class GUI : Instance
 	private Control _control = null!;
 	private bool _visible = true;
 	private int _zIndex = 0;
+	private bool _avoidCoreUI = false;
+
+	[ScriptProperty]
+	public static float CoreUIInset { get; } = 80;
 
 	[Editable, ScriptProperty]
 	public bool Visible
@@ -38,6 +42,21 @@ public partial class GUI : Instance
 		{
 			_zIndex = value;
 			_control.ZIndex = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool AvoidCoreUI
+	{
+		get => _avoidCoreUI;
+		set
+		{
+			_avoidCoreUI = value;
+			if (Root.SessionType != World.SessionTypeEnum.Creator)
+			{
+				_control.OffsetTop = value ? CoreUIInset : 0;
+			}
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/GUI.cs
+++ b/Polytoria/scripts/datamodel/GUI.cs
@@ -6,8 +6,8 @@ using Godot;
 using Polytoria.Attributes;
 #if CREATOR
 using Polytoria.Datamodel.Creator;
-using Polytoria.Datamodel.Services;
 #endif
+using Polytoria.Datamodel.Services;
 
 namespace Polytoria.Datamodel;
 

--- a/Polytoria/scripts/datamodel/services/CoreUIService.cs
+++ b/Polytoria/scripts/datamodel/services/CoreUIService.cs
@@ -31,6 +31,9 @@ public sealed partial class CoreUIService : Instance
 
 	public PTSignal CtrlLockCursorChanged { get; private set; } = new();
 
+	[ScriptProperty]
+	public static float TopInset => 80;
+
 	[Editable, ScriptProperty]
 	public CtrlLockCursorEnum CtrlLockCursor
 	{


### PR DESCRIPTION
## Summary

adds `GUI.AvoidCoreUI` (only works outside of creator) and `CoreUIService.TopInset` (\# of pixels `GUI.AvoidCoreUI` insets on the top, currently 80)

## Related issue or discussion

(no related issue, from [this discord suggestion](https://discord.com/channels/350679908390797313/1528732111425769593))

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None