### PR TITLE
Make NPC:Sit properly vacate previous seat

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -934,6 +934,11 @@ public partial class NPC : Physical
 
 	private void InternalSit(Seat seat)
 	{
+		if (IsSitting && SittingIn != null)
+		{
+			SittingIn.Occupant = null;
+			SittingIn.InvokeVacated(this);
+		}
 		IsSitting = true;
 		OverrideNetworkTransform = true;
 		SittingIn = seat;


### PR DESCRIPTION
## Summary

When NPC:Seat is called while the npc is seated, the previous seat is not properly vacated, this will cause the seat to not allow new occupants as it is still "occupied".
This pull request fixes this issue.

## Related issue or discussion

Related to #1008

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/ca00fc97-46c6-41e2-98c2-a4b881e6542e

## AI/LLM use

None