### PR TITLE
mistake, please ignore

### DIFF
--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -114,6 +114,10 @@ public partial class Grabbable : Instance
 
 	public override void PreDelete()
 	{
+		if (_dragging && _dragger == Root.Players.LocalPlayer)
+		{
+			Root.PlayerGUI.SetCursorShape(Control.CursorShape.Arrow);
+		}
 		Root.Input.GodotInputEvent -= OnInput;
 		base.PreDelete();
 	}


### PR DESCRIPTION
## Summary

When a grabbable object is destroyed while it is being dragged around, the dragging players mouse cursor will be stuck as a closed hand until they mouse over another grabbable object.
This pull request fixes that.

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/287e3323-942c-48b9-8f75-a031389bc9a1

## AI/LLM use

None