### PR TITLE
Fix camera zoom

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -454,11 +454,11 @@ public sealed partial class Camera : Dynamic
 			{
 				if (Input.IsActionPressed("zoom_in"))
 				{
-					_targetZoom = _distance - (ScrollSensitivity / 5);
+					_targetZoom -= ScrollSensitivity / 5;
 				}
 				if (Input.IsActionPressed("zoom_out"))
 				{
-					_targetZoom = _distance + (ScrollSensitivity / 5);
+					_targetZoom += ScrollSensitivity / 5;
 				}
 
 				// Handle Controller Right stick input
@@ -533,13 +533,7 @@ public sealed partial class Camera : Dynamic
 					Vector3 hitPoint = (Vector3)result["position"];
 
 					float hitDist = origin.DistanceTo(hitPoint) - ClipSafeMargin;
-					finalizedZoom = Mathf.Min(_distance, hitDist);
-
-					// Prevent zooming after zero
-					if (finalizedZoom < 0)
-					{
-						finalizedZoom = 0;
-					}
+					finalizedZoom = Mathf.Max(0, hitDist);
 				}
 			}
 

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -52,7 +52,7 @@ public sealed partial class Camera : Dynamic
 
 	private float _moveSpeed = 8f;
 	private readonly float _rotateSpeed = 0.005f;
-	private Dynamic? _target = null!;
+	private Dynamic? _target = null;
 
 	private bool _isMouseCaptured;
 	private Vector2I _lastMousePosition;
@@ -341,7 +341,7 @@ public sealed partial class Camera : Dynamic
 		{
 			if (_target != null && _target.IsDeleted)
 			{
-				_target = null!;
+				_target = null;
 			}
 			return _target;
 		}
@@ -509,7 +509,7 @@ public sealed partial class Camera : Dynamic
 				}
 			}
 
-			_currentZoom = (float)Mathf.Lerp(_currentZoom, _targetZoom, MathUtils.ExpDecay((float)delta, ScrollLerpSpeed));
+			_currentZoom = Mathf.Lerp(_currentZoom, _targetZoom, MathUtils.ExpDecay((float)delta, ScrollLerpSpeed));
 			float finalizedZoom = _currentZoom;
 
 			_turnY2.Position = new Vector3(0, 0, _currentZoom);
@@ -994,7 +994,7 @@ public sealed partial class Camera : Dynamic
 		Vector2 screenPos = new(pos.X * size.X, pos.Y * size.Y);
 		Vector3 origin = Camera3D.ProjectRayOrigin(screenPos);
 		Vector3 direction = Camera3D.ProjectRayNormal(screenPos);
-		return (origin + direction * Camera3D.Near);
+		return origin + direction * Camera3D.Near;
 	}
 
 	[ScriptMethod]
@@ -1029,7 +1029,7 @@ public sealed partial class Camera : Dynamic
 	{
 		Vector3 rayOrigin = Camera3D.ProjectRayOrigin(new(pos.X, pos.Y));
 		Vector3 rayDir = Camera3D.ProjectRayNormal(new(pos.X, pos.Y));
-		return (rayOrigin + rayDir * Camera3D.Near);
+		return rayOrigin + rayDir * Camera3D.Near;
 	}
 
 
@@ -1120,7 +1120,7 @@ public sealed partial class Camera : Dynamic
 		// In GoDot the Z axis points to the Camera
 		Vector3 direction = -globalTransform.Basis.Z;
 
-		Datamodel.Environment.RayResult? hit = GetPlacementRay(ignoreList);
+		RayResult? hit = GetPlacementRay(ignoreList);
 
 		if (hit != null)
 		{


### PR DESCRIPTION
## Summary

applies the camera target zoom change from #169 to I/O key zooming, and prevents the camera zoom from getting "stuck" when clipped by a wall (would previously only zoom in)

## Related issue or discussion

Fixes #850
Related to #136

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img src=https://github.com/user-attachments/assets/db209325-771f-4c11-a469-093ae7d4e955>

## AI/LLM use

None