### PR TITLE
Command Line & General Improvements

### DIFF
--- a/Polytoria/modules/creator/codehint/luau/globals.d.luau
+++ b/Polytoria/modules/creator/codehint/luau/globals.d.luau
@@ -16,7 +16,7 @@ declare _POLY_2: boolean
 
 declare _LOCALTEST: boolean
 
-declare function warn(message: string)
+declare function warn(...: any)
 
 declare function wait(seconds: number?)
 

--- a/Polytoria/scenes/creator/creator.tscn
+++ b/Polytoria/scenes/creator/creator.tscn
@@ -38,10 +38,13 @@
 [ext_resource type="Script" uid="uid://c5celm4bxr4vy" path="res://scripts/creator/ui/docks/bottombar/console/DebugConsole.cs" id="30_bc04q"]
 [ext_resource type="PackedScene" uid="uid://msq1k3h4a75p" path="res://scenes/creator/wizard/new_project/new_project.tscn" id="31_87ukk"]
 [ext_resource type="PackedScene" uid="uid://cvxoyotxeotax" path="res://scenes/creator/docks/explorer/explorer.tscn" id="32_4fw2t"]
+[ext_resource type="Script" uid="uid://b77lltdi1as4p" path="res://scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs" id="33_5ay1h"]
 [ext_resource type="PackedScene" uid="uid://duq8icfg2fwo0" path="res://scenes/creator/docks/properties/properties.tscn" id="34_bc04q"]
+[ext_resource type="Texture2D" uid="uid://deii1n7ji6sj0" path="res://assets/textures/ui-icons/play.svg" id="36_2ib2a"]
 [ext_resource type="PackedScene" uid="uid://dccewf7osrg82" path="res://scenes/creator/popups/search/search.tscn" id="38_ce354"]
 [ext_resource type="PackedScene" uid="uid://dauvdi8d2yqpy" path="res://scenes/creator/wizard/introduction_wizard.tscn" id="39_dfqoe"]
 [ext_resource type="PackedScene" uid="uid://b7voaj38vy8xd" path="res://scenes/creator/docks/bottombar/console_filters.tscn" id="40_console_filters"]
+[ext_resource type="PackedScene" uid="uid://bimokjkrp24ow" path="res://scenes/creator/tabs/text_editor/finder.tscn" id="40_ll2un"]
 
 [sub_resource type="FontVariation" id="FontVariation_khfyn"]
 variation_opentype = {
@@ -349,6 +352,13 @@ corner_radius_top_right = 8
 corner_radius_bottom_right = 8
 corner_radius_bottom_left = 8
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5xx7o"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+bg_color = Color(0, 0, 0, 0.49803922)
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y8rg4"]
 resource_name = "FooterTheme"
 content_margin_left = 5.0
@@ -625,7 +635,6 @@ button_pressed = true
 action_mode = 0
 button_group = SubResource("ButtonGroup_v0rtd")
 script = ExtResource("8_c8w7j")
-ToolMode = null
 
 [node name="Icon" type="TextureRect" parent="GUI/Ribbon/Buttons/Select" unique_id=75873074]
 layout_mode = 1
@@ -994,10 +1003,6 @@ anchor_top = 1.0
 anchor_bottom = 1.0
 grow_vertical = 0
 
-[node name="Separator3" type="VSeparator" parent="GUI/Ribbon/Buttons" unique_id=1661999198]
-layout_mode = 2
-mouse_filter = 2
-
 [node name="Insert" type="Button" parent="GUI/Ribbon/Buttons" unique_id=462576719]
 custom_minimum_size = Vector2(62, 0)
 layout_mode = 2
@@ -1025,6 +1030,10 @@ grow_vertical = 0
 text = "Insert"
 horizontal_alignment = 1
 vertical_alignment = 2
+
+[node name="Separator3" type="VSeparator" parent="GUI/Ribbon/Buttons" unique_id=1661999198]
+layout_mode = 2
+mouse_filter = 2
 
 [node name="Splitter" type="HSplitContainer" parent="GUI" unique_id=1718208415]
 layout_mode = 1
@@ -1165,6 +1174,28 @@ metadata/_tab_index = 0
 [node name="VBoxContainer" type="VBoxContainer" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console" unique_id=681967966]
 layout_mode = 2
 
+[node name="SearchBar" type="HBoxContainer" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer" unique_id=1369015190]
+custom_minimum_size = Vector2(0, 28)
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="ClearBtn" type="Button" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/SearchBar" unique_id=276167707]
+custom_minimum_size = Vector2(28, 0)
+layout_mode = 2
+icon = ExtResource("22_i1txp")
+expand_icon = true
+
+[node name="FilterBtn" type="Button" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/SearchBar" unique_id=1370024557]
+custom_minimum_size = Vector2(32, 0)
+layout_mode = 2
+tooltip_text = "Filter console output"
+icon = ExtResource("29_4fw2t")
+
+[node name="LineEdit" type="LineEdit" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/SearchBar" unique_id=767147599]
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "Search..."
+
 [node name="RichTextLabel" type="RichTextLabel" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer" unique_id=1372579414]
 layout_mode = 2
 size_flags_vertical = 3
@@ -1183,30 +1214,56 @@ scroll_following = true
 vertical_alignment = 2
 selection_enabled = true
 
-[node name="SearchBar" type="HBoxContainer" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer" unique_id=1369015190]
+[node name="CommandBar" type="HBoxContainer" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer" unique_id=2033668591 node_paths=PackedStringArray("_diagLabel", "_codeEdit", "_runButton", "_finder")]
 custom_minimum_size = Vector2(0, 28)
 layout_mode = 2
 theme_override_constants/separation = 8
+script = ExtResource("33_5ay1h")
+_diagLabel = NodePath("../DiagLabel")
+_codeEdit = NodePath("CodeEdit")
+_runButton = NodePath("Layout/RunBtn")
+_finder = NodePath("../../Finder")
 
-[node name="FilterBtn" type="Button" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/SearchBar" unique_id=1370024557]
-custom_minimum_size = Vector2(32, 0)
-layout_mode = 2
-tooltip_text = "Filter console output"
-icon = ExtResource("29_4fw2t")
-
-[node name="LineEdit" type="LineEdit" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/SearchBar" unique_id=767147599]
+[node name="CodeEdit" type="CodeEdit" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/CommandBar" unique_id=20449168]
 layout_mode = 2
 size_flags_horizontal = 3
-placeholder_text = "Search..."
+theme_override_colors/selection_color = Color(0.5, 0.5, 0.5, 0.30588236)
+theme_override_colors/word_highlighted_color = Color(0.80099994, 0.9, 0.9, 0.08627451)
+placeholder_text = "Type a command (Use 'Ctrl' + '↑/↓' to navigate recents)."
+caret_blink = true
+highlight_all_occurrences = true
+line_folding = true
+gutters_draw_line_numbers = true
+delimiter_strings = Array[String]([])
+code_completion_enabled = true
+indent_automatic = true
+auto_brace_completion_enabled = true
+auto_brace_completion_highlight_matching = true
 
-[node name="ClearBtn" type="Button" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/SearchBar" unique_id=276167707]
-custom_minimum_size = Vector2(28, 0)
+[node name="Layout" type="HBoxContainer" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/CommandBar" unique_id=1808549576]
 layout_mode = 2
-icon = ExtResource("22_i1txp")
-expand_icon = true
+
+[node name="RunBtn" type="Button" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/CommandBar/Layout" unique_id=835670722]
+custom_minimum_size = Vector2(32, 32)
+custom_maximum_size = Vector2(-1, 32)
+layout_mode = 2
+tooltip_text = "Filter console output"
+icon = ExtResource("36_2ib2a")
+
+[node name="DiagLabel" type="Label" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer" unique_id=569876121]
+visible = false
+layout_mode = 2
+theme_override_colors/font_color = Color(0.8666667, 0.33333334, 0.33333334, 1)
+theme_override_font_sizes/font_size = 14
+theme_override_styles/normal = SubResource("StyleBoxFlat_5xx7o")
+autowrap_mode = 3
 
 [node name="ConsoleFilters" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console" unique_id=1370024561 instance=ExtResource("40_console_filters")]
 visible = false
+
+[node name="Finder" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console" unique_id=495200113 instance=ExtResource("40_ll2un")]
+visible = false
+layout_mode = 2
 
 [node name="Right" type="PanelContainer" parent="GUI/Splitter" unique_id=528512110]
 custom_minimum_size = Vector2(320, 0)

--- a/Polytoria/scenes/creator/creator.tscn
+++ b/Polytoria/scenes/creator/creator.tscn
@@ -39,6 +39,7 @@
 [ext_resource type="PackedScene" uid="uid://msq1k3h4a75p" path="res://scenes/creator/wizard/new_project/new_project.tscn" id="31_87ukk"]
 [ext_resource type="PackedScene" uid="uid://cvxoyotxeotax" path="res://scenes/creator/docks/explorer/explorer.tscn" id="32_4fw2t"]
 [ext_resource type="Script" uid="uid://b77lltdi1as4p" path="res://scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs" id="33_5ay1h"]
+[ext_resource type="Script" uid="uid://do7oij3iu8c1a" path="res://scripts/creator/ui/tabs/text_editor/TextEditorField.cs" id="34_0jcko"]
 [ext_resource type="PackedScene" uid="uid://duq8icfg2fwo0" path="res://scenes/creator/docks/properties/properties.tscn" id="34_bc04q"]
 [ext_resource type="Texture2D" uid="uid://deii1n7ji6sj0" path="res://assets/textures/ui-icons/play.svg" id="36_2ib2a"]
 [ext_resource type="PackedScene" uid="uid://dccewf7osrg82" path="res://scenes/creator/popups/search/search.tscn" id="38_ce354"]
@@ -1239,6 +1240,7 @@ code_completion_enabled = true
 indent_automatic = true
 auto_brace_completion_enabled = true
 auto_brace_completion_highlight_matching = true
+script = ExtResource("34_0jcko")
 
 [node name="Layout" type="HBoxContainer" parent="GUI/Splitter/Center/BottomTabs/Tabs/Console/VBoxContainer/CommandBar" unique_id=1808549576]
 layout_mode = 2

--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -603,7 +603,7 @@ public partial class CreatorInterface : Control, IScriptObject
 
 	public static void PopupManageAddons()
 	{
-		OS.ShellShowInFileManager(ProjectSettings.GlobalizePath(AddonsManager.UserAddonFolder));
+		OS.ShellShowInFileManager(AddonsManager.UserAddonFolder);
 	}
 
 	public void PromptGiveName(string placeholder, Action<string> callback, string title = "Name...", string defaultValue = "")

--- a/Polytoria/scripts/creator/CreatorSession.cs
+++ b/Polytoria/scripts/creator/CreatorSession.cs
@@ -826,13 +826,23 @@ return module";
 		}
 	}
 
-	public void RunScript(string path)
+	public void RunScript(string path, Scripting.ScriptPermissionFlags permissionFlags = Scripting.ScriptPermissionFlags.IORead | Scripting.ScriptPermissionFlags.IOWrite)
+	{
+		if (World.Current == null) { PT.Print("World current is null, did not run script"); return; }
+		path = GlobalizePath(path);
+		string source = File.ReadAllText(path);
+		RunScriptSource(source, permissionFlags);
+	}
+
+	/// <summary>
+	/// Runs raw lua source with no script attached (used by the command line)
+	/// </summary>
+	public void RunScriptSource(string source, Scripting.ScriptPermissionFlags permissionFlags = Scripting.ScriptPermissionFlags.IORead | Scripting.ScriptPermissionFlags.IOWrite)
 	{
 		if (World.Current == null) { PT.Print("World current is null, did not run script"); return; }
 		Script s = new() { Root = World.Current };
-		path = GlobalizePath(path);
-		s.Source = File.ReadAllText(path);
-		s.PermissionFlags = Scripting.ScriptPermissionFlags.IORead | Scripting.ScriptPermissionFlags.IOWrite;
+		s.Source = source;
+		s.PermissionFlags = permissionFlags;
 		s.Parent = World.Current.TemporaryContainer;
 		s.Run();
 	}
@@ -953,7 +963,7 @@ return module";
 	{
 		CreatorService.Interface.StatusBar?.SetStatus("Backing up world...");
 
-		string backupFolderPath = PolyFolderPath.PathJoin("backups");
+		string backupFolderPath = GetBackupsFolderPath();
 		if (!Directory.Exists(backupFolderPath))
 		{
 			Directory.CreateDirectory(backupFolderPath);
@@ -996,6 +1006,13 @@ return module";
 			PolyFormat.SaveWorldToFile(game, writeTo);
 		}
 		CreatorService.Interface.StatusBar?.SetStatus("World backed up!");
+	}
+
+	private string GetBackupsFolderPath()
+	{
+		string projectName = ProjectFolderPath.TrimEnd('/').GetFile();
+		string projectHash = ProjectFolderPath.Sha256Text()[..8];
+		return Path.Combine(CreatorService.DocumentsRootPath, "Backups", $"{projectName}_{projectHash}");
 	}
 
 	public void CreateVSCodeConfig()

--- a/Polytoria/scripts/creator/managers/AddonsManager.cs
+++ b/Polytoria/scripts/creator/managers/AddonsManager.cs
@@ -7,6 +7,7 @@ using Polytoria.Datamodel;
 using Polytoria.Formats;
 using Polytoria.Scripting;
 using Polytoria.Shared;
+using Polytoria.Datamodel.Creator;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -24,24 +25,20 @@ public sealed partial class AddonsManager : Node
 {
 	private const ScriptPermissionFlags AddonDefaultPermissionFlags =
 		ScriptPermissionFlags.CreatorAccess | ScriptPermissionFlags.ContextAccess;
-	public const string UserAddonFolder = "user://creator/addons";
-	public const string AddonPermissionsFile = "user://creator/addon_perms";
+	public static readonly string UserAddonFolder = Path.Combine(CreatorService.DocumentsRootPath, "Addons");
+	public static readonly string AddonPermissionsFile = Path.Combine(CreatorService.DocumentsRootPath, "addon_perms");
 
 	private static readonly Dictionary<string, List<AddonSession>> _pathToAddons = [];
 	private static readonly Dictionary<Script, string> _scriptToPath = [];
 	private static readonly HashSet<World> _registeredRoots = [];
 
-	private static readonly string _addonsAbsolutePath = "";
-	private static readonly string _permissionsAbsolutePath = "";
 	private static AddonPermissionPair _permissions = [];
 
 	static AddonsManager()
 	{
-		_addonsAbsolutePath = ProjectSettings.GlobalizePath(UserAddonFolder);
-		_permissionsAbsolutePath = ProjectSettings.GlobalizePath(AddonPermissionsFile);
-		if (!Directory.Exists(_addonsAbsolutePath))
+		if (!Directory.Exists(UserAddonFolder))
 		{
-			Directory.CreateDirectory(_addonsAbsolutePath);
+			Directory.CreateDirectory(UserAddonFolder);
 		}
 		LoadPermissionsData();
 	}
@@ -71,7 +68,7 @@ public sealed partial class AddonsManager : Node
 	{
 		RegisterRoot(root);
 
-		foreach (string f in Directory.GetFiles(_addonsAbsolutePath))
+		foreach (string f in Directory.GetFiles(UserAddonFolder))
 		{
 			try
 			{
@@ -88,7 +85,7 @@ public sealed partial class AddonsManager : Node
 	{
 		string addonName = s.Name;
 		string addonFileName = addonName + ".ptaddon";
-		string addonPath = Path.GetFullPath(Path.Join(_addonsAbsolutePath, addonFileName));
+		string addonPath = Path.GetFullPath(Path.Join(UserAddonFolder, addonFileName));
 		PT.Print("Installing addon ", addonName, " to ", addonPath);
 		await PackedFormat.PackAddonToFile(s, addonPath, new() { Name = s.Name });
 		PT.Print("Addon Installed!");
@@ -275,14 +272,14 @@ public sealed partial class AddonsManager : Node
 
 	private static void LoadPermissionsData()
 	{
-		if (!File.Exists(_permissionsAbsolutePath)) return;
-		string f = File.ReadAllText(_permissionsAbsolutePath);
+		if (!File.Exists(AddonPermissionsFile)) return;
+		string f = File.ReadAllText(AddonPermissionsFile);
 		_permissions = JsonSerializer.Deserialize(f, AddonJSONGenerationContext.Default.AddonPermissionPair) ?? [];
 	}
 
 	private static void SavePermissionsData()
 	{
-		File.WriteAllText(_permissionsAbsolutePath, JsonSerializer.Serialize(_permissions, AddonJSONGenerationContext.Default.AddonPermissionPair));
+		File.WriteAllText(AddonPermissionsFile, JsonSerializer.Serialize(_permissions, AddonJSONGenerationContext.Default.AddonPermissionPair));
 	}
 
 	public struct AddonMetadata

--- a/Polytoria/scripts/creator/managers/ProjectManager.cs
+++ b/Polytoria/scripts/creator/managers/ProjectManager.cs
@@ -24,16 +24,15 @@ namespace Polytoria.Creator.Managers;
 
 public static class ProjectManager
 {
-	private const string RecentsPath = "user://creator/recents";
+	private static readonly string RecentsPath = Path.Combine(CreatorService.DocumentsRootPath, ".recents");
 	private const string ProjectTemplatesPath = "res://modules/creator/world-templates/";
 	private const string GitIgnoreContent = "# Polytoria specific ignores\n.poly/\n";
 
 	public static async Task<RecentData[]> GetRecents(bool loadData = true)
 	{
-		string recentsPath = ProjectSettings.GlobalizePath(RecentsPath);
-		if (File.Exists(recentsPath))
+		if (File.Exists(RecentsPath))
 		{
-			string raw = File.ReadAllText(recentsPath);
+			string raw = File.ReadAllText(RecentsPath);
 			RecentData[] data = JsonSerializer.Deserialize(raw, RecentsFileGenerationContext.Default.RecentDataArray) ?? [];
 
 			List<RecentData> finalData = [];
@@ -90,7 +89,6 @@ public static class ProjectManager
 
 	public static async Task AddToRecents(string folderPath)
 	{
-		string recentsPath = ProjectSettings.GlobalizePath(RecentsPath);
 		List<RecentData> existing = [.. await GetRecents(false)];
 
 		existing.RemoveAll(x => x.FolderPath == folderPath);
@@ -101,16 +99,25 @@ public static class ProjectManager
 			LastOpened = DateTime.Now,
 		});
 
-		File.WriteAllText(recentsPath, JsonSerializer.Serialize([.. existing], RecentsFileGenerationContext.Default.RecentDataArray));
+		WriteRecentsFile(existing);
 	}
 
 	public static async Task RemoveFromRecents(string folderPath)
 	{
-		string recentsPath = ProjectSettings.GlobalizePath(RecentsPath);
 		List<RecentData> existing = [.. await GetRecents(false)];
 
 		existing.RemoveAll(x => x.FolderPath == folderPath);
-		File.WriteAllText(recentsPath, JsonSerializer.Serialize([.. existing], RecentsFileGenerationContext.Default.RecentDataArray));
+		WriteRecentsFile(existing);
+	}
+
+	private static void WriteRecentsFile(List<RecentData> data)
+	{
+		File.WriteAllText(RecentsPath, JsonSerializer.Serialize([.. data], RecentsFileGenerationContext.Default.RecentDataArray));
+
+		if (OS.HasFeature("windows"))
+		{
+			File.SetAttributes(RecentsPath, File.GetAttributes(RecentsPath) | FileAttributes.Hidden);
+		}
 	}
 
 	public static async Task NewProject(string destFolder, CreatorProjectMetadata metadata, bool createFromTemplate = false)

--- a/Polytoria/scripts/creator/ui/ctxmenus/FileItemContextMenu.cs
+++ b/Polytoria/scripts/creator/ui/ctxmenus/FileItemContextMenu.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using Godot;
+using Polytoria.Scripting;
 using Polytoria.Datamodel.Creator;
 using Polytoria.Formats;
 using Polytoria.Shared;
@@ -13,6 +14,9 @@ namespace Polytoria.Creator.UI;
 
 public partial class FileItemContextMenu : ContextMenu
 {
+	private const ScriptPermissionFlags standardPermissionFlags = ScriptPermissionFlags.IORead | ScriptPermissionFlags.IOWrite | ScriptPermissionFlags.ContextAccess;
+	private const ScriptPermissionFlags debugPermissionFlags = standardPermissionFlags | ScriptPermissionFlags.CreatorAccess;
+
 	public CreatorSession Session = null!;
 
 	public required string[] Targets;
@@ -39,9 +43,9 @@ public partial class FileItemContextMenu : ContextMenu
 			Target = Targets[0];
 			string ext = Target.GetExtension();
 
-			if (Globals.ScriptFileExtensions.Contains(ext) && Globals.IsInGDEditor)
+			if (Globals.ScriptFileExtensions.Contains(ext))
 			{
-				AddIconItem("play", "Run (Developer Only)", 71);
+				AddIconItem("play", "Run", 71);
 			}
 
 			if (ext == "poly")
@@ -132,10 +136,9 @@ public partial class FileItemContextMenu : ContextMenu
 				CreatorService.Interface.PromptDeleteFiles(Targets);
 				break;
 			case 71: // Run script
-				if (!await CreatorService.Interface.PromptConfirmation("This script will have unrestricted access to your device. Are you sure you want to run it?")) return;
-				Session.RunScript(Targets[0]);
+				Session.RunScriptSource(Targets[0], Globals.IsInGDEditor ? debugPermissionFlags : standardPermissionFlags);
 				break;
-			case 81: // Run script
+			case 81: // Toggle Compressed
 				Session.ToggleCompressed(Targets[0]);
 				break;
 			case 89: // Set as main world

--- a/Polytoria/scripts/creator/ui/ctxmenus/FileItemContextMenu.cs
+++ b/Polytoria/scripts/creator/ui/ctxmenus/FileItemContextMenu.cs
@@ -14,8 +14,8 @@ namespace Polytoria.Creator.UI;
 
 public partial class FileItemContextMenu : ContextMenu
 {
-	private const ScriptPermissionFlags standardPermissionFlags = ScriptPermissionFlags.IORead | ScriptPermissionFlags.IOWrite | ScriptPermissionFlags.ContextAccess;
-	private const ScriptPermissionFlags debugPermissionFlags = standardPermissionFlags | ScriptPermissionFlags.CreatorAccess;
+	private const ScriptPermissionFlags standardPermissionFlags = ScriptPermissionFlags.ContextAccess;
+	private const ScriptPermissionFlags debugPermissionFlags = standardPermissionFlags | ScriptPermissionFlags.IORead | ScriptPermissionFlags.IOWrite | ScriptPermissionFlags.CreatorAccess;
 
 	public CreatorSession Session = null!;
 

--- a/Polytoria/scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs
+++ b/Polytoria/scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs
@@ -23,17 +23,15 @@ public partial class ConsoleCommandLine : Control
 	private const int MinVisibleLines = 1;
 	private const int MaxVisibleLines = 4;
 	private const int MaxRecents = 30;
-	private const string NonstrictLuauRcContent = "{\n\t\"languageMode\": \"nonstrict\"\n}";
-	private const ScriptPermissionFlags standardPermissionFlags = ScriptPermissionFlags.IORead | ScriptPermissionFlags.IOWrite | ScriptPermissionFlags.ContextAccess;
-	private const ScriptPermissionFlags debugPermissionFlags = standardPermissionFlags | ScriptPermissionFlags.CreatorAccess;
-
+	private const ScriptPermissionFlags standardPermissionFlags = ScriptPermissionFlags.ContextAccess;
+	private const ScriptPermissionFlags debugPermissionFlags = standardPermissionFlags | ScriptPermissionFlags.IORead | ScriptPermissionFlags.IOWrite | ScriptPermissionFlags.CreatorAccess;
 	private string _temporaryFile = null!;
 	private string _recentsFolder = null!;
 	private string _scratchFolder = null!;
 	private Godot.Timer? _completionRetryTimer;
 
 	[Export] private Label _diagLabel = null!;
-	[Export] private CodeEdit _codeEdit = null!;
+	[Export] private TextEditorField _codeEdit = null!;
 	[Export] private Button _runButton = null!;
 	[Export] private TextEditorFind _finder = null!;
 
@@ -99,21 +97,11 @@ public partial class ConsoleCommandLine : Control
 		_codeEdit.CodeCompletionRequested += OnCompletionRequest;
 
 		Directory.CreateDirectory(_scratchFolder);
-		EnsureNonstrictOverride(_scratchFolder);
 		if (!File.Exists(_temporaryFile))
 		{
 			File.WriteAllText(_temporaryFile, _codeEdit.Text);
 		}
 		_ = _completion.OpenScriptAsync(_temporaryFile);
-	}
-
-	private static void EnsureNonstrictOverride(string scratchFolder)
-	{
-		string luaurcPath = Path.Combine(scratchFolder, ".luaurc");
-		if (!File.Exists(luaurcPath))
-		{
-			File.WriteAllText(luaurcPath, NonstrictLuauRcContent);
-		}
 	}
 
 	public override async void _ExitTree()
@@ -240,6 +228,10 @@ public partial class ConsoleCommandLine : Control
 			}
 		}
 		_completion?.UpdateScriptChangeAsync(_temporaryFile, _codeEdit.Text);
+		if (_completion != null && TextEditorRoot.IsCompletionTrigger(_codeEdit))
+		{
+			OnCompletionRequest();
+		}
 		UpdateHeight();
 	}
 
@@ -268,7 +260,7 @@ public partial class ConsoleCommandLine : Control
 	private async void OnCompletionRequest()
 	{
 		if (_completion == null) return;
-		await TextEditorRoot.RequestCompletions(_codeEdit, _completion, _temporaryFile);
+		await TextEditorRoot.RequestCompletions(_codeEdit, _completion, _temporaryFile, skipIfMatches: TextEditorRoot.GetWordBeforeCaret(_codeEdit));
 	}
 
 	// Recalculates recent commands every commit from oldest to newest

--- a/Polytoria/scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs
+++ b/Polytoria/scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs
@@ -1,0 +1,319 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using Godot;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Polytoria.Creator.UI.TextEditor;
+using Polytoria.Datamodel.Creator;
+using Polytoria.Scripting;
+using Polytoria.Creator.LSP;
+using Polytoria.Creator.LSP.Schemas;
+using Polytoria.Shared;
+
+namespace Polytoria.Creator.UI;
+
+public partial class ConsoleCommandLine : Control
+{
+	private const int MinVisibleLines = 1;
+	private const int MaxVisibleLines = 4;
+	private const int MaxRecents = 30;
+	private const string NonstrictLuauRcContent = "{\n\t\"languageMode\": \"nonstrict\"\n}";
+	private const ScriptPermissionFlags standardPermissionFlags = ScriptPermissionFlags.IORead | ScriptPermissionFlags.IOWrite | ScriptPermissionFlags.ContextAccess;
+	private const ScriptPermissionFlags debugPermissionFlags = standardPermissionFlags | ScriptPermissionFlags.CreatorAccess;
+
+	private string _temporaryFile = null!;
+	private string _recentsFolder = null!;
+	private string _scratchFolder = null!;
+	private Godot.Timer? _completionRetryTimer;
+
+	[Export] private Label _diagLabel = null!;
+	[Export] private CodeEdit _codeEdit = null!;
+	[Export] private Button _runButton = null!;
+	[Export] private TextEditorFind _finder = null!;
+
+	private int _lineHeight;
+	private LuaCompletionService? _completion;
+
+	private string? _activeSnippetPath;
+	private CreatorSession? _activeSnippetSession;
+
+	private int _historyNavIndex = -1;
+	private bool _isNavigatingHistory = false;
+	private CancellationTokenSource? _diagCts;
+
+	public IEnumerable<string> GetRecentSnippetPaths()
+	{
+		if (!Directory.Exists(_recentsFolder))
+		{
+			return [];
+		}
+		return Directory.GetFiles(_recentsFolder, "recent*.luau").OrderByDescending(File.GetLastWriteTimeUtc);
+	}
+
+	public override void _Ready()
+	{
+		_recentsFolder = Path.Combine(CreatorService.DocumentsRootPath, "Commands");
+
+		string sessionRoot = CreatorService.CurrentSession?.PolyFolderPath ?? ProjectSettings.GlobalizePath("user://creator");
+		_scratchFolder = Path.Combine(sessionRoot, "console");
+		_temporaryFile = Path.Combine(_scratchFolder, $"scratch_{Guid.NewGuid():N}.luau");
+
+		_codeEdit.SyntaxHighlighter = TextEditorRoot.CreateLuaHighlighter();
+		TextEditorRoot.ApplyLuaStringDelimiters(_codeEdit);
+
+		_finder.TargetCodeEdit = _codeEdit;
+		TextEditorRoot.PopulateStandardMenu(_codeEdit);
+		_codeEdit.GetMenu().IdPressed += OnContextMenuIdPressed;
+
+		_lineHeight = _codeEdit.GetLineHeight();
+
+		_codeEdit.TextChanged += OnTextChanged;
+		_codeEdit.GuiInput += OnCodeEditGuiInput;
+		_runButton.Pressed += Submit;
+
+		TryBindCompletion();
+		UpdateHeight();
+	}
+
+	private void TryBindCompletion()
+	{
+		_completion = CreatorService.CurrentSession?.LuaCompletion;
+		if (_completion == null)
+		{
+			_completionRetryTimer = new() { OneShot = true, WaitTime = 0.25 };
+			AddChild(_completionRetryTimer);
+			_completionRetryTimer.Timeout += TryBindCompletion;
+			_completionRetryTimer.Start();
+			return;
+		}
+
+		_completion.PublishDiagnostics += OnPublishDiagnostics;
+		_codeEdit.CodeCompletionPrefixes = [".", ":", "\n", ",", " ", "("];
+		_codeEdit.CodeCompletionEnabled = true;
+		_codeEdit.CodeCompletionRequested += OnCompletionRequest;
+
+		Directory.CreateDirectory(_scratchFolder);
+		EnsureNonstrictOverride(_scratchFolder);
+		if (!File.Exists(_temporaryFile))
+		{
+			File.WriteAllText(_temporaryFile, _codeEdit.Text);
+		}
+		_ = _completion.OpenScriptAsync(_temporaryFile);
+	}
+
+	private static void EnsureNonstrictOverride(string scratchFolder)
+	{
+		string luaurcPath = Path.Combine(scratchFolder, ".luaurc");
+		if (!File.Exists(luaurcPath))
+		{
+			File.WriteAllText(luaurcPath, NonstrictLuauRcContent);
+		}
+	}
+
+	public override async void _ExitTree()
+	{
+		_codeEdit.TextChanged -= OnTextChanged;
+		_codeEdit.GuiInput -= OnCodeEditGuiInput;
+		_runButton.Pressed -= Submit;
+		_codeEdit.GetMenu().IdPressed -= OnContextMenuIdPressed;
+		_codeEdit.CodeCompletionRequested -= OnCompletionRequest;
+		_completionRetryTimer?.Stop();
+
+		if (_completion != null)
+		{
+			await _completion.CloseScriptAsync(_temporaryFile);
+			_completion.PublishDiagnostics -= OnPublishDiagnostics;
+		}
+		TextEditorRoot.ClearDiagnostics(_codeEdit, _diagLabel);
+
+		if (File.Exists(_temporaryFile))
+		{
+			try { File.Delete(_temporaryFile); } catch (IOException) { }
+		}
+
+		base._ExitTree();
+	}
+
+	private void OnCodeEditGuiInput(InputEvent @event)
+	{
+		if (@event is InputEventKey { Pressed: true, CtrlPressed: true } key)
+		{
+			if (key.Keycode == Key.Up)
+			{
+				_codeEdit.AcceptEvent();
+				NavigateHistory(older: true);
+				return;
+			}
+			if (key.Keycode == Key.Down)
+			{
+				_codeEdit.AcceptEvent();
+				NavigateHistory(older: false);
+				return;
+			}
+		}
+
+		if (@event.IsActionPressed("textedit_find") || @event.IsActionPressed("textedit_replace"))
+		{
+			_codeEdit.AcceptEvent();
+			_finder.Open(_codeEdit.GetSelectedText());
+		}
+		else if (@event.IsActionPressed("ui_cancel") && _finder.Active)
+		{
+			_codeEdit.AcceptEvent();
+			_finder.Close();
+		}
+		else if (TextEditorRoot.ShouldSwallowModifierInput(@event))
+		{
+			_codeEdit.AcceptEvent();
+		}
+	}
+
+	private async void OnContextMenuIdPressed(long id)
+	{
+		await TextEditorRoot.HandleStandardMenuId(id, _codeEdit, _finder, _temporaryFile, OnTextChanged);
+	}
+
+	private void NavigateHistory(bool older)
+	{
+		List<string> recents = [.. GetRecentSnippetPaths()];
+
+		if (older)
+		{
+			if (recents.Count == 0) return;
+			_historyNavIndex = Math.Min(_historyNavIndex + 1, recents.Count - 1);
+			LoadSnippet(recents[_historyNavIndex]);
+			return;
+		}
+
+		if (_historyNavIndex <= 0 || recents.Count == 0)
+		{
+			_historyNavIndex = -1;
+
+			_isNavigatingHistory = true;
+			_codeEdit.Text = "";
+			_isNavigatingHistory = false;
+
+			_activeSnippetPath = null;
+			_activeSnippetSession = null;
+			UpdateHeight();
+			return;
+		}
+
+		_historyNavIndex--;
+		LoadSnippet(recents[_historyNavIndex]);
+	}
+
+	public void LoadSnippet(string path)
+	{
+		if (!File.Exists(path)) return;
+		string content = File.ReadAllText(path);
+
+		_isNavigatingHistory = true;
+		_codeEdit.Text = content;
+		_isNavigatingHistory = false;
+
+		_activeSnippetPath = path;
+		_activeSnippetSession = CreatorService.CurrentSession;
+
+		TextEditorRoot.ClearDiagnostics(_codeEdit, _diagLabel);
+		_completion?.UpdateScriptChangeAsync(_temporaryFile, content);
+
+		UpdateHeight();
+	}
+
+	private void OnTextChanged()
+	{
+		if (!_isNavigatingHistory)
+		{
+			_historyNavIndex = -1;
+
+			if (string.IsNullOrWhiteSpace(_codeEdit.Text))
+			{
+				_activeSnippetPath = null;
+				_activeSnippetSession = null;
+			}
+		}
+		_completion?.UpdateScriptChangeAsync(_temporaryFile, _codeEdit.Text);
+		UpdateHeight();
+	}
+
+	private void UpdateHeight()
+	{
+		int visibleLines = Mathf.Clamp(_codeEdit.GetLineCount(), MinVisibleLines, MaxVisibleLines);
+		_codeEdit.CustomMinimumSize = _codeEdit.CustomMinimumSize with { Y = visibleLines * _lineHeight };
+	}
+
+	private async void OnPublishDiagnostics(string path, List<LspDiagnostic> diagnostics)
+	{
+		if (path != _temporaryFile) return;
+
+		_diagCts?.Cancel();
+		_diagCts = new CancellationTokenSource();
+		CancellationToken token = _diagCts.Token;
+
+		try
+		{
+			await Task.Delay(TextEditorRoot.DiagDelay, token);
+			TextEditorRoot.ApplyDiagnostics(_codeEdit, _diagLabel, diagnostics);
+		}
+		catch (TaskCanceledException) { }
+	}
+
+	private async void OnCompletionRequest()
+	{
+		if (_completion == null) return;
+		await TextEditorRoot.RequestCompletions(_codeEdit, _completion, _temporaryFile);
+	}
+
+	// Recalculates recent commands every commit from oldest to newest
+	private string CommitRecent(string content, string? overriddenPath)
+	{
+		Directory.CreateDirectory(_recentsFolder);
+
+		List<string> allExisting = [.. GetRecentSnippetPaths()];
+		List<string> keep = overriddenPath == null ? allExisting : [.. allExisting.Where(p => p != overriddenPath)];
+
+		List<string> contents = [content, .. keep.Select(File.ReadAllText)];
+		if (contents.Count > MaxRecents)
+		{
+			contents.RemoveRange(MaxRecents, contents.Count - MaxRecents);
+		}
+
+		foreach (string path in allExisting)
+		{
+			File.Delete(path);
+		}
+
+		DateTime baseTime = DateTime.UtcNow;
+		for (int i = 0; i < contents.Count; i++)
+		{
+			string path = Path.Combine(_recentsFolder, $"recent{i + 1}.luau");
+			File.WriteAllText(path, contents[i]);
+			File.SetLastWriteTimeUtc(path, baseTime - TimeSpan.FromSeconds(i));
+		}
+
+		return Path.Combine(_recentsFolder, "recent1.luau");
+	}
+
+	private void Submit()
+	{
+		string source = _codeEdit.Text;
+		if (string.IsNullOrWhiteSpace(source)) return;
+
+		// A different session "owns" the currently-active path (if any); don't let this run
+		// replace an entry that logically belongs to a project we've since left.
+		string? overriddenPath = _activeSnippetSession == CreatorService.CurrentSession ? _activeSnippetPath : null;
+
+		_activeSnippetPath = CommitRecent(source, overriddenPath);
+		_activeSnippetSession = CreatorService.CurrentSession;
+
+		CreatorService.CurrentSession?.RunScriptSource(source, Globals.IsInGDEditor ? debugPermissionFlags : standardPermissionFlags);
+		_historyNavIndex = -1;
+	}
+}

--- a/Polytoria/scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs
+++ b/Polytoria/scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs
@@ -68,7 +68,7 @@ public partial class ConsoleCommandLine : Control
 		TextEditorRoot.ApplyLuaStringDelimiters(_codeEdit);
 
 		_finder.TargetCodeEdit = _codeEdit;
-		TextEditorRoot.PopulateStandardMenu(_codeEdit);
+		TextEditorRoot.PopulateStandardMenu(_codeEdit, canFormat: true);
 		_codeEdit.GetMenu().IdPressed += OnContextMenuIdPressed;
 
 		_lineHeight = _codeEdit.GetLineHeight();
@@ -176,7 +176,7 @@ public partial class ConsoleCommandLine : Control
 
 	private async void OnContextMenuIdPressed(long id)
 	{
-		await TextEditorRoot.HandleStandardMenuId(id, _codeEdit, _finder, _temporaryFile, OnTextChanged);
+		await TextEditorRoot.HandleStandardMenuId(id, _codeEdit, _finder, _temporaryFile, OnTextChanged, canFormat: true);
 	}
 
 	private void NavigateHistory(bool older)

--- a/Polytoria/scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs.uid
+++ b/Polytoria/scripts/creator/ui/docks/bottombar/console/ConsoleCommandLine.cs.uid
@@ -1,0 +1,1 @@
+uid://b77lltdi1as4p

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorField.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorField.cs
@@ -8,35 +8,20 @@ namespace Polytoria.Creator.UI.TextEditor;
 
 public sealed partial class TextEditorField : CodeEdit
 {
-	private const int FontSizeStep = 2;
-	private const int MinFontSize = 8;
-	private const int MaxFontSize = 72;
-
 	public TextEditorRoot Root = null!;
-
-	private int _currentFontSize = 16;
-
-	public override void _Ready()
-	{
-		int size = GetThemeFontSize("font_size", "Label");
-		_currentFontSize = size > 0 ? size : 16;
-		base._Ready();
-	}
 
 	public override void _GuiInput(InputEvent @event)
 	{
-		if (@event is InputEventMouseButton mb && mb.Pressed)
+		if (@event is InputEventMouseButton { Pressed: true } mb)
 		{
 			if (mb.CtrlPressed && mb.ButtonIndex == MouseButton.WheelUp)
 			{
-				_currentFontSize = Mathf.Clamp(_currentFontSize + FontSizeStep, MinFontSize, MaxFontSize);
-				AddThemeFontSizeOverride("font_size", _currentFontSize);
+				TextEditorRoot.Zoom(this, TextEditorRoot.FontSizeStep);
 				AcceptEvent();
 			}
 			else if (mb.CtrlPressed && mb.ButtonIndex == MouseButton.WheelDown)
 			{
-				_currentFontSize = Mathf.Clamp(_currentFontSize - FontSizeStep, MinFontSize, MaxFontSize);
-				AddThemeFontSizeOverride("font_size", _currentFontSize);
+				TextEditorRoot.Zoom(this, -TextEditorRoot.FontSizeStep);
 				AcceptEvent();
 			}
 		}

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorFind.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorFind.cs
@@ -24,7 +24,7 @@ public sealed partial class TextEditorFind : Control
 	private readonly List<Vector2I> _searchResults = [];
 	private int _currentResultIndex = -1;
 
-	public TextEditorRoot Root = null!;
+	public CodeEdit TargetCodeEdit = null!;
 
 	public bool Active = false;
 
@@ -113,11 +113,11 @@ public sealed partial class TextEditorFind : Control
 			? StringComparison.Ordinal
 			: StringComparison.OrdinalIgnoreCase;
 
-		int lineCount = Root.CodeEditor.GetLineCount();
+		int lineCount = TargetCodeEdit.GetLineCount();
 
 		for (int line = 0; line < lineCount; line++)
 		{
-			string lineText = Root.CodeEditor.GetLine(line);
+			string lineText = TargetCodeEdit.GetLine(line);
 			int index = 0;
 
 			while (index < lineText.Length)
@@ -179,8 +179,8 @@ public sealed partial class TextEditorFind : Control
 		int line = result.X;
 		int column = result.Y;
 
-		Root.CodeEditor.Select(line, column, line, column + _searchField.Text.Length);
-		Root.CodeEditor.CenterViewportToCaret();
+		TargetCodeEdit.Select(line, column, line, column + _searchField.Text.Length);
+		TargetCodeEdit.CenterViewportToCaret();
 	}
 
 	private void UpdateResultLabel()
@@ -204,10 +204,10 @@ public sealed partial class TextEditorFind : Control
 		int line = result.X;
 		int column = result.Y;
 
-		string lineText = Root.CodeEditor.GetLine(line);
+		string lineText = TargetCodeEdit.GetLine(line);
 		string newLineText = lineText.Remove(column, _searchField.Text.Length)
 									 .Insert(column, _replaceField.Text);
-		Root.CodeEditor.SetLine(line, newLineText);
+		TargetCodeEdit.SetLine(line, newLineText);
 
 		SearchCurrent();
 
@@ -229,10 +229,10 @@ public sealed partial class TextEditorFind : Control
 			int line = result.X;
 			int column = result.Y;
 
-			string lineText = Root.CodeEditor.GetLine(line);
+			string lineText = TargetCodeEdit.GetLine(line);
 			string newLineText = lineText.Remove(column, _searchField.Text.Length)
 										 .Insert(column, _replaceField.Text);
-			Root.CodeEditor.SetLine(line, newLineText);
+			TargetCodeEdit.SetLine(line, newLineText);
 		}
 
 		// Refresh search results
@@ -257,6 +257,6 @@ public sealed partial class TextEditorFind : Control
 	{
 		Active = false;
 		Visible = false;
-		Root.CodeEditor.GrabFocus();
+		TargetCodeEdit.GrabFocus();
 	}
 }

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -14,13 +14,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Polytoria.Creator.UI.TextEditor;
 
 public partial class TextEditorRoot : Node
 {
 	private const string CodeCompletionIconPath = "res://assets/textures/creator/tabs/text_editor/code_completion/";
-	private const int DiagDelay = 500;
+	public const int DiagDelay = 500;
 
 	[Export] public TextEditorField CodeEditor = null!;
 	public TextEditorContainer Container = null!;
@@ -50,11 +51,25 @@ public partial class TextEditorRoot : Node
 
 	public override void _EnterTree()
 	{
-		_finder.Root = this;
+		_finder.TargetCodeEdit = CodeEditor;
 		base._EnterTree();
 	}
 
-	private const int FormatMenuId = 10010;
+	public const int FormatMenuId = 10010;
+	public const int FindMenuId = 10011;
+	public const int ZoomInMenuId = 10012;
+	public const int ZoomOutMenuId = 10013;
+	public const int ZoomResetMenuId = 10014;
+	public const int ToggleCommentMenuId = 10015;
+	public const int ToggleBlockCommentMenuId = 10016;
+
+	private const int FontSizeStep = 2;
+	private const int MinFontSize = 8;
+	private const int MaxFontSize = 72;
+	private const string BlockCommentStart = "--[[";
+	private const string BlockCommentEnd = "--]]";
+
+	private static readonly Key[] NativeEditShortcutKeys = [Key.Z, Key.Y, Key.C, Key.X, Key.V, Key.A];
 
 	public override async void _ExitTree()
 	{
@@ -64,6 +79,7 @@ public partial class TextEditorRoot : Node
 			_completion.PublishDiagnostics -= OnPublishDiagnostics;
 		}
 		CreatorSettingsService.Instance.Changed -= OnCreatorSettingChanged;
+		CodeEditor.GetMenu().IdPressed -= OnContextMenuIdPressed;
 		base._ExitTree();
 	}
 
@@ -88,8 +104,7 @@ public partial class TextEditorRoot : Node
 		CodeEditor.TextChanged += OnCodeEditTextChanged;
 		InitSyntaxHighlighter(Container.CodeCompletion);
 
-		// testing for now:
-		CodeEditor.GetMenu().AddItem("Format Script", id: FormatMenuId);
+		PopulateStandardMenu(CodeEditor);
 		CodeEditor.GetMenu().IdPressed += OnContextMenuIdPressed;
 
 		CreatorSettingsService.Instance.Changed += OnCreatorSettingChanged;
@@ -105,10 +120,7 @@ public partial class TextEditorRoot : Node
 		CodeEditor.SetGutterName(0, "diagnostics");
 
 		CodeEditor.Root = this;
-
-		// TODO: Can be made into TextEditorRoot.GrabFocus() ?
-		// Needs to be call deferred to be the last to grab
-		PT.CallDeferred(CodeEditor.GrabFocus);
+		GrabFocus();
 
 		if (_completion != null)
 		{
@@ -118,17 +130,106 @@ public partial class TextEditorRoot : Node
 		UpdateStatusBar();
 	}
 
+	public static bool ShouldSwallowModifierInput(InputEvent @event)
+	{
+		if (@event is not InputEventKey { Pressed: true } key) return false;
+		if (!key.CtrlPressed && !key.AltPressed && !key.MetaPressed) return false;
+		return !NativeEditShortcutKeys.Contains(key.Keycode);
+	}
+
+	// Needs to be call deferred to be the last to grab
+	public void GrabFocus()
+	{
+		PT.CallDeferred(CodeEditor.GrabFocus);
+	}
+
 	private async void OnContextMenuIdPressed(long id)
+	{
+		await HandleStandardMenuId(id, CodeEditor, _finder, Container.TargetFilePathAbsolute, OnCodeEditTextChanged);
+	}
+
+	public static async Task HandleStandardMenuId(long id, CodeEdit codeEdit, TextEditorFind finder, string formatPath, Action onTextChanged)
 	{
 		switch (id)
 		{
 			case FormatMenuId:
 				{
-					CodeEditor.Text = await LuaFormatService.FormatScriptAsync(Container.TargetFilePathAbsolute, CodeEditor.Text);
-					OnCodeEditTextChanged();
+					codeEdit.Text = await LuaFormatService.FormatScriptAsync(formatPath, codeEdit.Text);
+					onTextChanged();
+					break;
+				}
+			case FindMenuId:
+				{
+					finder.Open(codeEdit.GetSelectedText());
+					break;
+				}
+			case ZoomInMenuId:
+				{
+					Zoom(codeEdit, FontSizeStep);
+					break;
+				}
+			case ZoomOutMenuId:
+				{
+					Zoom(codeEdit, -FontSizeStep);
+					break;
+				}
+			case ZoomResetMenuId:
+				{
+					ResetZoom(codeEdit);
+					break;
+				}
+			case ToggleCommentMenuId:
+				{
+					ToggleComment(codeEdit);
+					break;
+				}
+			case ToggleBlockCommentMenuId:
+				{
+					ToggleBlockComment(codeEdit);
 					break;
 				}
 		}
+	}
+
+	public static void PopulateStandardMenu(CodeEdit codeEdit)
+	{
+		PopupMenu menu = codeEdit.GetMenu();
+		menu.AddSeparator();
+		menu.AddItem("Format Script", id: FormatMenuId);
+		menu.AddItem("Find / Replace", id: FindMenuId);
+		menu.AddSeparator();
+		menu.AddItem("Zoom In", id: ZoomInMenuId);
+		menu.AddItem("Zoom Out", id: ZoomOutMenuId);
+		menu.AddItem("Restore Zoom", id: ZoomResetMenuId);
+		menu.AddSeparator();
+		menu.AddItem("Toggle Comment", id: ToggleCommentMenuId);
+		menu.AddItem("Toggle Block Comment", id: ToggleBlockCommentMenuId);
+
+		(int Id, Key Key, bool Shift)[] accelerators =
+		[
+			(FindMenuId, Key.F, false),
+			(ZoomInMenuId, Key.Equal, false),
+			(ZoomOutMenuId, Key.Minus, false),
+			(ZoomResetMenuId, Key.Key0, false),
+			(ToggleCommentMenuId, Key.Slash, false),
+			(ToggleBlockCommentMenuId, Key.Slash, true)
+		];
+		foreach (var (id, key, shift) in accelerators)
+		{
+			Key mods = (Key)((int)KeyModifierMask.MaskCtrl | (shift ? (int)KeyModifierMask.MaskShift : 0));
+			menu.SetItemAccelerator(menu.GetItemIndex(id), key | mods);
+		}
+	}
+
+	public static void Zoom(CodeEdit codeEdit, int delta)
+	{
+		int current = codeEdit.GetThemeFontSize("font_size");
+		codeEdit.AddThemeFontSizeOverride("font_size", Mathf.Clamp(current + delta, MinFontSize, MaxFontSize));
+	}
+
+	public static void ResetZoom(CodeEdit codeEdit)
+	{
+		codeEdit.RemoveThemeFontSizeOverride("font_size");
 	}
 
 	private void OnCreatorSettingChanged(SettingChangedEvent e)
@@ -161,14 +262,14 @@ public partial class TextEditorRoot : Node
 		{
 			await Task.Delay(DiagDelay, token);
 
-			ApplyDiagnostics(diagnostics);
+			ApplyDiagnostics(CodeEditor, _diagLabel, diagnostics);
 		}
 		catch (TaskCanceledException) { }
 	}
 
-	private void ApplyDiagnostics(List<LspDiagnostic> diagnostics)
+	public static void ApplyDiagnostics(CodeEdit codeEdit, Label diagLabel, List<LspDiagnostic> diagnostics)
 	{
-		ClearDiagnostics();
+		ClearDiagnostics(codeEdit, diagLabel);
 
 		List<string> messages = [];
 
@@ -185,8 +286,8 @@ public partial class TextEditorRoot : Node
 				1 => GD.Load<Texture2D>("res://assets/textures/creator/tabs/text_editor/error.svg"), // Error
 				_ => null
 			};
-			CodeEditor.SetLineBackgroundColor(diag.Range.Start.Line, setTo);
-			CodeEditor.SetLineGutterIcon(line, 0, gutterIcon);
+			codeEdit.SetLineBackgroundColor(line, setTo);
+			codeEdit.SetLineGutterIcon(line, 0, gutterIcon);
 
 			if (diag.Severity == 1 && messages.Count < 5)
 			{
@@ -196,20 +297,20 @@ public partial class TextEditorRoot : Node
 
 		if (messages.Count > 0)
 		{
-			_diagLabel.Text = string.Join('\n', messages);
-			_diagLabel.Visible = true;
+			diagLabel.Text = string.Join('\n', messages);
+			diagLabel.Visible = true;
 		}
 	}
 
-	private void ClearDiagnostics()
+	public static void ClearDiagnostics(CodeEdit codeEdit, Label diagLabel)
 	{
-		_diagLabel.Text = "";
-		_diagLabel.Visible = false;
+		diagLabel.Text = "";
+		diagLabel.Visible = false;
 		Color to = new(0, 0, 0, 0);
-		for (int i = 0; i < CodeEditor.GetLineCount(); i++)
+		for (int i = 0; i < codeEdit.GetLineCount(); i++)
 		{
-			CodeEditor.SetLineBackgroundColor(i, to);
-			CodeEditor.SetLineGutterIcon(i, 0, null);
+			codeEdit.SetLineBackgroundColor(i, to);
+			codeEdit.SetLineGutterIcon(i, 0, null);
 		}
 	}
 
@@ -229,15 +330,19 @@ public partial class TextEditorRoot : Node
 			CodeEditor.AcceptEvent();
 			_finder.Open(CodeEditor.GetSelectedText());
 		}
-		else if (@event.IsActionPressed("textedit_toggle_comment"))
+		else if (@event.IsActionPressed("textedit_toggle_comment") && @event is InputEventKey { ShiftPressed: false })
 		{
 			CodeEditor.AcceptEvent();
 			ToggleComment();
 		}
-		else if (@event.IsActionPressed("ui_cancel"))
+		else if (@event.IsActionPressed("ui_cancel") && _finder.Active)
 		{
 			CodeEditor.AcceptEvent();
 			_finder.Close();
+		}
+		else if (ShouldSwallowModifierInput(@event))
+		{
+			CodeEditor.AcceptEvent();
 		}
 		else
 		{
@@ -247,39 +352,55 @@ public partial class TextEditorRoot : Node
 
 	private void InitSyntaxHighlighter(FileTypeEnum fileType)
 	{
-		_highlighter = new();
-		CodeEditor.SyntaxHighlighter = _highlighter;
-
 		if (fileType == FileTypeEnum.Lua)
 		{
-			_highlighter.FunctionColor = ColorWarn;
-			_highlighter.MemberVariableColor = ColorWhite;
-			_highlighter.NumberColor = ColorSuccess;
-			_highlighter.SymbolColor = ColorWhite;
-
-			foreach (string item in LuaCompletionService.LuaKeywords)
-			{
-				_highlighter.AddKeywordColor(item, ColorDanger);
-			}
-
-			_highlighter.AddColorRegion("\"", "\"", ColorWarn);
-			_highlighter.AddColorRegion("'", "'", ColorWarn);
-			_highlighter.AddColorRegion("`", "`", ColorWarn);
-			_highlighter.AddColorRegion("[[", "]]", ColorWarn);
-			_highlighter.AddColorRegion("--[[", "]]", ColorGrey);
-			_highlighter.AddColorRegion("--", "", ColorGrey);
-
-			CodeEditor.AddStringDelimiter("\"", "\"", true);
-			CodeEditor.AddStringDelimiter("'", "'", true);
-			CodeEditor.AddStringDelimiter("[[", "]]", false);
+			_highlighter = CreateLuaHighlighter();
+			CodeEditor.SyntaxHighlighter = _highlighter;
+			ApplyLuaStringDelimiters(CodeEditor);
 		}
 		else
 		{
-			_highlighter.FunctionColor = ColorWhite;
-			_highlighter.MemberVariableColor = ColorWhite;
-			_highlighter.NumberColor = ColorWhite;
-			_highlighter.SymbolColor = ColorWhite;
+			_highlighter = new()
+			{
+				FunctionColor = ColorWhite,
+				MemberVariableColor = ColorWhite,
+				NumberColor = ColorWhite,
+				SymbolColor = ColorWhite
+			};
+			CodeEditor.SyntaxHighlighter = _highlighter;
 		}
+	}
+
+	public static CodeHighlighter CreateLuaHighlighter()
+	{
+		CodeHighlighter highlighter = new()
+		{
+			FunctionColor = ColorWarn,
+			MemberVariableColor = ColorWhite,
+			NumberColor = ColorSuccess,
+			SymbolColor = ColorWhite
+		};
+
+		foreach (string item in LuaCompletionService.LuaKeywords)
+		{
+			highlighter.AddKeywordColor(item, ColorDanger);
+		}
+
+		highlighter.AddColorRegion("\"", "\"", ColorWarn);
+		highlighter.AddColorRegion("'", "'", ColorWarn);
+		highlighter.AddColorRegion("`", "`", ColorWarn);
+		highlighter.AddColorRegion("[[", "]]", ColorWarn);
+		highlighter.AddColorRegion("--[[", "]]", ColorGrey);
+		highlighter.AddColorRegion("--", "", ColorGrey);
+
+		return highlighter;
+	}
+
+	public static void ApplyLuaStringDelimiters(CodeEdit edit)
+	{
+		edit.AddStringDelimiter("\"", "\"", true);
+		edit.AddStringDelimiter("'", "'", true);
+		edit.AddStringDelimiter("[[", "]]", false);
 	}
 
 	public async Task Save()
@@ -340,42 +461,48 @@ public partial class TextEditorRoot : Node
 	public async void OnCompletionRequest()
 	{
 		if (_completion == null) return;
+		await RequestCompletions(CodeEditor, _completion, Container.TargetFilePathAbsolute, iconBasePath: CodeCompletionIconPath, skipIfMatches: GetWordBeforeCaret());
+	}
+
+	public static async Task RequestCompletions(CodeEdit codeEdit, LuaCompletionService completion, string scriptPath, string? iconBasePath = null, string? skipIfMatches = null)
+	{
 		CodeEditCompletionContext context = new()
 		{
-			ScriptPath = Container.TargetFilePathAbsolute,
-			Content = CodeEditor.Text,
-			CursorLine = CodeEditor.GetCaretLine(),
-			CursorColumn = CodeEditor.GetCaretColumn(),
+			ScriptPath = scriptPath,
+			Content = codeEdit.Text,
+			CursorLine = codeEdit.GetCaretLine(),
+			CursorColumn = codeEdit.GetCaretColumn()
 		};
 
-		List<CodeEditCompletionItem> items = await _completion.GetCompletionsAsync(context);
+		List<CodeEditCompletionItem> items = await completion.GetCompletionsAsync(context);
 
-		string wcaret = GetWordBeforeCaret();
-
-		foreach (CodeEditCompletionItem item in items)
+		if (skipIfMatches != null)
 		{
-			if (wcaret == item.InsertText)
+			foreach (CodeEditCompletionItem item in items)
 			{
-				return;
+				if (skipIfMatches == item.InsertText) return;
 			}
 		}
 
 		foreach (CodeEditCompletionItem item in items)
 		{
-			string? iconTxt = item.Kind switch
-			{
-				CodeEdit.CodeCompletionKind.Member => "Property",
-				CodeEdit.CodeCompletionKind.Function => "Method",
-				_ => "None"
-			};
 			Texture2D? icon = null;
-			if (iconTxt != null)
+			if (iconBasePath != null)
 			{
-				icon = GD.Load<Texture2D>(CodeCompletionIconPath.PathJoin(iconTxt + ".svg"));
+				string? iconTxt = item.Kind switch
+				{
+					CodeEdit.CodeCompletionKind.Member => "Property",
+					CodeEdit.CodeCompletionKind.Function => "Method",
+					_ => "None"
+				};
+				if (iconTxt != null)
+				{
+					icon = GD.Load<Texture2D>(iconBasePath.PathJoin(iconTxt + ".svg"));
+				}
 			}
-			CodeEditor.AddCodeCompletionOption(item.Kind, item.DisplayText, item.InsertText, icon: icon, location: -1);
+			codeEdit.AddCodeCompletionOption(item.Kind, item.DisplayText, item.InsertText, icon: icon, location: -1);
 		}
-		CodeEditor.UpdateCodeCompletionOptions(false);
+		codeEdit.UpdateCodeCompletionOptions(false);
 	}
 
 	private void UpdateStatusBar()
@@ -412,47 +539,91 @@ public partial class TextEditorRoot : Node
 		return lineText[startPos..column];
 	}
 
-	public IEnumerable<int> GetSelectedLines()
+	public void ToggleComment() => ToggleComment(CodeEditor);
+
+	public static IEnumerable<int> GetSelectedLines(CodeEdit codeEdit)
 	{
-		for (int caretIdx = 0; caretIdx < CodeEditor.GetCaretCount(); caretIdx++)
+		for (int caretIdx = 0; caretIdx < codeEdit.GetCaretCount(); caretIdx++)
 		{
-			for (int lineIdx = CodeEditor.GetSelectionFromLine(caretIdx); lineIdx <= CodeEditor.GetSelectionToLine(caretIdx); lineIdx++)
+			for (int lineIdx = codeEdit.GetSelectionFromLine(caretIdx); lineIdx <= codeEdit.GetSelectionToLine(caretIdx); lineIdx++)
 			{
 				yield return lineIdx;
 			}
 		}
 	}
 
-	private bool IsSelectionCommented()
+	public static void ToggleComment(CodeEdit codeEdit)
 	{
-		foreach (int lineIdx in GetSelectedLines())
+		List<int> lines = [.. GetSelectedLines(codeEdit)];
+		if (lines.Count == 0) return;
+
+		bool commented = lines.All(l => codeEdit.GetLine(l).StartsWith("--"));
+		foreach (int lineIdx in lines)
 		{
-			string lineText = CodeEditor.GetLine(lineIdx);
-			if (!lineText.StartsWith("--"))
-			{
-				return false;
-			}
+			string lineText = codeEdit.GetLine(lineIdx);
+			codeEdit.SetLine(lineIdx, commented ? lineText[2..] : "--" + lineText);
 		}
-		return true;
+
+		codeEdit.Select(lines[0], 0, lines[^1], codeEdit.GetLine(lines[^1]).Length);
 	}
 
-	public void ToggleComment()
+	public static void ToggleBlockComment(CodeEdit codeEdit)
 	{
-		if (IsSelectionCommented())
+		const int caret = 0;
+		bool hasSelection = codeEdit.HasSelection(caret);
+
+		int fromLine = hasSelection ? codeEdit.GetSelectionFromLine(caret) : codeEdit.GetCaretLine();
+		int toLine = hasSelection ? codeEdit.GetSelectionToLine(caret) : codeEdit.GetCaretLine();
+		bool isWrapped = fromLine > 0 && toLine < codeEdit.GetLineCount() - 1 && codeEdit.GetLine(fromLine - 1).Trim() == BlockCommentStart && codeEdit.GetLine(toLine + 1).Trim() == BlockCommentEnd;
+
+		codeEdit.BeginComplexOperation();
+
+		if (isWrapped)
 		{
-			foreach (int lineIdx in GetSelectedLines())
-			{
-				string lineText = CodeEditor.GetLine(lineIdx);
-				CodeEditor.SetLine(lineIdx, lineText[2..]);
-			}
+			RemoveEntireLine(codeEdit, toLine + 1);
+			RemoveEntireLine(codeEdit, fromLine - 1);
+
+			int newFrom = fromLine - 1;
+			int newTo = toLine - 1;
+			codeEdit.Select(newFrom, 0, newTo, codeEdit.GetLine(newTo).Length);
+			codeEdit.UnindentLines();
 		}
 		else
 		{
-			foreach (int lineIdx in GetSelectedLines())
-			{
-				string lineText = CodeEditor.GetLine(lineIdx);
-				CodeEditor.SetLine(lineIdx, "--" + lineText);
-			}
+			codeEdit.Select(fromLine, 0, toLine, codeEdit.GetLine(toLine).Length);
+			codeEdit.IndentLines();
+			codeEdit.Deselect();
+
+			codeEdit.SetCaretLine(toLine);
+			codeEdit.SetCaretColumn(codeEdit.GetLine(toLine).Length);
+			codeEdit.InsertTextAtCaret("\n" + BlockCommentEnd);
+
+			codeEdit.SetCaretLine(fromLine);
+			codeEdit.SetCaretColumn(0);
+			codeEdit.InsertTextAtCaret(BlockCommentStart + "\n");
+
+			int newFrom = fromLine + 1;
+			int newTo = toLine + 1;
+			codeEdit.Select(newFrom, 0, newTo, codeEdit.GetLine(newTo).Length);
+		}
+
+		codeEdit.EndComplexOperation();
+	}
+
+	private static void RemoveEntireLine(CodeEdit codeEdit, int lineIdx)
+	{
+		if (codeEdit.GetLineCount() > lineIdx + 1)
+		{
+			codeEdit.RemoveText(lineIdx, 0, lineIdx + 1, 0);
+		}
+		else if (lineIdx > 0)
+		{
+			int prevLen = codeEdit.GetLine(lineIdx - 1).Length;
+			codeEdit.RemoveText(lineIdx - 1, prevLen, lineIdx, codeEdit.GetLine(lineIdx).Length);
+		}
+		else
+		{
+			codeEdit.SetLine(lineIdx, "");
 		}
 	}
 }

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -104,7 +104,7 @@ public partial class TextEditorRoot : Node
 		CodeEditor.TextChanged += OnCodeEditTextChanged;
 		InitSyntaxHighlighter(Container.CodeCompletion);
 
-		PopulateStandardMenu(CodeEditor);
+		PopulateStandardMenu(CodeEditor, Container.CodeCompletion == FileTypeEnum.Lua);
 		CodeEditor.GetMenu().IdPressed += OnContextMenuIdPressed;
 
 		CreatorSettingsService.Instance.Changed += OnCreatorSettingChanged;
@@ -145,17 +145,20 @@ public partial class TextEditorRoot : Node
 
 	private async void OnContextMenuIdPressed(long id)
 	{
-		await HandleStandardMenuId(id, CodeEditor, _finder, Container.TargetFilePathAbsolute, OnCodeEditTextChanged);
+		await HandleStandardMenuId(id, CodeEditor, _finder, Container.TargetFilePathAbsolute, OnCodeEditTextChanged, Container.CodeCompletion == FileTypeEnum.Lua);
 	}
 
-	public static async Task HandleStandardMenuId(long id, CodeEdit codeEdit, TextEditorFind finder, string formatPath, Action onTextChanged)
+	public static async Task HandleStandardMenuId(long id, CodeEdit codeEdit, TextEditorFind finder, string formatPath, Action onTextChanged, bool canFormat)
 	{
 		switch (id)
 		{
 			case FormatMenuId:
 				{
-					codeEdit.Text = await LuaFormatService.FormatScriptAsync(formatPath, codeEdit.Text);
-					onTextChanged();
+					if (canFormat)
+					{
+						codeEdit.Text = await LuaFormatService.FormatScriptAsync(formatPath, codeEdit.Text);
+						onTextChanged();
+					}
 					break;
 				}
 			case FindMenuId:
@@ -191,11 +194,12 @@ public partial class TextEditorRoot : Node
 		}
 	}
 
-	public static void PopulateStandardMenu(CodeEdit codeEdit)
+	public static void PopulateStandardMenu(CodeEdit codeEdit, bool canFormat)
 	{
 		PopupMenu menu = codeEdit.GetMenu();
 		menu.AddSeparator();
 		menu.AddItem("Format Script", id: FormatMenuId);
+		menu.SetItemDisabled(menu.GetItemIndex(FormatMenuId), !canFormat);
 		menu.AddItem("Find / Replace", id: FindMenuId);
 		menu.AddSeparator();
 		menu.AddItem("Zoom In", id: ZoomInMenuId);

--- a/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
+++ b/Polytoria/scripts/creator/ui/tabs/text_editor/TextEditorRoot.cs
@@ -63,9 +63,9 @@ public partial class TextEditorRoot : Node
 	public const int ToggleCommentMenuId = 10015;
 	public const int ToggleBlockCommentMenuId = 10016;
 
-	private const int FontSizeStep = 2;
-	private const int MinFontSize = 8;
-	private const int MaxFontSize = 72;
+	public const int FontSizeStep = 2;
+	public const int MinFontSize = 8;
+	public const int MaxFontSize = 72;
 	private const string BlockCommentStart = "--[[";
 	private const string BlockCommentEnd = "--]]";
 
@@ -430,7 +430,7 @@ public partial class TextEditorRoot : Node
 			{
 				_oldText = curText;
 
-				if (IsCompletionTrigger())
+				if (IsCompletionTrigger(CodeEditor))
 				{
 					OnCompletionRequest();
 				}
@@ -438,11 +438,11 @@ public partial class TextEditorRoot : Node
 		}
 	}
 
-	private bool IsCompletionTrigger()
+	public static bool IsCompletionTrigger(CodeEdit codeEdit)
 	{
-		int line = CodeEditor.GetCaretLine();
-		int col = CodeEditor.GetCaretColumn();
-		string lineText = CodeEditor.GetLine(line);
+		int line = codeEdit.GetCaretLine();
+		int col = codeEdit.GetCaretColumn();
+		string lineText = codeEdit.GetLine(line);
 
 		if (string.IsNullOrWhiteSpace(lineText)) return false;
 
@@ -465,7 +465,7 @@ public partial class TextEditorRoot : Node
 	public async void OnCompletionRequest()
 	{
 		if (_completion == null) return;
-		await RequestCompletions(CodeEditor, _completion, Container.TargetFilePathAbsolute, iconBasePath: CodeCompletionIconPath, skipIfMatches: GetWordBeforeCaret());
+		await RequestCompletions(CodeEditor, _completion, Container.TargetFilePathAbsolute, iconBasePath: CodeCompletionIconPath, skipIfMatches: GetWordBeforeCaret(CodeEditor));
 	}
 
 	public static async Task RequestCompletions(CodeEdit codeEdit, LuaCompletionService completion, string scriptPath, string? iconBasePath = null, string? skipIfMatches = null)
@@ -516,11 +516,11 @@ public partial class TextEditorRoot : Node
 		_statusBar.Text = $"{Container.OriginTabName}: ({lineIndex}:{column})";
 	}
 
-	public string GetWordBeforeCaret()
+	public static string GetWordBeforeCaret(CodeEdit codeEdit)
 	{
-		int lineIndex = CodeEditor.GetCaretLine();
-		int column = CodeEditor.GetCaretColumn();
-		string lineText = CodeEditor.GetLine(lineIndex);
+		int lineIndex = codeEdit.GetCaretLine();
+		int column = codeEdit.GetCaretColumn();
+		string lineText = codeEdit.GetLine(lineIndex);
 
 		if (column == 0) return string.Empty;
 

--- a/Polytoria/scripts/creator/ui/wizards/new_project/NewProjectWizard.cs
+++ b/Polytoria/scripts/creator/ui/wizards/new_project/NewProjectWizard.cs
@@ -98,12 +98,25 @@ public partial class NewProjectWizard : Control
 		return card;
 	}
 
+	private static string GetNextAvailableProjectName(string projectsRoot)
+	{
+		int index = 1;
+		string name;
+		do { name = $"{DefaultProjectName}{index++}"; }
+		while (Directory.Exists(Path.Join(projectsRoot, name)));
+		return name;
+	}
+
 	public void Open()
 	{
 		Visible = true;
-		_oldNameText = DefaultProjectName;
-		_projectNameEdit.Text = DefaultProjectName;
-		_projectPathEdit.Text = Path.Join(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments), CreatorService.PolytoriaFolderName, DefaultProjectName).SanitizePath();
+		string projectsRoot = Path.Join(CreatorService.DocumentsRootPath, "Projects");
+		Directory.CreateDirectory(projectsRoot);
+
+		string defaultName = GetNextAvailableProjectName(projectsRoot);
+		_oldNameText = defaultName;
+		_projectNameEdit.Text = defaultName;
+		_projectPathEdit.Text = Path.Join(projectsRoot, defaultName).SanitizePath();
 	}
 
 	public void Back()

--- a/Polytoria/scripts/datamodel/creator/CreatorAddons.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorAddons.cs
@@ -2,14 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using Godot;
 using Polytoria.Attributes;
 using Polytoria.Creator.Managers;
 using Polytoria.Creator.UI;
 using Polytoria.Datamodel.Resources;
 using Polytoria.Scripting;
+using Polytoria.Scripting.Luau;
 using Polytoria.Shared;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace Polytoria.Datamodel.Creator;
 
@@ -122,6 +125,54 @@ public sealed partial class CreatorAddons : Instance
 			ToolItems.Add(item);
 			Menu.Singleton.UpdateAddonMenu(this);
 			return item;
+		}
+
+		/// <summary>
+		/// Saves the passed string to the user's clipboard.
+		/// </summary>
+		[ScriptMethod(Permissions = ScriptPermissionFlags.ContextAccess)]
+		public static void SetClipboard(string text) => DisplayServer.ClipboardSet(text);
+
+		/// <summary>
+		/// Returns the contents of the user's clipboard.
+		/// </summary>
+		[ScriptMethod(Permissions = ScriptPermissionFlags.ContextAccess)]
+		public static string GetClipboard() => DisplayServer.ClipboardGet();
+
+		/// <summary>
+		/// Prompts the user to pick a script file and returns it's result, or nil if invalid.
+		/// </summary>
+		[ScriptMethod(Permissions = ScriptPermissionFlags.IORead)]
+		public static async Task<object?> RequestScriptFile([ScriptingCaller] Script caller)
+		{
+			TaskCompletionSource<string?> fileTcs = new();
+			CreatorService.Interface.PromptFileSelect(new()
+			{
+				Title = "Select script file",
+				DialogMode = DisplayServer.FileDialogMode.OpenFile,
+				Filters = ["*.lua,*.luau;Luau Script"]
+			},
+			paths => fileTcs.SetResult(File.ReadAllText(paths[0])),
+			() => fileTcs.SetResult(null));
+
+			string? source = await fileTcs.Task;
+			if (source == null || caller.LuauState == null || !caller.LuauState.IsAlive) return null;
+
+			byte[] bytecode;
+			try { bytecode = LuauProvider.Singleton.CompileSource(source); }
+			catch { return null; }
+
+			LuaState mainState = caller.LuauState;
+			LuaState co = LuauProvider.NewThread(mainState);
+			int coRef = mainState.Ref();
+			try
+			{
+				co.Load("@requested_script", bytecode);
+				await LuauProvider.ResumeThread(co, mainState, 0, throwError: true);
+				return co.GetTop() > 0 ? LuauProvider.Singleton.LuaToObject(co, 1) : null;
+			}
+			catch { return null; }
+			finally { mainState.Unref(coRef); }
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/creator/CreatorHistory.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorHistory.cs
@@ -17,6 +17,9 @@ public sealed partial class CreatorHistory : Instance
 {
 	private const float DeleteTimeoutSec = 60;
 	private HistoryAction? _currentAction = null;
+	private bool _trackInstances = false;
+	private Action<Instance>? _creationTracker = null;
+	private Action<Instance>? _removalTracker = null;
 	private readonly Stack<HistoryAction> _undoStack = new();
 	private readonly Stack<HistoryAction> _redoStack = new();
 
@@ -56,19 +59,43 @@ public sealed partial class CreatorHistory : Instance
 		CreatorService.Interface.StatusBar?.SetStatus("Redo " + action.Title);
 	}
 
+	/// <summary>
+	/// Creates new action.
+	/// </summary>
 	[ScriptMethod]
 	public void NewAction(string title)
 	{
 		_currentAction = new HistoryAction { Title = title };
 	}
 
+	/// <summary>
+	/// Tracks instance additions/removals performed during the current action automatically.
+	///	<br/>
+	/// Must be called after <see cref="NewAction"/> and before <see cref="CommitAction"/>.
+	/// No callbacks are required if this is called.
+	/// </summary>
+	[ScriptMethod]
+	public void TrackInstances()
+	{
+		if (_currentAction == null)
+		{
+			throw new InvalidOperationException("No action in progress. Call 'NewAction()' first.");
+		}
+		_trackInstances = true;
+	}
+
+	/// <summary>
+	/// Adds do callback to the current action.
+	///	<br/>
+	/// Must be called after <see cref="NewAction"/> and before <see cref="CommitAction"/>.
+	/// </summary>
 	[ScriptMethod]
 	public void AddDoCallback(PTCallback callback)
 	{
 		if (_currentAction == null)
 		{
 			throw new InvalidOperationException(
-				"No action in progress. Call NewAction() first.");
+				"No action in progress. Call 'NewAction()' first.");
 		}
 
 		ArgumentNullException.ThrowIfNull(callback);
@@ -76,13 +103,18 @@ public sealed partial class CreatorHistory : Instance
 		_currentAction.DoCallbacks.Add(callback);
 	}
 
+	/// <summary>
+	/// Adds undo callback to the current action.
+	///	<br/>
+	/// Must be called after <see cref="NewAction"/> and before <see cref="CommitAction"/>.
+	/// </summary>
 	[ScriptMethod]
 	public void AddUndoCallback(PTCallback callback)
 	{
 		if (_currentAction == null)
 		{
 			throw new InvalidOperationException(
-				"No action in progress. Call NewAction() first.");
+				"No action in progress. Call 'NewAction()' first.");
 		}
 
 		ArgumentNullException.ThrowIfNull(callback);
@@ -90,30 +122,104 @@ public sealed partial class CreatorHistory : Instance
 		_currentAction.UndoCallbacks.Add(callback);
 	}
 
+	/// <summary>
+	/// Commits the current action.
+	/// </summary>
 	[ScriptMethod]
 	public void CommitAction()
 	{
 		if (_currentAction == null)
 		{
 			throw new InvalidOperationException(
-				"No action to commit. Call NewAction() first.");
+				"No action to commit. Call 'NewAction()' first.");
 		}
 
-		if (_currentAction.DoCallbacks.Count == 0)
+		if (!_trackInstances && _currentAction.DoCallbacks.Count == 0)
 		{
-			throw new InvalidOperationException(
-				"Action must have at least one 'do' callback.");
+			throw new InvalidOperationException("Action must have at least one 'do' callback.");
 		}
 
-		if (_currentAction.UndoCallbacks.Count == 0)
+		if (!_trackInstances && _currentAction.UndoCallbacks.Count == 0)
 		{
-			throw new InvalidOperationException(
-				"Action must have at least one 'undo' callback.");
+			throw new InvalidOperationException("Action must have at least one 'undo' callback.");
+		}
+
+		List<(Instance Inst, Instance Parent, int Index)>? additions = null;
+		List<(Instance Inst, Instance Parent, int Index)>? removals = null;
+		if (_trackInstances)
+		{
+			additions = [];
+			removals = [];
+			_removalTracker = inst => removals.Add((inst, inst.Parent!, inst.Index));
+			_creationTracker = inst => additions.Add((inst, inst.Parent!, inst.Index));
+			Root.InstanceExitingTree += _removalTracker;
+			Root.InstanceEnteredTree += _creationTracker;
 		}
 
 		foreach (PTCallback callback in _currentAction.DoCallbacks)
 		{
 			callback?.Invoke();
+		}
+
+		if (_trackInstances && additions != null && removals != null)
+		{
+			Root.InstanceExitingTree -= _removalTracker;
+			Root.InstanceEnteredTree -= _creationTracker;
+			_removalTracker = null;
+			_creationTracker = null;
+			_trackInstances = false;
+
+			bool hasChanges = additions.Count > 0 || removals.Count > 0;
+			if (hasChanges)
+			{
+				(Instance Inst, Instance Parent, int Index)[] addedSnapshot = [.. additions];
+				(Instance Inst, Instance Parent, int Index)[] removedSnapshot = [.. removals];
+
+				bool additionsRecovered = true;
+				bool removalsRecovered = false;
+
+				_currentAction.UndoCallbacks.Insert(0, new((_callback) =>
+				{
+					additionsRecovered = false;
+					foreach ((Instance inst, _, _) in addedSnapshot)
+					{
+						inst.Parent = Root.TemporaryContainer;
+					}
+					StartSoftDeleteTimer(addedSnapshot, () => additionsRecovered);
+
+					removalsRecovered = true;
+					foreach ((Instance inst, Instance parent, int index) in removedSnapshot)
+					{
+						inst.Parent = parent;
+						parent.MoveChild(inst, index);
+					}
+				}));
+
+				_currentAction.DoCallbacks.Clear();
+				_currentAction.DoCallbacks.Add(new((_callback) =>
+				{
+					additionsRecovered = true;
+					foreach ((Instance inst, Instance parent, int index) in addedSnapshot)
+					{
+						inst.Parent = parent;
+						parent.MoveChild(inst, index);
+					}
+
+					removalsRecovered = false;
+					foreach ((Instance inst, _, _) in removedSnapshot)
+					{
+						inst.Parent = Root.TemporaryContainer;
+					}
+					StartSoftDeleteTimer(removedSnapshot, () => removalsRecovered);
+				}));
+			}
+		}
+
+		bool hasAnyEffect = _currentAction.DoCallbacks.Count > 0 || _currentAction.UndoCallbacks.Count > 0;
+		if (!hasAnyEffect)
+		{
+			_currentAction = null;
+			return;
 		}
 
 		_undoStack.Push(_currentAction);
@@ -201,6 +307,22 @@ public sealed partial class CreatorHistory : Instance
 		}));
 
 		CommitAction();
+	}
+
+	private void StartSoftDeleteTimer((Instance Inst, Instance Parent, int Index)[] instances, Func<bool> isRecovered)
+	{
+		Timer timer = new();
+		GDNode.AddChild(timer, @internal: Node.InternalMode.Back);
+		timer.Timeout += () =>
+		{
+			if (isRecovered()) return;
+			foreach ((Instance inst, _, _) in instances)
+			{
+				inst.Delete();
+			}
+			timer.QueueFree();
+		};
+		timer.Start(DeleteTimeoutSec);
 	}
 
 	public void DuplicateInstances(Instance[] instances)

--- a/Polytoria/scripts/datamodel/creator/CreatorService.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorService.cs
@@ -27,6 +27,7 @@ namespace Polytoria.Datamodel.Creator;
 public sealed partial class CreatorService : Node, IScriptObject
 {
 	public const string PolytoriaFolderName = "Polytoria/";
+	public static readonly string DocumentsRootPath = Path.Join(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments), PolytoriaFolderName);
 
 	private long _localTestIDCounter = 0;
 
@@ -63,10 +64,22 @@ public sealed partial class CreatorService : Node, IScriptObject
 		};
 		AddChild(Interface);
 
-		string polyFolder = Path.Join(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments), PolytoriaFolderName);
-		if (!Directory.Exists(polyFolder))
+		if (!Directory.Exists(DocumentsRootPath))
 		{
-			Directory.CreateDirectory(polyFolder);
+			Directory.CreateDirectory(DocumentsRootPath);
+		}
+
+		string localDataShortcut = Path.Combine(DocumentsRootPath, "Root");
+		if (!Directory.Exists(localDataShortcut) && !File.Exists(localDataShortcut))
+		{
+			try
+			{
+				Directory.CreateSymbolicLink(localDataShortcut, ProjectSettings.GlobalizePath("user://"));
+			}
+			catch (Exception ex)
+			{
+				PT.PrintWarn("Failed to create shortcut to root: ", ex.Message);
+			}
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/services/ScriptService.cs
+++ b/Polytoria/scripts/datamodel/services/ScriptService.cs
@@ -104,7 +104,10 @@ public sealed partial class ScriptService : Instance
 
 	public void Run(Script script)
 	{
-		PT.Print("Running script: ", script.LuaPath);
+		if (script.LuaPath != "world.Temporary.Instance")
+		{
+			PT.Print("Running script: ", script.LuaPath);
+		}
 
 		if (!_languageProviders.TryGetValue(script.ChosenLanguage, out var provider))
 		{

--- a/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
@@ -910,7 +910,7 @@ public class LuaMetatable : LuaObject
 			{
 				if (!script.PermissionFlags.HasFlag(methodAttribute.Permissions))
 				{
-				#if CREATOR
+#if CREATOR
 					if (script.Root.SessionType == World.SessionTypeEnum.Creator)
 					{
 						var addonSession = AddonsManager.GetAddonSession(script);
@@ -923,7 +923,7 @@ public class LuaMetatable : LuaObject
 							return state.Yield(1);
 						}
 					}
-				#endif
+#endif
 					throw new UnauthorizedAccessException("script does not have permission to call the specified method (" + targetMethod.Name + ")");
 				}
 			}

--- a/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuaMetatable.cs
@@ -3,6 +3,12 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using Godot;
+#if CREATOR
+using Polytoria.Creator;
+using Polytoria.Creator.Managers;
+using Polytoria.Datamodel.Creator;
+using static Polytoria.Datamodel.Creator.CreatorAddons;
+#endif
 using Polytoria.Attributes;
 using Polytoria.Datamodel;
 using Polytoria.Datamodel.Data;
@@ -840,26 +846,6 @@ public class LuaMetatable : LuaObject
 			throw new Exception("attempt to call non static method on a static object (" + key + ")");
 		}
 
-		ScriptMethodAttribute? methodAttribute = targetMethod.GetCustomAttribute<ScriptMethodAttribute>();
-
-		if (methodAttribute != null)
-		{
-			if (methodAttribute.Permissions != ScriptPermissionFlags.None)
-			{
-				if (!script.PermissionFlags.HasFlag(methodAttribute.Permissions))
-				{
-					throw new UnauthorizedAccessException("script does not have permission to call the specified method (" + targetMethod.Name + ")");
-				}
-			}
-		}
-
-		Attributes.ObsoleteAttribute? obsoleteAttribute = targetMethod.GetCustomAttribute<Attributes.ObsoleteAttribute>();
-
-		if (obsoleteAttribute != null)
-		{
-			PT.PrintWarn($"{targetMethod.Name} is obsolete. {obsoleteAttribute.Message}");
-		}
-
 		// Prepare args array formatted for params
 		ParameterInfo[] parametersFinal = targetMethod.GetParameters();
 		int callerParamIndex = Array.FindIndex(parametersFinal, p => p.IsDefined(typeof(ScriptingCallerAttribute)));
@@ -872,26 +858,25 @@ public class LuaMetatable : LuaObject
 			int paramsCount = Math.Max(0, argsCount - fixedParamCount);
 			Type paramsElementType = parametersFinal[^1].ParameterType.GetElementType()!;
 
-			// Convert fixed args
 			for (int i = 0; i < fixedParamCount; i++)
+			{
 				finalArgs.Add(ScriptService.ConvertToPropertyType(args[i], parametersFinal[i].ParameterType));
+			}
 
-			// Convert params args
 			Array paramsArray = new object[paramsCount];
 			for (int i = 0; i < paramsCount; i++)
+			{
 				paramsArray.SetValue(ScriptService.ConvertToPropertyType(args[fixedParamCount + i], paramsElementType), i);
+			}
 
 			finalArgs.Add(paramsArray);
 		}
 		else
 		{
-			// No params, just convert normally
 			int argIndex = 0;
 			for (int i = 0; i < parametersFinal.Length; i++)
 			{
-				if (i == callerParamIndex)
-					continue; // Skip the caller parameter
-
+				if (i == callerParamIndex) continue;
 				if (argIndex < argsCount)
 				{
 					finalArgs.Add(ScriptService.ConvertToPropertyType(args[argIndex], parametersFinal[i].ParameterType));
@@ -899,23 +884,57 @@ public class LuaMetatable : LuaObject
 				}
 			}
 
-			// Fill remaining with default values
 			for (int i = argsCount; i < parametersFinal.Length; i++)
 			{
-				if (i == callerParamIndex)
-					continue; // Skip the caller parameter
-
+				if (i == callerParamIndex) continue;
 				int paramIndex = i + (callerParamIndex >= 0 && i >= callerParamIndex ? 1 : 0);
 				if (paramIndex < parametersFinal.Length)
+				{
 					finalArgs.Add(parametersFinal[paramIndex].HasDefaultValue ? parametersFinal[paramIndex].DefaultValue : null);
+				}
 			}
 		}
 
-		// Apply caller if ScriptingCallerAttribute is found
 		if (callerParamIndex >= 0)
+		{
 			finalArgs.Insert(callerParamIndex, script);
+		}
 
 		object?[] invokeArgs = [.. finalArgs];
+
+		ScriptMethodAttribute? methodAttribute = targetMethod.GetCustomAttribute<ScriptMethodAttribute>();
+
+		if (methodAttribute != null)
+		{
+			if (methodAttribute.Permissions != ScriptPermissionFlags.None)
+			{
+				if (!script.PermissionFlags.HasFlag(methodAttribute.Permissions))
+				{
+				#if CREATOR
+					if (script.Root.SessionType == World.SessionTypeEnum.Creator)
+					{
+						var addonSession = AddonsManager.GetAddonSession(script);
+						if (addonSession != null)
+						{
+							AddonPermissionEnum[] needed = PermissionsToAddonPerms(methodAttribute.Permissions);
+							TaskCompletionSource<int> permTcs = new();
+							LuauProvider.SetYieldTask(state, permTcs.Task);
+							_ = RequestPermAndResume(script, state, targetMethod, targetObject, invokeArgs, needed, addonSession, permTcs);
+							return state.Yield(1);
+						}
+					}
+				#endif
+					throw new UnauthorizedAccessException("script does not have permission to call the specified method (" + targetMethod.Name + ")");
+				}
+			}
+		}
+
+		Attributes.ObsoleteAttribute? obsoleteAttribute = targetMethod.GetCustomAttribute<Attributes.ObsoleteAttribute>();
+
+		if (obsoleteAttribute != null)
+		{
+			PT.PrintWarn($"{targetMethod.Name} is obsolete. {obsoleteAttribute.Message}");
+		}
 
 		if (ScriptService.IsAsyncMethod(targetMethod))
 		{
@@ -1061,4 +1080,40 @@ public class LuaMetatable : LuaObject
 		public override bool Equals(object? obj) => obj is OverloadKey k && Equals(k);
 		public override int GetHashCode() => _hashCode;
 	}
+
+#if CREATOR
+	private static AddonPermissionEnum[] PermissionsToAddonPerms(ScriptPermissionFlags flags)
+	{
+		List<AddonPermissionEnum> list = [];
+		if (flags.HasFlag(ScriptPermissionFlags.IORead)) list.Add(AddonPermissionEnum.IORead);
+		if (flags.HasFlag(ScriptPermissionFlags.IOWrite)) list.Add(AddonPermissionEnum.IOWrite);
+		return [.. list];
+	}
+
+	private async Task RequestPermAndResume(Script script, LuaState state, MethodInfo method, object? target, object?[] args, AddonPermissionEnum[] perms, AddonsManager.AddonSession session, TaskCompletionSource<int> tcs)
+	{
+		try
+		{
+			bool granted = await CreatorService.Interface.PromptAddonReqPerm(perms, session.Data);
+			if (!granted)
+			{
+				tcs.SetException(new UnauthorizedAccessException("User declined permissions for " + method.Name));
+				return;
+			}
+			AddonsManager.SetAddonPermissions(script, perms, true);
+			if (ScriptService.IsAsyncMethod(method))
+			{
+				TaskCompletionSource<int> innerTcs = new();
+				AsyncExec(target, state, method, args, innerTcs);
+				tcs.SetResult(await innerTcs.Task);
+			}
+			else
+			{
+				LangProvider.PushValueToLua(state, method.Invoke(target, args));
+				tcs.SetResult(1);
+			}
+		}
+		catch (Exception ex) { tcs.SetException(ex); }
+	}
+#endif
 }

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -662,6 +662,17 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 			}
 		}
 		string logInfo = sb.ToString();
+
+		string? traceback;
+		lock (lua)
+		{
+			traceback = lua.DebugTrace();
+		}
+		if (!string.IsNullOrEmpty(traceback))
+		{
+			logInfo += "\nstacktrace:\n" + traceback;
+		}
+
 		logger.LogWarning(script, logInfo);
 		return 0;
 	}

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -735,7 +735,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		}
 
 		// Return existing if already required
-		if (ms.LuauState != null)
+		if (ms.LuauState != null && ms.Root.SessionType != World.SessionTypeEnum.Creator)
 		{
 			if (ms.CachedLuauResultRef.HasValue)
 			{

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -148,7 +148,10 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 
 	public void Run(Script script)
 	{
-		PT.Print("Running script: ", script.LuaPath);
+		if (script.LuaPath != "world.Temporary.Instance")
+		{
+			PT.Print("Running script: ", script.LuaPath);
+		}
 		LuaState state = InitalizeScript(script);
 
 		// Try compile

--- a/Polytoria/scripts/shared/asset_loaders/WebAssetLoader.cs
+++ b/Polytoria/scripts/shared/asset_loaders/WebAssetLoader.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Polytoria.Shared;
 
 namespace Polytoria.Shared.AssetLoaders;
 
@@ -53,7 +54,10 @@ public partial class WebAssetLoader : Node
 					}
 					catch (Exception exception)
 					{
-						PT.PrintErr("Failed to load resource (Type: " + item.Type + ", URL: " + item.URL + "): " + exception.Message);
+						if (!Globals.IsInGDEditor)
+						{
+							PT.PrintErr("Failed to load resource (Type: " + item.Type + ", URL: " + item.URL + "): " + exception.Message);
+						}
 					}
 				}
 			}));


### PR DESCRIPTION
## Summary

* A multi-line command line was added to the creator (some refactors/additions and scene changes were needed to allow for this).
  * Command line saves your last 30 commands in `Documents/Polytoria/Commands` in order so you can access them later (every time an older file is edited, order is recalculated so it stays as the most recent command without adding duplicates).
* TextEdit's context menu was expanded with more items to allow doing most most actions (eg. "find / replace") without shortcuts.
* The console's clear button felt hard to spot, so it was also moved to the left side.
* The ribbon's insert button was moved before the separator to leave space for me to display addons next to it on a follow up PR.
* Run action from FileItem's context menu was simplified and exposed to creators.
  * Warning was removed, and instead permissions are decided on the background by whether you are on godot or not.
* Silenced WebAssetLoader's `Failed to load resource` error spam while testing on godot as it always throws.
* Changed save directory project wide from `user://creator/` to `MyDocuments/Polytoria` to prevent data loss.
  * Recents file is saved on the new directory as a hidden file to avoid it being wiped with updates.
  * A shortcut to the project's `Root` is now generated in the new directory to allow creators to find non-persistent files, such as logs (this needs to be tested on windows, works fine on linux so far).
* Made default project name incremental to avoid overriding existing ones by mistake.
* Fixed warn definition expecting a single string instead of varargs, and made warns return their stack trace.
* Adds `TrackInstanceChanges` method to `CreatorHistory` for opt-in automatic instance addition/removal tracking for addons.
  * Also documented all methods to make them easier to understand, highlighting when Commit/New actions need to be called.
* Adds `SetClipboard`, `GetClipboard`, `RequestScriptFile` methods to `CreatorAddons`, to allow for more powerful use cases (still gated behind permissions).
  * Along these, made it so addons can request permissions again if they lack them at the time of them trying to perform an action they don't have permissions for (which avoid them silently failing if creators forget to manually use `RequestPermissions`, or if they simply don't need them at all times).
* Made modules not get cached on the creator, as said behaviour breaks addons/commands.

Known Issues:
* Autocompletion box gets clipped on the command line's textEdit until you add a couple lines, unsure how to prevent this.

## Related issue or discussion

Closes #401
Closes #516
Related to #196 (in that it will likely conflict, i'm willing to make changes if said PR gets merged)

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/baae1e7e-2747-40fe-bcfc-702c16d22205

https://github.com/user-attachments/assets/4c5ad53e-7f73-4cda-ad67-80d6e4387bd3

<img width="2070" height="1028" alt="Captura de pantalla de 2026-07-30 03-09-49" src="https://github.com/user-attachments/assets/1a03330c-2af1-4e42-8d35-bfb426540854" />


## AI/LLM use

Claude was used for drafting, code review/cleanup, and troubleshooting. All code was manually reviewed and tested.