### PR TITLE
(conditionally) Use `UnitQuaternionUInt64Dto` in `TransformPayloadDto`

### DIFF
--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -90,7 +90,7 @@ public partial class NetworkTransformSync : Instance
 				data.Add(new()
 				{
 					NetID = dyn.NetworkedObjectID,
-					Value = TransformPayloadDto.ToArray(dyn.GetLocalTransform())
+					Value = TransformPayloadDto.ToArrayUInt64(dyn.GetLocalTransform())
 				});
 			}
 		}
@@ -106,7 +106,7 @@ public partial class NetworkTransformSync : Instance
 		{
 			// There might be newer pending transforms
 			if (_pendingTransforms.ContainsKey(item.NetID)) { continue; }
-			RecvUpdateTransformHandler(item.NetID, TransformPayloadDto.FromArray(item.Value), 1, true, false);
+			RecvUpdateTransformHandler(item.NetID, new(item.Value), 1, true, false);
 		}
 
 		if (isFirstInit)
@@ -127,7 +127,8 @@ public partial class NetworkTransformSync : Instance
 		// Check if self has the network authority
 		if (!CheckDynAuthor(dyn, NetService.LocalPeerID)) return;
 
-		TransformPayloadDto payload = TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform());
+		Transform3D transform = dyn.GetLocalTransform();
+		TransformPayloadDto payload = isReliable ? TransformPayloadDto.FromTransformUInt64(transform) : TransformPayloadDto.FromTransform(transform);
 		string objID = dyn.NetworkedObjectID;
 
 		if (sendTo != 0)
@@ -209,7 +210,7 @@ public partial class NetworkTransformSync : Instance
 		// Check authority
 		if (!CheckDynAuthor(dyn, NetService.LocalPeerID)) return;
 
-		TransformPayloadDto payload = TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform());
+		TransformPayloadDto payload = TransformPayloadDto.FromTransform(dyn.GetLocalTransform());
 		string objID = dyn.NetworkedObjectID;
 
 		RpcId(1, nameof(NetRecvTransformOnServer), objID, payload, lerpTransform);
@@ -221,7 +222,8 @@ public partial class NetworkTransformSync : Instance
 		if (!dyn.IsNetworkReady) return;
 		string objID = dyn.NetworkedObjectID;
 
-		SetPendingBatch(objID, new(dyn, TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform()), lerpTransform, excludePeer)
+		Transform3D transform = dyn.GetLocalTransform();
+		SetPendingBatch(objID, new(dyn, reliable ? TransformPayloadDto.FromTransformUInt64(transform) : TransformPayloadDto.FromTransform(transform), lerpTransform, excludePeer)
 		{
 			Reliable = reliable,
 			Forced = true
@@ -253,7 +255,7 @@ public partial class NetworkTransformSync : Instance
 			TransformPayloadDto processed = dyn.TransformNetworkPass(fromPeer, transform);
 
 			// If is equal approx to last, return
-			if (processed.IsEqualApprox(TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform())))
+			if (processed.IsEqualApprox(dyn.GetLocalTransform()))
 				return;
 
 			// Update on server
@@ -373,7 +375,7 @@ public partial class NetworkTransformSync : Instance
 		{
 			if (NetService.Root.GetNetObjectFromID(data.ObjID) is Dynamic dyn)
 			{
-				dyn.UpdateTransformFromNet(TransformPayloadDto.FromArray(data.Transform), isReliable, data.Lerp);
+				dyn.UpdateTransformFromNet(new(data.Transform), isReliable, data.Lerp);
 			}
 		}
 	}
@@ -401,7 +403,7 @@ public partial class NetworkTransformSync : Instance
 
 	private struct PendingTransform()
 	{
-		public TransformPayloadDto Transform;
+		public required TransformPayloadDto Transform;
 		public int FromPeer;
 		public int ToPeer = -1;
 	}
@@ -419,7 +421,7 @@ public partial class NetworkTransformSync : Instance
 		public BatchTransformData(string objID, TransformPayloadDto transform, bool lerp)
 		{
 			ObjID = objID;
-			Transform = TransformPayloadDto.ToArray(transform);
+			Transform = transform.Data;
 			Lerp = lerp;
 		}
 	}

--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -128,7 +128,7 @@ public partial class NetworkTransformSync : Instance
 		if (!CheckDynAuthor(dyn, NetService.LocalPeerID)) return;
 
 		Transform3D transform = dyn.GetLocalTransform();
-		TransformPayloadDto payload = isReliable ? TransformPayloadDto.FromTransformUInt64(transform) : TransformPayloadDto.FromTransform(transform);
+		TransformPayloadDto payload = isReliable ? TransformPayloadDto.FromGDTransformUInt64(transform) : TransformPayloadDto.FromGDTransform(transform);
 		string objID = dyn.NetworkedObjectID;
 
 		if (sendTo != 0)
@@ -210,7 +210,7 @@ public partial class NetworkTransformSync : Instance
 		// Check authority
 		if (!CheckDynAuthor(dyn, NetService.LocalPeerID)) return;
 
-		TransformPayloadDto payload = TransformPayloadDto.FromTransform(dyn.GetLocalTransform());
+		TransformPayloadDto payload = TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform());
 		string objID = dyn.NetworkedObjectID;
 
 		RpcId(1, nameof(NetRecvTransformOnServer), objID, payload, lerpTransform);
@@ -223,7 +223,7 @@ public partial class NetworkTransformSync : Instance
 		string objID = dyn.NetworkedObjectID;
 
 		Transform3D transform = dyn.GetLocalTransform();
-		SetPendingBatch(objID, new(dyn, reliable ? TransformPayloadDto.FromTransformUInt64(transform) : TransformPayloadDto.FromTransform(transform), lerpTransform, excludePeer)
+		SetPendingBatch(objID, new(dyn, reliable ? TransformPayloadDto.FromGDTransformUInt64(transform) : TransformPayloadDto.FromGDTransform(transform), lerpTransform, excludePeer)
 		{
 			Reliable = reliable,
 			Forced = true

--- a/Polytoria/scripts/utils/dto/TransformPayload.cs
+++ b/Polytoria/scripts/utils/dto/TransformPayload.cs
@@ -13,9 +13,33 @@ namespace Polytoria.Utils.DTOs;
 [MemoryPackable]
 public partial class TransformPayloadDto
 {
-	private readonly bool _uInt64 = false;
+	private const int UInt32Length = sizeof(float) * 3 + sizeof(uint);
+	private const int UInt64Length = sizeof(float) * 3 + sizeof(ulong);
 
-	public byte[] Data { get; set; } = null!;
+	private bool _uInt64 = false;
+	private byte[] _data = new byte[UInt32Length];
+
+	public byte[] Data
+	{
+		get => _data;
+		set
+		{
+			if (_data == value) return;
+
+			switch (value.Length)
+			{
+				case UInt32Length: // UnitQuaternionDto
+					_uInt64 = false;
+					break;
+				case UInt64Length: // UnitQuaternionUInt64Dto
+					_uInt64 = true;
+					break;
+				default:
+					return;
+			}
+			_data = value;
+		}
+	}
 
 	[MemoryPackIgnore, JsonIgnore]
 	public Vector3 Position => new(
@@ -31,22 +55,7 @@ public partial class TransformPayloadDto
 
 	[MemoryPackConstructor, JsonConstructor]
 	public TransformPayloadDto() { }
-	public TransformPayloadDto(byte[] bytes)
-	{
-		switch (bytes.Length)
-		{
-			case 16: // 3 floats + 1 uint (use UnitQuaternionDto)
-				_uInt64 = false;
-				break;
-			case 20: // 3 floats + 1 ulong (use UnitQuaternionUInt64Dto)
-				_uInt64 = true;
-				break;
-			default: // invalid
-				Data = new byte[16];
-				return;
-		}
-		Data = bytes;
-	}
+	public TransformPayloadDto(byte[] bytes) { Data = bytes; }
 
 	public bool IsEqualApprox(Vector3 pos, Quaternion rot) => Position.IsEqualApprox(pos) && Rotation.IsEqualApprox(rot);
 	public bool IsEqualApprox(Transform3D t) => Position.IsEqualApprox(t.Origin) && Rotation.IsEqualApprox(t.Basis.GetRotationQuaternion());
@@ -54,7 +63,7 @@ public partial class TransformPayloadDto
 
 	public static byte[] ToArray(Vector3 Position, uint Rotation)
 	{
-		byte[] data = new byte[16];
+		byte[] data = new byte[UInt32Length];
 		BinaryPrimitives.WriteSingleLittleEndian(data.AsSpan(0, 4), Position.X);
 		BinaryPrimitives.WriteSingleLittleEndian(data.AsSpan(4, 4), Position.Y);
 		BinaryPrimitives.WriteSingleLittleEndian(data.AsSpan(8, 4), Position.Z);
@@ -67,7 +76,7 @@ public partial class TransformPayloadDto
 
 	public static byte[] ToArrayUInt64(Vector3 Position, ulong Rotation)
 	{
-		byte[] data = new byte[20];
+		byte[] data = new byte[UInt64Length];
 		BinaryPrimitives.WriteSingleLittleEndian(data.AsSpan(0, 4), Position.X);
 		BinaryPrimitives.WriteSingleLittleEndian(data.AsSpan(4, 4), Position.Y);
 		BinaryPrimitives.WriteSingleLittleEndian(data.AsSpan(8, 4), Position.Z);

--- a/Polytoria/scripts/utils/dto/TransformPayload.cs
+++ b/Polytoria/scripts/utils/dto/TransformPayload.cs
@@ -14,9 +14,13 @@ public partial class TransformPayloadDto
 {
 	public byte[] Data { get; set; } = null!;
 
+	[MemoryPackIgnore, JsonIgnore]
+	public bool UInt64 = false;
+
+	[MemoryPackIgnore, JsonIgnore]
 	public Vector3 Position
 	{
-		get => new Vector3(
+		get => new(
 			BitConverter.ToSingle(Data, 0),
 			BitConverter.ToSingle(Data, 4),
 			BitConverter.ToSingle(Data, 8)
@@ -32,70 +36,54 @@ public partial class TransformPayloadDto
 		}
 	}
 
-	public uint RawRotation
-	{
-		get => BitConverter.ToUInt32(Data, 12);
-		set
-		{
-			byte[] rot = BitConverter.GetBytes(value);
-			Array.Copy(rot, 0, Data, 12, 4);
-		}
-	}
-
+	[MemoryPackIgnore, JsonIgnore]
 	public Quaternion Rotation
 	{
-		get => UnitQuaternionDto.FromCompressed(RawRotation);
-		set
+		get
 		{
-			RawRotation = UnitQuaternionDto.ToCompressed(value);
+			if (UInt64)
+			{
+				return UnitQuaternionUInt64Dto.FromCompressed(BitConverter.ToUInt64(Data, 12));
+			}
+			return UnitQuaternionDto.FromCompressed(BitConverter.ToUInt32(Data, 12));
 		}
-	}
-
-	// UnitQuaternionDto is suitable for most network replication, however may be problematic at larger scales.
-	// UnitQuaternionDto has a ~0.137 degree step and uses 4 bytes,
-	// UnitQuaternionUInt64Dto has a ~0.003 497 degree step and uses 8 bytes.
-	// This is the the unimplemented TransformPayload logic for higher precision network replication of rotations.
-	[MemoryPackIgnore]
-	[JsonIgnore]
-	public ulong RawRotationUInt64
-	{
-		get => BitConverter.ToUInt64(Data, 12);
 		set
 		{
-			byte[] rot = BitConverter.GetBytes(value);
-			Array.Copy(rot, 0, Data, 12, 8);
-		}
-	}
-
-	[MemoryPackIgnore]
-	[JsonIgnore]
-	public Quaternion RotationUInt64
-	{
-		get => UnitQuaternionUInt64Dto.FromCompressed(RawRotationUInt64);
-		set
-		{
-			RawRotationUInt64 = UnitQuaternionUInt64Dto.ToCompressed(value);
+			if (UInt64)
+			{
+				Array.Copy(BitConverter.GetBytes(UnitQuaternionUInt64Dto.ToCompressed(value)), 0, Data, 12, 8);
+			}
+			else
+			{
+				Array.Copy(BitConverter.GetBytes(UnitQuaternionDto.ToCompressed(value)), 0, Data, 12, 4);
+			}
 		}
 	}
 
 	[MemoryPackConstructor, JsonConstructor]
 	public TransformPayloadDto() { }
-	public TransformPayloadDto(byte[] bytes)
+	public TransformPayloadDto(byte[] bytes, bool uint64)
 	{
 		Data = bytes;
+		UInt64 = uint64;
 	}
-	public TransformPayloadDto(Vector3 position, Quaternion rotation)
-	{
-		Data = ToArray(position, rotation);
-	}
+	public TransformPayloadDto(byte[] bytes) : this(bytes, bytes.Length == 20) { }
 
-	public bool IsEqualApprox(TransformPayloadDto other) => Position.IsEqualApprox(other.Position) && Rotation.IsEqualApprox(other.Rotation);
+	public bool IsEqualApprox(Vector3 pos, Quaternion rot) => Position.IsEqualApprox(pos) && Rotation.IsEqualApprox(rot);
+	public bool IsEqualApprox(Transform3D t) => Position.IsEqualApprox(t.Origin) && Rotation.IsEqualApprox(t.Basis.GetRotationQuaternion());
+	public bool IsEqualApprox(TransformPayloadDto other) => IsEqualApprox(other.Position, other.Rotation);
 
 	// String helpers because memory pack don't like nested objects
 	public static TransformPayloadDto FromString(string str)
 	{
 		var parts = str.Split('|');
-		return new TransformPayloadDto(Vector3Dto.FromString(parts[0]), UnitQuaternionDto.FromString(parts[1]));
+		return new(ToArray(Vector3Dto.FromString(parts[0]), UnitQuaternionDto.FromString(parts[1])), false);
+	}
+
+	public static TransformPayloadDto FromStringUInt64(string str)
+	{
+		var parts = str.Split('|');
+		return new(ToArrayUInt64(Vector3Dto.FromString(parts[0]), UnitQuaternionUInt64Dto.FromString(parts[1])), true);
 	}
 
 	public static string ToString(Vector3 Position, Quaternion Rotation)
@@ -111,8 +99,15 @@ public partial class TransformPayloadDto
 	];
 	public static byte[] ToArray(Vector3 Position, Quaternion Rotation) => ToArray(Position, UnitQuaternionDto.ToCompressed(Rotation));
 	public static byte[] ToArray(Transform3D t) => ToArray(t.Origin, t.Basis.GetRotationQuaternion());
-	public static byte[] ToArray(TransformPayloadDto t) => ToArray(t.Position, t.RawRotation);
+	public static TransformPayloadDto FromTransform(Transform3D t) => new(ToArray(t), false);
 
-	public static TransformPayloadDto FromArray(byte[] f) => new(f);
-	public static TransformPayloadDto FromGDTransform(Transform3D t) => new(t.Origin, t.Basis.GetRotationQuaternion());
+	public static byte[] ToArrayUInt64(Vector3 Position, ulong Rotation) => [
+		..BitConverter.GetBytes(Position.X),
+		..BitConverter.GetBytes(Position.Y),
+		..BitConverter.GetBytes(Position.Z),
+		..BitConverter.GetBytes(Rotation)
+	];
+	public static byte[] ToArrayUInt64(Vector3 Position, Quaternion Rotation) => ToArrayUInt64(Position, UnitQuaternionUInt64Dto.ToCompressed(Rotation));
+	public static byte[] ToArrayUInt64(Transform3D t) => ToArrayUInt64(t.Origin, t.Basis.GetRotationQuaternion());
+	public static TransformPayloadDto FromTransformUInt64(Transform3D t) => new(ToArrayUInt64(t), true);
 }

--- a/Polytoria/scripts/utils/dto/TransformPayload.cs
+++ b/Polytoria/scripts/utils/dto/TransformPayload.cs
@@ -12,84 +12,39 @@ namespace Polytoria.Utils.DTOs;
 [MemoryPackable]
 public partial class TransformPayloadDto
 {
+	private readonly bool UInt64 = false;
+
 	public byte[] Data { get; set; } = null!;
 
 	[MemoryPackIgnore, JsonIgnore]
-	public bool UInt64 = false;
+	public Vector3 Position => new(
+		BitConverter.ToSingle(Data, 0),
+		BitConverter.ToSingle(Data, 4),
+		BitConverter.ToSingle(Data, 8)
+	);
 
 	[MemoryPackIgnore, JsonIgnore]
-	public Vector3 Position
-	{
-		get => new(
-			BitConverter.ToSingle(Data, 0),
-			BitConverter.ToSingle(Data, 4),
-			BitConverter.ToSingle(Data, 8)
-		);
-		set
-		{
-			byte[] newData = [
-				..BitConverter.GetBytes(value.X),
-				..BitConverter.GetBytes(value.Y),
-				..BitConverter.GetBytes(value.Z)
-			];
-			Array.Copy(newData, Data, 12);
-		}
-	}
-
-	[MemoryPackIgnore, JsonIgnore]
-	public Quaternion Rotation
-	{
-		get
-		{
-			if (UInt64)
-			{
-				return UnitQuaternionUInt64Dto.FromCompressed(BitConverter.ToUInt64(Data, 12));
-			}
-			return UnitQuaternionDto.FromCompressed(BitConverter.ToUInt32(Data, 12));
-		}
-		set
-		{
-			if (UInt64)
-			{
-				Array.Copy(BitConverter.GetBytes(UnitQuaternionUInt64Dto.ToCompressed(value)), 0, Data, 12, 8);
-			}
-			else
-			{
-				Array.Copy(BitConverter.GetBytes(UnitQuaternionDto.ToCompressed(value)), 0, Data, 12, 4);
-			}
-		}
-	}
+	public Quaternion Rotation => UInt64 ? UnitQuaternionUInt64Dto.FromCompressed(BitConverter.ToUInt64(Data, 12)) : UnitQuaternionDto.FromCompressed(BitConverter.ToUInt32(Data, 12));
 
 	[MemoryPackConstructor, JsonConstructor]
 	public TransformPayloadDto() { }
-	public TransformPayloadDto(byte[] bytes, bool uint64)
+	public TransformPayloadDto(byte[] bytes)
 	{
+		UInt64 = bytes.Length switch
+		{
+			// 3 floats + 1 uint (use UnitQuaternionDto)
+			16 => false,
+			// 3 floats + 1 ulong (use UnitQuaternionUInt64Dto)
+			20 => true,
+			// invalid
+			_ => throw new ArgumentOutOfRangeException(nameof(bytes)),
+		};
 		Data = bytes;
-		UInt64 = uint64;
 	}
-	public TransformPayloadDto(byte[] bytes) : this(bytes, bytes.Length == 20) { }
 
 	public bool IsEqualApprox(Vector3 pos, Quaternion rot) => Position.IsEqualApprox(pos) && Rotation.IsEqualApprox(rot);
 	public bool IsEqualApprox(Transform3D t) => Position.IsEqualApprox(t.Origin) && Rotation.IsEqualApprox(t.Basis.GetRotationQuaternion());
 	public bool IsEqualApprox(TransformPayloadDto other) => IsEqualApprox(other.Position, other.Rotation);
-
-	// String helpers because memory pack don't like nested objects
-	public static TransformPayloadDto FromString(string str)
-	{
-		var parts = str.Split('|');
-		return new(ToArray(Vector3Dto.FromString(parts[0]), UnitQuaternionDto.FromString(parts[1])), false);
-	}
-
-	public static TransformPayloadDto FromStringUInt64(string str)
-	{
-		var parts = str.Split('|');
-		return new(ToArrayUInt64(Vector3Dto.FromString(parts[0]), UnitQuaternionUInt64Dto.FromString(parts[1])), true);
-	}
-
-	public static string ToString(Vector3 Position, Quaternion Rotation)
-	{
-		return $"{Vector3Dto.ToString(Position)}|{UnitQuaternionDto.ToString(Rotation)}";
-	}
 
 	public static byte[] ToArray(Vector3 Position, uint Rotation) => [
 		..BitConverter.GetBytes(Position.X),
@@ -99,7 +54,7 @@ public partial class TransformPayloadDto
 	];
 	public static byte[] ToArray(Vector3 Position, Quaternion Rotation) => ToArray(Position, UnitQuaternionDto.ToCompressed(Rotation));
 	public static byte[] ToArray(Transform3D t) => ToArray(t.Origin, t.Basis.GetRotationQuaternion());
-	public static TransformPayloadDto FromTransform(Transform3D t) => new(ToArray(t), false);
+	public static TransformPayloadDto FromGDTransform(Transform3D t) => new(ToArray(t));
 
 	public static byte[] ToArrayUInt64(Vector3 Position, ulong Rotation) => [
 		..BitConverter.GetBytes(Position.X),
@@ -109,5 +64,5 @@ public partial class TransformPayloadDto
 	];
 	public static byte[] ToArrayUInt64(Vector3 Position, Quaternion Rotation) => ToArrayUInt64(Position, UnitQuaternionUInt64Dto.ToCompressed(Rotation));
 	public static byte[] ToArrayUInt64(Transform3D t) => ToArrayUInt64(t.Origin, t.Basis.GetRotationQuaternion());
-	public static TransformPayloadDto FromTransformUInt64(Transform3D t) => new(ToArrayUInt64(t), true);
+	public static TransformPayloadDto FromGDTransformUInt64(Transform3D t) => new(ToArrayUInt64(t));
 }


### PR DESCRIPTION
## Summary

`TransformPayloadDto` chooses between using `UnitQuaternionUInt64Dto` and `UnitQuaternionDto` depending on the length of its `Data`. `NetworkTransformSync` uses `UnitQuaternionUInt64Dto` for reliable RPCs (e.g. property changes and initial world replication) and `UnitQuaternionDto` for unreliable RPCs (e.g. `Physical` replication)

some improvements could be made to the quaternion `Dto` selection here to reduce bandwidth (e.g. a [LOD system](https://github.com/Polytoria/polytoria-game/pull/1049#issuecomment-5142388898)), but this solution seems to be Good Enough for now

## Related issue or discussion

Fixes #618

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [X] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img src=https://github.com/user-attachments/assets/dbc506d5-432e-408d-bf96-1f9b38a3a405>

###### left is `UnitQuaternionUInt64Dto`, right is `UnitQuaternionDto`

## AI/LLM use

None