### PR TITLE
Fix parts never being batched after they are anchored

### DIFF
--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -19,6 +19,7 @@ public partial class DatamodelBridge : Node3D
 	public long SeparatedPartCount = 0;
 
 	private readonly Dictionary<Part, PartHandle> _handles = [];
+	private readonly Dictionary<Part, System.Action> _propertyHandlers = [];
 	private readonly Dictionary<ChunkKey, ChunkBatch> _batches = [];
 	private readonly HashSet<Part> _dirty = [];
 	private Rid _scenario;
@@ -64,8 +65,9 @@ public partial class DatamodelBridge : Node3D
 			Root.InstanceExitingTree -= OnInstanceRemoving;
 			Root.Loaded.Disconnect(OnGameReady);
 
-			// Cleanup parts
-			foreach (var item in _handles.Keys)
+			// Cleanup parts. Iterates the handler map rather than _handles so separately
+			// rendered parts are unsubscribed too, and snapshots it because RemovePart mutates.
+			foreach (Part item in new List<Part>(_propertyHandlers.Keys))
 			{
 				RemovePart(item);
 			}
@@ -208,6 +210,16 @@ public partial class DatamodelBridge : Node3D
 
 	private void AddToBatch(Part part, ChunkKey key)
 	{
+		// Batched parts rely on PropertyChanged to re-enter _dirty for color/transform/key
+		// updates. Subscribing here rather than in AddPart covers both entry paths: parts that
+		// are eligible when they enter the tree, and parts promoted later via the _dirty loop.
+		if (!_propertyHandlers.ContainsKey(part))
+		{
+			void propertyChangedHandler() { if (isGameReady) _dirty.Add(part); }
+			part.PropertyChanged.Connect(propertyChangedHandler);
+			_propertyHandlers[part] = propertyChangedHandler;
+		}
+
 		if (!_batches.TryGetValue(key, out var batch))
 		{
 			(Godot.Mesh mesh, _) = Globals.LoadShape(part.Shape.ToString());
@@ -324,30 +336,36 @@ public partial class DatamodelBridge : Node3D
 		if (_handles.ContainsKey(part)) return;
 		if (!IsPartEligible(part))
 		{
+			// Deliberately no PropertyChanged subscription here: moving unanchored parts fire
+			// PropertyChanged every tick via InvokeTransformChanged(), and none of it can make
+			// them batchable. Eligibility changes are pushed explicitly instead - see
+			// QueuePartForReevaluation and the Anchored setter.
 			part.CreateSeparateMesh();
 			return;
 		}
 
-		void propertyChangedHandler() { if (isGameReady) _dirty.Add(part); }
-
-		part.PropertyChanged.Connect(propertyChangedHandler);
-
 		var key = GetKeyForPart(part);
 		AddToBatch(part, key);
 
-		if (_handles.TryGetValue(part, out var handle))
-		{
-			handle.PropertyChangedHandler = propertyChangedHandler;
-		}
+		_dirty.Add(part);
+	}
 
+	/// <summary>
+	/// Re-evaluates a part's batch eligibility on the next frame. Parts that enter the tree
+	/// ineligible have no PropertyChanged subscription, so the transitions that can make them
+	/// batchable (anchoring, primarily) must be pushed here explicitly by the datamodel.
+	/// </summary>
+	internal void QueuePartForReevaluation(Part part)
+	{
+		if (!isGameReady) return;
 		_dirty.Add(part);
 	}
 
 	public void RemovePart(Part part)
 	{
-		if (_handles.TryGetValue(part, out var handle))
+		if (_propertyHandlers.Remove(part, out System.Action? propertyChangedHandler))
 		{
-			part.PropertyChanged.Disconnect(handle.PropertyChangedHandler);
+			part.PropertyChanged.Disconnect(propertyChangedHandler);
 		}
 
 		part.CreateSeparateMesh();
@@ -371,7 +389,6 @@ public partial class DatamodelBridge : Node3D
 	{
 		public ChunkKey Key;
 		public int Index;
-		public System.Action PropertyChangedHandler = null!;
 	}
 
 	private struct ChunkKey

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -105,6 +105,13 @@ public partial class Physical : Dynamic
 				UpdateFreeze();
 			}
 
+			// Anchoring changes multimesh batch eligibility, and parts that entered the tree
+			// unanchored have no bridge subscription to catch it - push it explicitly.
+			if (this is Part part)
+			{
+				Root?.Bridge?.QueuePartForReevaluation(part);
+			}
+
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

`DatamodelBridge.AddPart()` connects the `PropertyChanged` handler only after the `IsPartEligible()` check, so a part that enters the tree ineligible — typically unanchored — never subscribes at all. `_dirty` is fed only by that handler, so such a part can never be re-evaluated and stays separately rendered for its entire lifetime, even after it is anchored.

Any place that creates parts unanchored and anchors them afterwards is affected — building and placement systems, physics props that come to rest and are then locked down, editor-driven or script-driven construction. A world loaded from file is unaffected, because those parts are already anchored when they enter the tree, which is why this is easy to miss. The separately rendered count only ever grows over a session, and those parts keep paying individual mesh cost instead of collapsing into a MultiMesh chunk.

- Ineligible parts get no subscription, so the engine's hottest path is untouched — moving unanchored parts fire `PropertyChanged` eight times per tick via `InvokeTransformChanged()`, and none of it can make them batchable
- The `Anchored` setter notifies the bridge explicitly, and the existing `_Process` path promotes the part into a batch
- The batch subscription moves into `AddToBatch` so both entry paths — eligible at tree-enter, and promoted later — end with a live handler for future color/transform updates
- Fixes a latent stale handler reference: `RemoveFromBatch()` rebuilds `PartHandle` on index swap without carrying `PropertyChangedHandler` across
- `_ExitTree()` iterates a snapshot of the handler map; the old loop enumerated `_handles.Keys` while `RemoveFromBatch()` overwrites entries mid-iteration

## Related issue or discussion

Fixes #1071

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Not included. The change affects which render path a part takes rather than its appearance.

Verified via the performance overlay's "Non-DMB Parts" counter (`Bridge.SeparatedPartCount`): anchoring a part that entered the tree unanchored now decreases it, where previously it stayed flat for the rest of the session. Exercised in a local Creator session and in a physics-heavy multiplayer place of my own, whose placement flow creates parts unanchored and anchors them afterwards.

After recommendation, I shared the reproduction steps in the open issue #1071.

## AI/LLM use

AI tools assisted with identifying the defect, reviewing the patch for regressions, and drafting in-code documentation. I owned the diagnosis of the root cause, the fix design, local validation, and final technical decisions.
