### PR TITLE
Allow pending assets in local playtest

### DIFF
--- a/Polytoria/scripts/client/ClientEntry.cs
+++ b/Polytoria/scripts/client/ClientEntry.cs
@@ -49,6 +49,9 @@ public sealed partial class ClientEntry : Node3D
 
 	private Timer? _connectTimer;
 	private APIClientAuthResponseMessage? _clientConnectData;
+#if CREATOR
+	private string? _creatorTestToken;
+#endif
 #if ALLOW_SELFHOST
 	public Vector3? DebugSpawnPos { get; private set; }
 #endif
@@ -105,6 +108,15 @@ public sealed partial class ClientEntry : Node3D
 		if (testUserID != null)
 		{
 			TestUserID = int.Parse(testUserID);
+		}
+#endif
+
+#if CREATOR
+		_creatorTestToken = ctoken;
+
+		if (!string.IsNullOrWhiteSpace(_creatorTestToken))
+		{
+			PolyCreatorAPI.SetToken(_creatorTestToken);
 		}
 #endif
 		networkMode ??= "client";
@@ -239,14 +251,6 @@ public sealed partial class ClientEntry : Node3D
 		sw.Restart();
 		Root.Setup();
 		PT.Print($"World setup in {sw.ElapsedMilliseconds}ms");
-
-#if CREATOR
-		// Set creator token for testing (used for loading unapproved assets made by the user)
-		if (ctoken != null)
-		{
-			PolyCreatorAPI.SetToken(ctoken);
-		}
-#endif
 
 #if ALLOW_SELFHOST
 		// Load the test world for server
@@ -528,6 +532,13 @@ public sealed partial class ClientEntry : Node3D
 		string logFilePath = abs.PathJoin(plrID + ".txt");
 
 		List<string> args = ["--windowed", "--log-file", logFilePath, "-network", "client", "-id", plrID.ToString(), "-ltchild", "-port", port.ToString()];
+
+#if CREATOR
+		if (!string.IsNullOrWhiteSpace(_creatorTestToken))
+		{
+			args.AddRange(["-ctoken", _creatorTestToken]);
+		}
+#endif
 
 		if (Globals.IsInGDEditor)
 		{

--- a/Polytoria/scripts/creator/CreatorInterface.cs
+++ b/Polytoria/scripts/creator/CreatorInterface.cs
@@ -662,12 +662,12 @@ public partial class CreatorInterface : Control, IScriptObject
 
 		FileDialog dialog = new()
 		{
+			Access = FileDialog.AccessEnum.Filesystem,
 			Title = data.Title,
 			CurrentDir = currentDir,
 			CurrentFile = data.FileName,
 			ShowHiddenFiles = data.ShowHidden,
 			FileMode = MapFileMode(data.DialogMode),
-			Access = FileDialog.AccessEnum.Filesystem,
 			UseNativeDialog = true,
 		};
 


### PR DESCRIPTION
## Summary

Passes the creator token to playtest clients to allow viewing unapproved assets locally similar to the creator

## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None