### PR TITLE
Fix dynamic transform inheritance through folders

### DIFF
--- a/Polytoria/scripts/datamodel/Folder.cs
+++ b/Polytoria/scripts/datamodel/Folder.cs
@@ -2,10 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using Godot;
 using Polytoria.Attributes;
 using Polytoria.Datamodel.Interfaces;
 
 namespace Polytoria.Datamodel;
 
 [Instantiable]
-public sealed partial class Folder : Instance, IGroup { }
+public sealed partial class Folder : Instance, IGroup
+{
+	public override Node CreateGDNode()
+	{
+		// Keep the spatial transform chain intact for Dynamic descendants.
+		return new Node3D();
+	}
+}

--- a/Polytoria/scripts/datamodel/Folder.cs
+++ b/Polytoria/scripts/datamodel/Folder.cs
@@ -11,9 +11,65 @@ namespace Polytoria.Datamodel;
 [Instantiable]
 public sealed partial class Folder : Instance, IGroup
 {
+	private Dynamic? _transformParent;
+
 	public override Node CreateGDNode()
 	{
 		// Keep the spatial transform chain intact for Dynamic descendants.
 		return new Node3D();
+	}
+
+	public override void EnterTree()
+	{
+		base.EnterTree();
+		SubscribeToTransformParent();
+	}
+
+	public override void ExitTree()
+	{
+		UnsubscribeFromTransformParent();
+		base.ExitTree();
+	}
+
+	private void SubscribeToTransformParent()
+	{
+		UnsubscribeFromTransformParent();
+
+		// Only the first Folder after a Dynamic needs to forward the event.
+		// Nested Folders are reached recursively by PropagateTransformChanged.
+		_transformParent = Parent as Dynamic;
+		if (_transformParent != null)
+		{
+			_transformParent.TransformChanged += OnTransformParentChanged;
+		}
+	}
+
+	private void UnsubscribeFromTransformParent()
+	{
+		if (_transformParent != null)
+		{
+			_transformParent.TransformChanged -= OnTransformParentChanged;
+			_transformParent = null;
+		}
+	}
+
+	private void OnTransformParentChanged()
+	{
+		PropagateTransformChanged(this);
+	}
+
+	private static void PropagateTransformChanged(Instance parent)
+	{
+		foreach (Instance child in parent.GetChildren())
+		{
+			if (child is Dynamic dynamicChild)
+			{
+				dynamicChild.InvokeTransformChanged();
+			}
+			else
+			{
+				PropagateTransformChanged(child);
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes transform inheritance for `Dynamic` instances nested beneath `Folder` instances.

- Gives `Folder` instances a `Node3D` proxy so they preserve the spatial transform hierarchy
- Forwards transform-change notifications through Folder hierarchies
- Ensures anchored, MultiMesh-rendered Parts refresh when an ancestor Model moves or rotates
- Supports nested hierarchies such as `Model -> Folder -> Folder -> Part`

## Related issue or discussion

Fixes #1032

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

The test suite completed with 28 of 29 tests passing locally. The remaining `Test_HttpURLPass` failure is unrelated to this change and is caused by a DNS lookup throwing `SocketException` instead of the test's expected `InvalidOperationException`.

## Screenshots / video

Manually verified in Creator using the following hierarchies:

- `Model -> Folder -> Part`
- `Model -> Folder -> Folder -> Part`

Parts nested beneath Folders now correctly follow the Model when it is moved or rotated.

<!-- Attach the Creator screenshot or short test video here. -->

## AI/LLM use

AI tools assisted with portions of implementation, debugging, and code review. I reproduced the issue, tested the fix locally in Creator, reviewed the resulting behavior, and made the final technical decisions.