### PR TITLE
Datamodel: Added a toggle for explosion effects

### DIFF
--- a/Polytoria/scripts/datamodel/Explosion.cs
+++ b/Polytoria/scripts/datamodel/Explosion.cs
@@ -21,6 +21,7 @@ public partial class Explosion : Dynamic
 	private bool _affectAnchored = false;
 	private float _damage = 100000;
 	private bool _affectWelds;
+	private bool _useEffects = true;
 
 	[Editable, ScriptProperty]
 	public float Radius
@@ -77,6 +78,17 @@ public partial class Explosion : Dynamic
 		}
 	}
 
+	[Editable, ScriptProperty]
+	public bool UseEffects
+	{
+		get => _useEffects;
+		set
+		{
+			_useEffects = value;
+			OnPropertyChanged();
+		}
+	}
+
 	[ScriptProperty] public PTFunction? AffectPredicate { get; set; }
 
 	[ScriptProperty] public PTSignal<Instance> Touched { get; private set; } = new();
@@ -108,22 +120,25 @@ public partial class Explosion : Dynamic
 	private async void TryIgnite()
 	{
 		if (!IsNetworkReady || IsHidden) return;
-		_particle.Scale = Vector3.One * _radius / 15;
-		_particle.Visible = true;
-		_particle.Emitting = true;
-
-		BuiltInAudioAsset audio = New<BuiltInAudioAsset>();
-		audio.AudioPreset = BuiltInAudioAsset.BuiltInAudioPresetEnum.Explosion;
 
 		Sound? s = null;
-
-		if (!Root.Network.IsServer)
+		if (_useEffects)
 		{
-			s = New<Sound>();
-			s.Audio = audio;
-			s.PlayInWorld = true;
-			s.Parent = this;
-			s.LocalPosition = Vector3.Zero;
+			_particle.Scale = Vector3.One * _radius / 15;
+			_particle.Visible = true;
+			_particle.Emitting = true;
+
+			if (!Root.Network.IsServer)
+			{
+				BuiltInAudioAsset audio = New<BuiltInAudioAsset>();
+				audio.AudioPreset = BuiltInAudioAsset.BuiltInAudioPresetEnum.Explosion;
+
+				s = New<Sound>();
+				s.Audio = audio;
+				s.PlayInWorld = true;
+				s.Parent = this;
+				s.LocalPosition = Vector3.Zero;
+			}
 		}
 
 		Instance[] overlaps = Root.Environment.OverlapSphere(Position, Radius);


### PR DESCRIPTION
## Summary

This pull request introduces a new property to explosions: `UseEffects`. This allows the user to toggle the explosion's effects on or off, giving the user the power to write his/her own explosion effects in their place.

## Related issue or discussion

Fixes #990, #1044

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/a3424610-3241-42d5-9793-a57d6fc8b171

_Me messing around with this feature..._

Here's the project I used to test the feature:
[BigExplosions.zip](https://github.com/user-attachments/files/30602028/BigExplosions.zip)

## AI/LLM use

No AI/LLMs were used in the making of this pull request.