### PR TITLE
limit disconnect reason to 16 lines

### DIFF
--- a/Polytoria/scenes/client/ui/core/disconnected_ui.tscn
+++ b/Polytoria/scenes/client/ui/core/disconnected_ui.tscn
@@ -241,6 +241,7 @@ theme_override_font_sizes/font_size = 16
 text = "Reason"
 horizontal_alignment = 1
 autowrap_mode = 3
+max_lines_visible = 16
 
 [node name="DisconnectCode" type="Label" parent="ColorRect/Pivot/Panel/VBoxContainer" unique_id=1066318451]
 layout_mode = 2


### PR DESCRIPTION
## Summary

disconnect UI reason is now limited to 16 lines

## Related issue or discussion

Fixes #975 (kinda? it's not ideal but it's there)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] ~~Added in-code documentation (where needed)~~ no code was touched
- [x] Ran `dotnet restore`
- [ ] ~~Ran `dotnet format`~~ no code was touched
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
dunno how?

## AI/LLM use
none