### PR TITLE
Return time waited from wait()

### DIFF
--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -677,7 +677,6 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 			Task task = n > 0 ? Globals.Singleton.WaitAsync((float)n) : Globals.Singleton.WaitPhysicsFrame();
 			Stopwatch sw = Stopwatch.StartNew();
 			await task;
-			sw.Stop();
 
 			lua.PushNumber(sw.Elapsed.TotalSeconds);
 			tcs.SetResult(1);

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -662,20 +662,11 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		logger.LogWarning(script, logInfo);
 		return 0;
 	}
-	public int LuaWait(IntPtr L)
+	public static int LuaWait(IntPtr L)
 	{
 		LuaState lua = LuaState.FromIntPtr(L);
 
-		double n;
-
-		if (lua.IsNumber(1))
-		{
-			n = lua.ToNumber(1);
-		}
-		else
-		{
-			n = 0;
-		}
+		double n = lua.IsNumber(1) ? lua.ToNumber(1) : 0;
 
 		TaskCompletionSource<int> tcs = new();
 
@@ -683,18 +674,12 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 
 		async void RunAsync()
 		{
-			Stopwatch stopwatch = Stopwatch.StartNew();
-			if (n != 0)
-			{
-				await Globals.Singleton.WaitAsync((float)n);
-			}
-			else
-			{
-				await Globals.Singleton.WaitPhysicsFrame();
-			}
-			stopwatch.Stop();
+			Task task = n > 0 ? Globals.Singleton.WaitAsync((float)n) : Globals.Singleton.WaitPhysicsFrame();
+			Stopwatch sw = Stopwatch.StartNew();
+			await task;
+			sw.Stop();
 
-			lua.PushNumber(stopwatch.Elapsed.TotalSeconds);
+			lua.PushNumber(sw.Elapsed.TotalSeconds);
 			tcs.SetResult(1);
 		}
 

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Script = Polytoria.Datamodel.Script;
+using System.Diagnostics;
 
 namespace Polytoria.Scripting.Luau;
 
@@ -682,6 +683,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 
 		async void RunAsync()
 		{
+			Stopwatch stopwatch = Stopwatch.StartNew();
 			if (n != 0)
 			{
 				await Globals.Singleton.WaitAsync((float)n);
@@ -690,8 +692,9 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 			{
 				await Globals.Singleton.WaitPhysicsFrame();
 			}
+			stopwatch.Stop();
 
-			PushValueToLua(lua, true);
+			lua.PushNumber(stopwatch.Elapsed.TotalSeconds);
 			tcs.SetResult(1);
 		}
 


### PR DESCRIPTION
## Summary

returns the amount of time waited from `wait()` in seconds (instead of `true`)

## Related issue or discussion

Related to #1017

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None