### PR TITLE
Fix file select ignoring CurrentDir on Windows

### DIFF
--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -662,12 +662,12 @@ public partial class CreatorInterface : Control, IScriptObject
 
 		FileDialog dialog = new()
 		{
+			Access = FileDialog.AccessEnum.Filesystem,
 			Title = data.Title,
 			CurrentDir = currentDir,
 			CurrentFile = data.FileName,
 			ShowHiddenFiles = data.ShowHidden,
 			FileMode = MapFileMode(data.DialogMode),
-			Access = FileDialog.AccessEnum.Filesystem,
 			UseNativeDialog = true,
 		};
 


### PR DESCRIPTION
## Summary

Fixes an issue where AppData/Polytoria is picked as the default location in file pickers, causing people to save their worlds there and losing their world after Polytoria updates

## Related issue or discussion

Fixes #830 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None