### PR TITLE
Fix detection of some keys

### DIFF
--- a/Polytoria/scripts/enums/KeyCode.cs
+++ b/Polytoria/scripts/enums/KeyCode.cs
@@ -47,6 +47,18 @@ public enum KeyCodeEnum
 	/// </summary>
 	Delete = 4194312,
 	/// <summary>
+	/// <para>Print screen key.</para>
+	/// </summary>
+	Print = 4194314,
+	/// <summary>
+	/// <para>Home key.</para>
+	/// </summary>
+	Home = 4194317,
+	/// <summary>
+	/// <para>End key.</para>
+	/// </summary>
+	End = 4194318,
+	/// <summary>
 	/// <para>Left arrow key.</para>
 	/// </summary>
 	Left = 4194319,
@@ -65,11 +77,11 @@ public enum KeyCodeEnum
 	/// <summary>
 	/// <para>Page Up key.</para>
 	/// </summary>
-	PageUp = 4194323,
+	Pageup = 4194323,
 	/// <summary>
 	/// <para>Page Down key.</para>
 	/// </summary>
-	PageDown = 4194324,
+	Pagedown = 4194324,
 	/// <summary>
 	/// <para>Shift key.</para>
 	/// </summary>
@@ -89,15 +101,15 @@ public enum KeyCodeEnum
 	/// <summary>
 	/// <para>Caps Lock key.</para>
 	/// </summary>
-	CapsLock = 4194329,
+	Capslock = 4194329,
 	/// <summary>
 	/// <para>Num Lock key.</para>
 	/// </summary>
-	NumLock = 4194330,
+	Numlock = 4194330,
 	/// <summary>
 	/// <para>Scroll Lock key.</para>
 	/// </summary>
-	ScrollLock = 4194331,
+	Scrolllock = 4194331,
 	/// <summary>
 	/// <para>F1 key.</para>
 	/// </summary>

--- a/Polytoria/scripts/enums/KeyCode.cs
+++ b/Polytoria/scripts/enums/KeyCode.cs
@@ -457,7 +457,7 @@ public enum KeyCodeEnum
 	/// <summary>
 	/// <para>Left bracket (<c>[lb]</c>) key.</para>
 	/// </summary>
-	BracketLeft = 91,
+	Bracketleft = 91,
 	/// <summary>
 	/// <para>Backslash (<c>\</c>) key.</para>
 	/// </summary>
@@ -465,7 +465,7 @@ public enum KeyCodeEnum
 	/// <summary>
 	/// <para>Right bracket (<c>[rb]</c>) key.</para>
 	/// </summary>
-	BracketRight = 93,
+	Bracketright = 93,
 	/// <summary>
 	/// <para>Caret (<c>^</c>) key.</para>
 	/// </summary>
@@ -477,7 +477,7 @@ public enum KeyCodeEnum
 	/// <summary>
 	/// <para>Backtick (<c>`</c>) key.</para>
 	/// </summary>
-	QuoteLeft = 96,
+	Quoteleft = 96,
 	/// <summary>
 	/// <para>Left brace (<c>{</c>) key.</para>
 	/// </summary>


### PR DESCRIPTION
## Summary


Due to a capitalization mismatch, some keys are unable to be converted to their respective KeyCode enum value causing those keys to not be detectable via input actions or InputService.KeyDown/KeyUp.
This affects the ``` ` ``` (Quoteleft), ``` [ ``` (Bracketleft), ``` ] ``` (Bracketright), page up (Pageup), page down (Pagedown), caps lock (Capslock) and number lock (Numlock) keys.
Scroll lock (Scrolllock) is probably affected but it's not on my laptops keyboard, it seems reasonable to assume it's also affected.

Additionally, the Home, End and Print screen keys are not even defined in Keycode causing those keys to not be detected.

This pull request fixes these issues.

## Related issue or discussion

Fixes #1004

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [x] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/40be24da-485e-47f0-8c42-64dce3253da4

## AI/LLM use

None