### PR TITLE
dragging on slopes + {rotate/tilt, drag} on every tool + rotate on slopes

### DIFF
--- a/Polytoria/scenes/creator/creator.tscn
+++ b/Polytoria/scenes/creator/creator.tscn
@@ -625,7 +625,6 @@ button_pressed = true
 action_mode = 0
 button_group = SubResource("ButtonGroup_v0rtd")
 script = ExtResource("8_c8w7j")
-ToolMode = null
 
 [node name="Icon" type="TextureRect" parent="GUI/Ribbon/Buttons/Select" unique_id=75873074]
 layout_mode = 1
@@ -750,7 +749,7 @@ vertical_alignment = 2
 layout_mode = 2
 mouse_filter = 2
 
-[node name="Snapping" type="VBoxContainer" parent="GUI/Ribbon/Buttons" unique_id=2133884039 node_paths=PackedStringArray("_moveCheck", "_moveValue", "_rotateCheck", "_rotateValue")]
+[node name="Snapping" type="VBoxContainer" parent="GUI/Ribbon/Buttons" unique_id=2133884039 node_paths=PackedStringArray("_moveCheck", "_moveValue", "_rotateCheck", "_rotateValue", "_rotateAlignCheck")]
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/separation = 0
@@ -759,6 +758,7 @@ _moveCheck = NodePath("Move/Check")
 _moveValue = NodePath("Move/Value")
 _rotateCheck = NodePath("Rotate/Check")
 _rotateValue = NodePath("Rotate/Value")
+_rotateAlignCheck = NodePath("../Alignment/Check")
 
 [node name="Move" type="HBoxContainer" parent="GUI/Ribbon/Buttons/Snapping" unique_id=1273399493]
 layout_mode = 2
@@ -819,6 +819,29 @@ horizontal_alignment = 1
 vertical_alignment = 2
 
 [node name="Separator2" type="VSeparator" parent="GUI/Ribbon/Buttons" unique_id=204083408]
+layout_mode = 2
+mouse_filter = 2
+
+[node name="Alignment" type="VBoxContainer" parent="GUI/Ribbon/Buttons" unique_id=1434806598]
+layout_mode = 2
+mouse_filter = 2
+theme_override_constants/separation = 0
+
+[node name="Check" type="CheckBox" parent="GUI/Ribbon/Buttons/Alignment" unique_id=1337395454]
+custom_minimum_size = Vector2(87, 56)
+layout_mode = 2
+size_flags_horizontal = 3
+action_mode = 0
+text = "Rotate"
+
+[node name="Label" type="Label" parent="GUI/Ribbon/Buttons/Alignment" unique_id=205097386]
+layout_mode = 2
+size_flags_vertical = 8
+text = "Alignment"
+horizontal_alignment = 1
+vertical_alignment = 2
+
+[node name="Separator3" type="VSeparator" parent="GUI/Ribbon/Buttons" unique_id=1661999198]
 layout_mode = 2
 mouse_filter = 2
 
@@ -994,7 +1017,7 @@ anchor_top = 1.0
 anchor_bottom = 1.0
 grow_vertical = 0
 
-[node name="Separator3" type="VSeparator" parent="GUI/Ribbon/Buttons" unique_id=1661999198]
+[node name="Separator4" type="VSeparator" parent="GUI/Ribbon/Buttons" unique_id=1646011575]
 layout_mode = 2
 mouse_filter = 2
 

--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -55,6 +55,7 @@ public partial class CreatorInterface : Control, IScriptObject
 	[ScriptProperty] public Part.PartMaterialEnum TargetPartMaterial { get; internal set; } = Part.PartMaterialEnum.SmoothPlastic;
 
 	[ScriptProperty] public bool MoveSnapEnabled { get; internal set; } = true;
+	[ScriptProperty] public bool RotateAlignEnabled { get; internal set; } = false;
 
 	[ScriptProperty]
 	public float MoveSnapping

--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -30,6 +30,9 @@ public sealed partial class Gizmos : Node
 	private SelectionBox _paintBox = null!;
 	private SelectionBox _hoverBox = null!;
 
+	private Vector3 _dragStartNormal;
+	private Vector3 _dragStartOrigin;
+
 	public bool HoveringGizmos { get; set; }
 	public bool HoveringUIGizmo { get; set; }
 	public bool IsDraggingDynamic => _isDraggingDyn;
@@ -423,9 +426,9 @@ public sealed partial class Gizmos : Node
 		Vector2 mousePos = _camera.GetViewport().GetMousePosition();
 
 		Vector3 rayOrigin = _camera.ProjectRayOrigin(mousePos);
-		Vector3 rayNormal = rayOrigin + _camera.ProjectRayNormal(mousePos) * 1000;
+		Vector3 rayTarget = rayOrigin + _camera.ProjectRayNormal(mousePos) * 1000;
 
-		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayOrigin, rayNormal);
+		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayOrigin, rayTarget);
 		query.CollideWithAreas = true;
 		query.CollideWithBodies = true;
 		query.CollisionMask = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
@@ -472,8 +475,13 @@ public sealed partial class Gizmos : Node
 			_hoverBox.Target = null;
 		}
 
-		// Select shortcuts
-		if (toolMode == ToolModeEnum.Select)
+		// Select and transform shortcuts
+		if (
+			toolMode == ToolModeEnum.Scale ||
+			toolMode == ToolModeEnum.Move ||
+			toolMode == ToolModeEnum.Rotate ||
+			toolMode == ToolModeEnum.Select
+		)
 		{
 			if (@event.IsActionPressed("gizmo_rotate"))
 			{
@@ -573,6 +581,7 @@ public sealed partial class Gizmos : Node
 				if (distance >= DragThreshold)
 				{
 					_isDraggingDyn = true;
+					OnDragStart();
 					_isDragPending = false;
 					_history.NewAction("Select Drag Transform");
 					RecordHistoryUndo();
@@ -586,6 +595,55 @@ public sealed partial class Gizmos : Node
 		}
 	}
 
+	private void OnDragStart()
+	{
+		// prepare _dragStartNormal and _dragStartOrigin
+		Vector2 mousePos = _camera.GetViewport().GetMousePosition();
+		Vector3 rayOrigin = _camera.ProjectRayOrigin(mousePos);
+		Vector3 rayTarget = rayOrigin + _camera.ProjectRayNormal(mousePos) * 1000;
+
+		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayTarget, rayOrigin); // backwards ray
+		query.CollideWithBodies = true;
+		query.CollideWithAreas = false;
+		query.CollisionMask = (1 << 4);
+
+		List<Physical> dragged = [];
+
+		foreach (Dynamic item in DragSelected)
+		{
+			if (item is Physical p)
+			{
+				dragged.Add(p);
+			}
+			// Add Descendants
+			foreach (Instance n in item.GetDescendants())
+			{
+				if (n is Physical p2)
+				{
+					dragged.Add(p2);
+				}
+			}
+		}
+
+		foreach (Physical p in dragged)
+		{
+			p.SetCollisionLayer(5, true);
+		}
+
+		Godot.Collections.Dictionary intersection = Root.World3D.DirectSpaceState.IntersectRay(query);
+
+		foreach (Physical p in dragged)
+		{
+			p.SetCollisionLayer(5, false);
+		}
+
+		if (intersection.Count > 0)
+		{
+			_dragStartOrigin = (Vector3)intersection["position"];
+			_dragStartNormal = (Vector3)intersection["normal"];
+		}
+	}
+
 	private void RotateSelectedAround(float angle)
 	{
 		Transform3D t = GetCenterPivot([.. Selected]);
@@ -595,11 +653,11 @@ public sealed partial class Gizmos : Node
 		foreach (Dynamic item in Selected)
 		{
 			Vector3 relativePos = item.GetGlobalPosition() - pivotPosition;
-			Transform3D rotation = Transform3D.Identity.Rotated(Vector3.Up, rotateAngle);
+			Transform3D rotation = Transform3D.Identity.Rotated(_dragStartNormal, -rotateAngle);
 			Vector3 rotatedPos = rotation * relativePos;
 
 			item.SetGlobalPosition(pivotPosition + rotatedPos);
-			item.GDNode3D.Rotation += new Vector3(0, rotateAngle, 0);
+			item.Quaternion = new Quaternion(_dragStartNormal, -rotateAngle) * item.Quaternion;
 
 			if (_selectionBoxes.TryGetValue(item, out var box)) box.InvalidateBoundCache();
 			item.UpdateCurrentTransformCache();
@@ -680,9 +738,9 @@ public sealed partial class Gizmos : Node
 	{
 		Vector2 mousePos = _camera.GetViewport().GetMousePosition();
 		Vector3 rayOrigin = _camera.ProjectRayOrigin(mousePos);
-		Vector3 rayNormal = rayOrigin + _camera.ProjectRayNormal(mousePos) * 1000;
+		Vector3 rayTarget = rayOrigin + _camera.ProjectRayNormal(mousePos) * 1000;
 
-		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayOrigin, rayNormal);
+		PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(rayOrigin, rayTarget);
 		query.CollideWithBodies = true;
 		query.CollideWithAreas = true;
 		query.CollisionMask = (1 << 0) | (1 << 1) | (1 << 3);
@@ -725,29 +783,37 @@ public sealed partial class Gizmos : Node
 
 			foreach (Dynamic item in DragSelected)
 			{
-				Aabb bounds = item.CreatorBounds;
-				Vector3 center = bounds.GetCenter();
-
-				Vector3 surfacePoint = center;
-
-				if (Mathf.Abs(hitNormal.X) > 0.5f)
-					surfacePoint.X = hitNormal.X > 0 ? bounds.Position.X : bounds.End.X;
-
-				if (Mathf.Abs(hitNormal.Y) > 0.5f)
-					surfacePoint.Y = hitNormal.Y > 0 ? bounds.Position.Y : bounds.End.Y;
-
-				if (Mathf.Abs(hitNormal.Z) > 0.5f)
-					surfacePoint.Z = hitNormal.Z > 0 ? bounds.Position.Z : bounds.End.Z;
-
-				Vector3 pivotOffset = item.GetGlobalPosition() - surfacePoint;
-
-				Vector3 snappedHitPos = new(
-					Mathf.Abs(hitNormal.X) > 0.9f ? pos.X : Mathf.Snapped(pos.X, snapAmount),
-					Mathf.Abs(hitNormal.Y) > 0.9f ? pos.Y : Mathf.Snapped(pos.Y, snapAmount),
-					Mathf.Abs(hitNormal.Z) > 0.9f ? pos.Z : Mathf.Snapped(pos.Z, snapAmount)
-				);
-
-				item.SetGlobalPosition(snappedHitPos + pivotOffset);
+				Vector3 offset = pos - _dragStartOrigin;
+				if (offset.LengthSquared() < 1e-6f) continue;
+				Vector3 arcOffset = Vector3.Zero;
+				if (CreatorService.Interface.RotateAlignEnabled)
+				{
+					Quaternion q = new Quaternion(-_dragStartNormal, hitNormal);
+					item.Quaternion = q * item.Quaternion;
+					Vector3 leg = item.Position - _dragStartOrigin;
+					arcOffset = leg * q.Inverse() - leg;
+					_dragStartNormal = -hitNormal;
+				}
+				Vector3 newpos = item.Position + offset;
+				{
+					Transform3D trans = ((Node3D)intersection["collider"]).GlobalTransform;
+					Vector3 dragCenter = trans.Origin;
+					Quaternion dragRotation = trans.Basis.GetRotationQuaternion();
+					Vector3 posdiff = (newpos - dragCenter);
+					Vector3 surfaceSnap = posdiff.Dot(hitNormal) * hitNormal;
+					Quaternion verticalize = new Quaternion(Vector3.Up, hitNormal);
+					Vector3 plane = ((posdiff - surfaceSnap) * dragRotation) * verticalize;
+					Vector3 snapped = new Vector3(
+						Mathf.Snapped(plane.X, snapAmount),
+						0,
+						Mathf.Snapped(plane.Z, snapAmount)
+					);
+					Vector3 rotatedSnappedPlane = dragRotation * (verticalize * snapped);
+					newpos = surfaceSnap + rotatedSnappedPlane + dragCenter;
+				}
+				Vector3 realoffset = newpos - item.Position;
+				_dragStartOrigin += realoffset;
+				item.SetGlobalPosition(newpos + arcOffset);
 				item.UpdateCurrentTransformCache();
 			}
 		}

--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -801,14 +801,14 @@ public sealed partial class Gizmos : Node
 					Quaternion dragRotation = trans.Basis.GetRotationQuaternion();
 					Vector3 posdiff = (newpos - dragCenter);
 					Vector3 surfaceSnap = posdiff.Dot(hitNormal) * hitNormal;
-					Quaternion verticalize = new Quaternion(Vector3.Up, hitNormal);
-					Vector3 plane = ((posdiff - surfaceSnap) * dragRotation) * verticalize;
+					Quaternion verticalize = new Quaternion(hitNormal * dragRotation, Vector3.Up);
+					Vector3 plane = verticalize * ((posdiff - surfaceSnap) * dragRotation);
 					Vector3 snapped = new Vector3(
 						Mathf.Snapped(plane.X, snapAmount),
 						0,
 						Mathf.Snapped(plane.Z, snapAmount)
 					);
-					Vector3 rotatedSnappedPlane = dragRotation * (verticalize * snapped);
+					Vector3 rotatedSnappedPlane = dragRotation * (snapped * verticalize);
 					newpos = surfaceSnap + rotatedSnappedPlane + dragCenter;
 				}
 				Vector3 realoffset = newpos - item.Position;

--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -641,6 +641,24 @@ public sealed partial class Gizmos : Node
 		{
 			_dragStartOrigin = (Vector3)intersection["position"];
 			_dragStartNormal = (Vector3)intersection["normal"];
+			{
+				Transform3D trans = ((Node3D)intersection["collider"]).GlobalTransform;
+				Vector3 dragCenter = trans.Origin;
+				Quaternion dragRotation = trans.Basis.GetRotationQuaternion();
+				Vector3 posdiff = (_dragStartOrigin - dragCenter);
+				Vector3 surfaceSnap = posdiff.Dot(_dragStartNormal) * _dragStartNormal;
+				Quaternion verticalize = new Quaternion(_dragStartNormal * dragRotation, Vector3.Up);
+				Vector3 plane = verticalize * ((posdiff - surfaceSnap) * dragRotation);
+				float snapAmount = CreatorService.Interface.MoveSnapping;
+				float halfsnap = snapAmount * 0.5f;
+				Vector3 snapped = new Vector3(
+					Mathf.Snapped(plane.X + halfsnap, snapAmount) - halfsnap,
+					0,
+					Mathf.Snapped(plane.Z + halfsnap, snapAmount) - halfsnap
+				);
+				Vector3 rotatedSnappedPlane = dragRotation * (snapped * verticalize);
+				_dragStartOrigin = surfaceSnap + rotatedSnappedPlane + dragCenter;
+			}
 		}
 	}
 

--- a/Polytoria/scripts/creator/ui/SnappingMenu.cs
+++ b/Polytoria/scripts/creator/ui/SnappingMenu.cs
@@ -13,6 +13,7 @@ public partial class SnappingMenu : Control
 	[Export] private SpinBox _moveValue = null!;
 	[Export] private CheckBox _rotateCheck = null!;
 	[Export] private SpinBox _rotateValue = null!;
+	[Export] private CheckBox _rotateAlignCheck = null!;
 
 	public override void _Ready()
 	{
@@ -22,7 +23,14 @@ public partial class SnappingMenu : Control
 		_moveCheck.Toggled += MoveCheckToggled;
 		_rotateCheck.Toggled += RotateCheckToggled;
 
+		_rotateAlignCheck.Toggled += RotateAlignCheckToggled;
+
 		base._Ready();
+	}
+
+	private void RotateAlignCheckToggled(bool toggledOn)
+	{
+		CreatorService.Interface.RotateAlignEnabled = toggledOn;
 	}
 
 	private void MoveCheckToggled(bool toggledOn)

--- a/Polytoria/scripts/creator/ui/misc/MultiSelectionBox.cs
+++ b/Polytoria/scripts/creator/ui/misc/MultiSelectionBox.cs
@@ -98,7 +98,7 @@ public partial class MultiSelectionBox : Control
 		{
 			if (mouseEvent.Pressed)
 			{
-				if (_dragging == false && !gizmos.HoveringGizmos && selections.SelectedInstances.Count == 0)
+				if (!_dragging && !gizmos.HoveringGizmos && selections.SelectedInstances.Count == 0)
 				{
 					_tween?.Stop();
 

--- a/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTQuaternion.cs
@@ -130,27 +130,7 @@ public class PTQuaternion : IScriptGDObject
 	[ScriptMethod]
 	public static PTQuaternion FromToRotation(Vector3 fromDirection, Vector3 toDirection)
 	{
-		Vector3 from = fromDirection.Normalized();
-		Vector3 to = toDirection.Normalized();
-
-		float dot = from.Dot(to);
-
-		// same direction
-		if (dot >= 1.0f - 1e-6f)
-			return FromGDClass(Quaternion.Identity);
-
-		// opposite directions
-		if (dot <= -1.0f + 1e-6f)
-		{
-			Vector3 perpendicular = from.Cross(Vector3.Up);
-			if (perpendicular.LengthSquared() < 1e-6f)
-				perpendicular = from.Cross(Vector3.Right);
-			return FromGDClass(new Quaternion(perpendicular.Normalized(), Mathf.Pi));
-		}
-
-		Vector3 axis = from.Cross(to).Normalized();
-		float angle = Mathf.Acos(Mathf.Clamp(dot, -1.0f, 1.0f));
-		return FromGDClass(new Quaternion(axis, angle));
+		return FromGDClass(new Quaternion(fromDirection, toDirection));
 	}
 
 	[ScriptMethod(ConvertParamsToGD = false, SemiStatic = true)]


### PR DESCRIPTION
## Summary

1. dragging and grid snapping now resolve correctly on slopes
2. rotate now rotates around the last dragged-on' surface, rather than just up
3. dragging now uses the exact geometry of the dragged object rather than the bounding box
4. optional rotation alignment on slopes
5. rotate/tilt and drag work on every tool

## Related issue or discussion

resolves #959
resolves #718 which is a duplicate of resolved #524

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)
- [x] fix behavior on rotated parts

## AI/LLM use
none