### PR TITLE
Implement Player.Grabbing plus signals

### DIFF
--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -98,7 +98,7 @@ public partial class Grabbable : Instance
 
 	public override void ExitTree()
 	{
-		_dragger?.SetGrabbing(null);
+		_dragger?.ReleaseGrabbing();
 		_parent?.Clicked.Disconnect(OnClicked);
 		_parent?.MouseEnter.Disconnect(OnMouseEnter);
 		_parent?.MouseExit.Disconnect(OnMouseExit);
@@ -246,7 +246,7 @@ public partial class Grabbable : Instance
 	private void InternalReleaseDrag()
 	{
 		_dragging = false;
-		_dragger?.SetGrabbing(null);
+		_dragger?.ReleaseGrabbing();
 		_dragger = null;
 		Released.Invoke();
 	}

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -98,7 +98,7 @@ public partial class Grabbable : Instance
 
 	public override void ExitTree()
 	{
-		_dragger?.SetGrabbed(null);
+		_dragger?.SetGrabbing(null);
 		_parent?.Clicked.Disconnect(OnClicked);
 		_parent?.MouseEnter.Disconnect(OnMouseEnter);
 		_parent?.MouseExit.Disconnect(OnMouseExit);
@@ -193,7 +193,7 @@ public partial class Grabbable : Instance
 	{
 		if (_parent == null) return;
 		_dragger = plr;
-		_dragger.SetGrabbed(_parent);
+		_dragger.SetGrabbing(_parent);
 		_parent.SetNetworkAuthority(plr);
 		Grabbed.Invoke(plr);
 		RpcId(plr.PeerID, nameof(NetGrabDrag));
@@ -215,7 +215,7 @@ public partial class Grabbable : Instance
 	internal void InternalGiveGrab()
 	{
 		_dragger = Root.Players.LocalPlayer;
-		_dragger.SetGrabbed(_parent);
+		_dragger.SetGrabbing(_parent);
 		_dragging = true;
 		Grabbed.Invoke(_dragger);
 		Root.PlayerGUI.SetCursorShape(Control.CursorShape.CanDrop);
@@ -246,7 +246,7 @@ public partial class Grabbable : Instance
 	private void InternalReleaseDrag()
 	{
 		_dragging = false;
-		_dragger?.SetGrabbed(null);
+		_dragger?.SetGrabbing(null);
 		_dragger = null;
 		Released.Invoke();
 	}

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -98,6 +98,7 @@ public partial class Grabbable : Instance
 
 	public override void ExitTree()
 	{
+		_dragger?.SetGrabbed(null);
 		_parent?.Clicked.Disconnect(OnClicked);
 		_parent?.MouseEnter.Disconnect(OnMouseEnter);
 		_parent?.MouseExit.Disconnect(OnMouseExit);
@@ -192,6 +193,7 @@ public partial class Grabbable : Instance
 	{
 		if (_parent == null) return;
 		_dragger = plr;
+		_dragger.SetGrabbed(_parent);
 		_parent.SetNetworkAuthority(plr);
 		Grabbed.Invoke(plr);
 		RpcId(plr.PeerID, nameof(NetGrabDrag));
@@ -213,6 +215,7 @@ public partial class Grabbable : Instance
 	internal void InternalGiveGrab()
 	{
 		_dragger = Root.Players.LocalPlayer;
+		_dragger.SetGrabbed(_parent);
 		_dragging = true;
 		Grabbed.Invoke(_dragger);
 		Root.PlayerGUI.SetCursorShape(Control.CursorShape.CanDrop);
@@ -243,6 +246,7 @@ public partial class Grabbable : Instance
 	private void InternalReleaseDrag()
 	{
 		_dragging = false;
+		_dragger?.SetGrabbed(null);
 		_dragger = null;
 		Released.Invoke();
 	}

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -215,7 +215,10 @@ public partial class Grabbable : Instance
 	internal void InternalGiveGrab()
 	{
 		_dragger = Root.Players.LocalPlayer;
-		_dragger.SetGrabbing(_parent);
+		if (_parent != null)
+		{
+			_dragger.SetGrabbing(_parent);
+		}
 		_dragging = true;
 		Grabbed.Invoke(_dragger);
 		Root.PlayerGUI.SetCursorShape(Control.CursorShape.CanDrop);

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -70,7 +70,7 @@ public sealed partial class Player : NPC
 	private RemoteTransform3D _remoteCamAttach = null!;
 	internal Dynamic CamAttach = null!;
 	private Physical? _mouseHoveringOn;
-	private Physical? _grabbed;
+	private Physical? _grabbing;
 
 	private Vector3 DefaultSpawnLocation = new(0, 5, 0);
 	internal event Action<APIUserInfo>? UserInfoReady;
@@ -315,11 +315,11 @@ public sealed partial class Player : NPC
 	}
 
 	[ScriptProperty]
-	public Physical? Grabbed => _grabbed;
+	public Physical? Grabbing => _grabbing;
 
-	public void SetGrabbed(Physical? phy)
+	public void SetGrabbing(Physical? phy)
 	{
-		_grabbed = phy;
+		_grabbing = phy;
 	}
 
 	[ScriptProperty]

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -103,6 +103,12 @@ public sealed partial class Player : NPC
 	[ScriptProperty]
 	public PTSignal Respawned { get; private set; } = new();
 
+	[ScriptProperty]
+	public PTSignal<Physical> GrabbedGrabbable { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal<Physical> ReleasedGrabbable { get; private set; } = new();
+
 	[SyncVar, ScriptProperty]
 	public int UserID
 	{
@@ -317,9 +323,16 @@ public sealed partial class Player : NPC
 	[ScriptProperty]
 	public Physical? Grabbing => _grabbing;
 
-	public void SetGrabbing(Physical? phy)
+	public void SetGrabbing(Physical phy)
 	{
 		_grabbing = phy;
+		GrabbedGrabbable.Invoke(phy);
+	}
+
+	public void ReleaseGrabbing()
+	{
+		ReleasedGrabbable.Invoke(_grabbing);
+		_grabbing = null;
 	}
 
 	[ScriptProperty]

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -104,10 +104,10 @@ public sealed partial class Player : NPC
 	public PTSignal Respawned { get; private set; } = new();
 
 	[ScriptProperty]
-	public PTSignal<Physical> GrabbedGrabbable { get; private set; } = new();
+	public PTSignal<Physical> Grabbed { get; private set; } = new();
 
 	[ScriptProperty]
-	public PTSignal<Physical> ReleasedGrabbable { get; private set; } = new();
+	public PTSignal<Physical> Ungrabbed { get; private set; } = new();
 
 	[SyncVar, ScriptProperty]
 	public int UserID
@@ -326,12 +326,12 @@ public sealed partial class Player : NPC
 	public void SetGrabbing(Physical phy)
 	{
 		_grabbing = phy;
-		GrabbedGrabbable.Invoke(phy);
+		Grabbed.Invoke(phy);
 	}
 
 	public void ReleaseGrabbing()
 	{
-		ReleasedGrabbable.Invoke(_grabbing);
+		Ungrabbed.Invoke(_grabbing);
 		_grabbing = null;
 	}
 

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -70,6 +70,7 @@ public sealed partial class Player : NPC
 	private RemoteTransform3D _remoteCamAttach = null!;
 	internal Dynamic CamAttach = null!;
 	private Physical? _mouseHoveringOn;
+	private Physical? _grabbed;
 
 	private Vector3 DefaultSpawnLocation = new(0, 5, 0);
 	internal event Action<APIUserInfo>? UserInfoReady;
@@ -311,6 +312,14 @@ public sealed partial class Player : NPC
 			_rotationMode = value;
 			OnPropertyChanged();
 		}
+	}
+
+	[ScriptProperty]
+	public Physical? Grabbed => _grabbed;
+
+	public void SetGrabbed(Physical? phy)
+	{
+		_grabbed = phy;
 	}
 
 	[ScriptProperty]


### PR DESCRIPTION
## Summary

Adds a simple property plus events to get what object the player is grabbing around.

## Related issue or discussion

Closes #1055

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/8f5d989c-2967-4183-ad37-b32cd9a56801

## AI/LLM use

None