### PR TITLE
Adds singleton property to modulescripts

### DIFF
--- a/Polytoria/scripts/datamodel/ModuleScript.cs
+++ b/Polytoria/scripts/datamodel/ModuleScript.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 using Polytoria.Attributes;
+using Polytoria.Scripting.Luau;
 
 namespace Polytoria.Datamodel;
 
@@ -11,10 +12,31 @@ public sealed partial class ModuleScript : Script
 {
 	internal int? CachedLuauResultRef { get; set; } = null;
 
+	private bool _singleton = false;
+	private bool _singletonRequired = false;
+
+	[Editable, ScriptProperty]
+	public bool Singleton
+	{
+		get => _singleton;
+		set
+		{
+			_singleton = value;
+			OnPropertyChanged();
+			TryRunSingleton();
+		}
+	}
+
 	public override void EnterTree()
 	{
 		CheckSource();
 		base.EnterTree();
+	}
+
+	public override void Ready()
+	{
+		TryRunSingleton();
+		base.Ready();
 	}
 
 	internal void CheckSource()
@@ -28,6 +50,28 @@ public sealed partial class ModuleScript : Script
 		}
 	}
 
+	internal void NotifyBytecodeReceived()
+	{
+		TryRunSingleton();
+	}
+
+	private void TryRunSingleton()
+	{
+		if (!_singleton || _singletonRequired) return;
+		if (Root == null || IsDeleted) return;
+		if (Root.SessionType == World.SessionTypeEnum.Creator) return;
+		if (!IsEnabled || IsHidden) return;
+		if (!IsNetworkReady) return;
+
+		if (!Root.IsLoaded)
+		{
+			Root.Loaded.Once(TryRunSingleton);
+			return;
+		}
+
+		_singletonRequired = true;
+		LuauProvider.Singleton.RequireSingleton(this);
+	}
 
 	private void RequestSource()
 	{

--- a/Polytoria/scripts/network/syncs/NetworkScriptSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkScriptSync.cs
@@ -74,6 +74,7 @@ public partial class NetworkScriptSync : Instance
 				{
 					if (_useNetworkLog) { PT.Print($"[Net] [ScriptSync] Recv {s.Name} source"); }
 					s.Bytecode = item.Bytecode;
+					if (s is ModuleScript ms) ms.NotifyBytecodeReceived();
 				}
 			}
 			else
@@ -120,10 +121,15 @@ public partial class NetworkScriptSync : Instance
 	private void NetRecvSource(string netID, byte[] byteCode)
 	{
 		NetworkedObject? obj = NetService.Root.GetNetObjectFromID(netID);
-		if (obj != null && obj is ClientScript script)
+		if (obj is ClientScript script)
 		{
 			script.Bytecode = byteCode;
 			script.TryRun();
+		}
+		else if (obj is ModuleScript ms)
+		{
+			ms.Bytecode = byteCode;
+			ms.NotifyBytecodeReceived();
 		}
 	}
 

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -789,6 +789,62 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 		return state.Yield(1);
 	}
 
+	// Self-requires a module marked Singleton
+	public void RequireSingleton(Datamodel.ModuleScript ms)
+	{
+		if (ms.LuauState != null) return; // already required, by this path or a real caller
+
+		if (ms.Source == "" && ms.Bytecode == null) return;
+
+		string chunkName = ms.LuaPath;
+
+		LuaState co = InitalizeScript(ms);
+		co.SandboxGlobals();
+
+		bool isClient = !ms.Root.Network.IsServer;
+		co.PushBoolean(isClient);
+		co.SetGlobal("_CLIENT");
+		co.PushBoolean(!isClient);
+		co.SetGlobal("_SERVER");
+
+		try
+		{
+			ms.TryCompile();
+		}
+		catch (Exception e)
+		{
+			ms.Root.ScriptService.Logger.LogError(ms, e.Message);
+			return;
+		}
+
+		try
+		{
+			co.Load(chunkName, ms.Bytecode!);
+		}
+		catch (Exception e)
+		{
+			ms.Root.ScriptService.Logger.LogError(ms, e.Message);
+			return;
+		}
+
+		_ = HandleSingletonRequireAsync(co, chunkName, ms);
+	}
+
+	private static async Task HandleSingletonRequireAsync(LuaState co, string chunkName, Datamodel.ModuleScript ms)
+	{
+		// throwError: false; ResumeThread already logs runtime errors against `ms` itself
+		// (registered as co's internal script pointer inside InitalizeScript), so nothing
+		// further needs to happen here for a failed module body.
+		await ResumeThread(co, null, 0, throwError: false, isMainThread: false);
+
+		int top = co.GetTop();
+		if (top > 0)
+		{
+			co.PushValue(1); // duplicate the first return value onto co's own stack top
+			ms.CachedLuauResultRef = co.Ref();
+		}
+	}
+
 	private static async Task HandleRequireAsync(LuaState co, LuaState state, int coRef, string chunkName, TaskCompletionSource<int> tcs, ModuleScript ms)
 	{
 		try


### PR DESCRIPTION
## Summary

Adds a `Singleton` property to module scripts, allowing them to run on their own, which is useful for imperative scripts that need to share state via signals, but don't necessarily need any input (eg. a MusicZones script with `State`/`Sound`/`Playlist` properties and their respective `Changed` signals).

Property is basically the equivalent of parenting a server and a client script to the module with this one liner:
```lua
require(script.Parent)
```
Which is not hard to do but clutters the file browser.

## Related issue or discussion

None, this is mostly made as a throwaway proof of concept. If this were to be added it'd probably need an enum to pick which contexts the module would autorun on (saw no demand for this one so I didn't bother with that).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [x] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

Claude was used for drafting, code review/cleanup, and troubleshooting. All code was manually reviewed and tested.