### PR TITLE
Disallow redirects in HTTP client

### DIFF
--- a/Polytoria/scripts/shared/PTHttpClient.cs
+++ b/Polytoria/scripts/shared/PTHttpClient.cs
@@ -20,7 +20,12 @@ public partial class PTHttpClient
 {
 	private const int DefaultDownloadChunkSize = 10000;
 #if USE_NATIVE_HTTP
-	private static readonly HttpClient _httpClient = new();
+	private static readonly HttpClient _httpClient = new(
+		new HttpClientHandler
+		{
+			AllowAutoRedirect = false
+		}
+	);
 #endif
 	public Dictionary<string, string> DefaultRequestHeaders { get; set; } = [];
 
@@ -66,7 +71,11 @@ public partial class PTHttpClient
 			{
 				byte[] body = msg.Content != null ? await msg.Content.ReadAsByteArrayAsync() : [];
 
-				HttpRequest req = new() { DownloadChunkSize = DefaultDownloadChunkSize };
+				HttpRequest req = new()
+				{
+					DownloadChunkSize = DefaultDownloadChunkSize,
+					MaxRedirects = 0
+				};
 
 				Globals.Singleton.AddChild(req);
 


### PR DESCRIPTION
## Summary

Fixes a potential SSRF vulnerability that could be used to access future internal services (none currently exist but future proofing)

Thanks to Svendy on Polytoria for privately reporting this issue

## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [x] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None