### PR TITLE
Add New method to create UIScale

### DIFF
--- a/Polytoria/scripts/datamodel/data/UIScale.cs
+++ b/Polytoria/scripts/datamodel/data/UIScale.cs
@@ -27,6 +27,12 @@ public struct UIScale : IScriptObject, IData
 	}
 
 	[ScriptMethod]
+	public static UIScale New(float offset, float scale)
+	{
+		return new() { Offset = offset, Scale = scale };
+	}
+
+	[ScriptMethod]
 	public readonly float Compute(float parentSize)
 	{
 		return Mathf.Max(0, Offset + Scale * parentSize);


### PR DESCRIPTION
## Summary

Adds a `New` constructor function for `UIScale` in the scripting API.

`UIScale.New(10, 0.25)` creates and returns a `UIScale` instance with:
- Offset: 10
- Scale: 0.25

## Related issue or discussion

Fixes #630 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

Github Copilot to make sure the syntax was correct.