### PR TITLE
Fix: Creator Play Test immediate crash on MacOS

### DIFF
--- a/Polytoria/scripts/creator/debugger/DebugServer.cs
+++ b/Polytoria/scripts/creator/debugger/DebugServer.cs
@@ -83,14 +83,24 @@ public class DebugServer
 		}
 		finally
 		{
-			client.Close();
-			PT.Print("Debug client disconnected");
+			// remove from lists first before disposing client
 			if (_clientToData.Remove(client, out var data))
 			{
-				// Cleanup local test process
-				CreatorService.Singleton.LocalTestProcesses.Remove(data.ProcessID);
+				// mutate list only on the main thread
+				PT.CallOnMainThread(() =>
+				{
+					// Cleanup local test process
+					CreatorService.Singleton.LocalTestProcesses.Remove(data.ProcessID);
+				});
+
 			}
+
 			_tcpClients.Remove(client);
+			client.Close();
+
+			PT.Print("Debug client disconnected");
+
+
 			foreach ((string id, TcpClient c) in _idToClient)
 			{
 				if (c == client)
@@ -114,7 +124,11 @@ public class DebugServer
 
 			if (data.ProcessID != 0)
 			{
-				CreatorService.Singleton.LocalTestProcesses.Add(data.ProcessID);
+				PT.CallOnMainThread(() =>
+				{
+					CreatorService.Singleton.LocalTestProcesses.Add(data.ProcessID);
+				});
+				
 			}
 		}
 		else if (msg is MessageLogDispatch log)
@@ -181,6 +195,7 @@ public class DebugServer
 		byte[] data = SerializeUtils.Serialize(msg);
 		foreach (TcpClient client in _tcpClients)
 		{
+
 			NetworkStream stream = client.GetStream();
 			await stream.WriteAsync(data);
 		}

--- a/Polytoria/scripts/creator/debugger/DebugServer.cs
+++ b/Polytoria/scripts/creator/debugger/DebugServer.cs
@@ -128,7 +128,7 @@ public class DebugServer
 				{
 					CreatorService.Singleton.LocalTestProcesses.Add(data.ProcessID);
 				});
-				
+
 			}
 		}
 		else if (msg is MessageLogDispatch log)

--- a/Polytoria/scripts/creator/ui/docks/toolbox/Toolbox.cs
+++ b/Polytoria/scripts/creator/ui/docks/toolbox/Toolbox.cs
@@ -31,6 +31,7 @@ public sealed partial class Toolbox : Control
 
 	public override void _Ready()
 	{
+		return; // so annoying oh my god
 		base._Ready();
 
 		_searchEdit.TextSubmitted += (_) => OnSearch();

--- a/Polytoria/scripts/creator/ui/docks/toolbox/Toolbox.cs
+++ b/Polytoria/scripts/creator/ui/docks/toolbox/Toolbox.cs
@@ -31,7 +31,6 @@ public sealed partial class Toolbox : Control
 
 	public override void _Ready()
 	{
-		return; // so annoying oh my god
 		base._Ready();
 
 		_searchEdit.TextSubmitted += (_) => OnSearch();

--- a/Polytoria/scripts/datamodel/creator/CreatorService.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorService.cs
@@ -136,6 +136,7 @@ public sealed partial class CreatorService : Node, IScriptObject
 				{
 					LocalTestProcesses.Remove(procID);
 				}
+
 			}
 
 			if (LocalTestProcesses.Count == 0)
@@ -144,6 +145,7 @@ public sealed partial class CreatorService : Node, IScriptObject
 				LocalTestStopped.Invoke();
 			}
 		}
+
 		base._Process(delta);
 	}
 
@@ -605,6 +607,12 @@ public sealed partial class CreatorService : Node, IScriptObject
 		LocalTestWorlds.Add(placeFilePath);
 
 		int procID = OS.CreateProcess(exePath, [.. args]);
+		if (procID == -1)
+		{
+			PT.Print("Starting local test server failed.");
+			return;
+		}
+
 		PT.Print("Starting server with args: ", string.Join(" ", args));
 
 		LocalTestProcesses.Add(procID);
@@ -617,7 +625,12 @@ public sealed partial class CreatorService : Node, IScriptObject
 		{
 			OS.Kill(item);
 		}
+		
 		DebugServer.SendTerminateProgram();
+		LocalTestProcesses.Clear();
+
+		CleanupLocalTest();
+		LocalTestStopped.Invoke();
 	}
 
 	public static void MigrateCoordinates(World root)

--- a/Polytoria/scripts/datamodel/creator/CreatorService.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorService.cs
@@ -625,7 +625,7 @@ public sealed partial class CreatorService : Node, IScriptObject
 		{
 			OS.Kill(item);
 		}
-		
+
 		DebugServer.SendTerminateProgram();
 		LocalTestProcesses.Clear();
 


### PR DESCRIPTION
## Summary

`DebugServer` was mutating a list from another thread and a guard check added in `CreatorService.StartLocalTestServer` and `CreatorService.StopLocalTest` will do playtest cleanup itself instead of relying on `_Process`'s if LocalTestProcesses count check. This was done as sometimes Godot would just throw an error when checking for `OS.IsProcessRunning` which would cause the state to be stuck.

This was only tested on MacOS, unsure how windows and linux would react to this so that needs to be tested real quick.

## Related issue or discussion

Fixes #367 
Or should atleast. After this change I was unable to recreate that bug.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
None

## AI/LLM use
None