### PR TITLE
Keep bodies with standing constant forces awake

### DIFF
--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -211,6 +211,27 @@ public partial class RigidBody : Physical
 		CanCollide = true;
 	}
 
+	/// <summary>
+	/// Constant forces are stored on the body and applied each simulation step - but only while
+	/// the body is awake. Jolt wakes a body when the constant force is SET, not while it acts,
+	/// so a body that later slows down still falls asleep with the force in place and hangs
+	/// wherever it is (a hull slowly rising under a stored buoyancy force can stop mid-air).
+	/// A body with a standing constant force or torque must not be allowed to sleep.
+	/// </summary>
+	private void UpdateSleepForConstantForces()
+	{
+		bool noStandingForce = GDRigidBody.ConstantForce == Vector3.Zero && GDRigidBody.ConstantTorque == Vector3.Zero;
+
+		if (GDRigidBody.CanSleep != noStandingForce)
+		{
+			GDRigidBody.CanSleep = noStandingForce;
+			if (!noStandingForce)
+			{
+				GDRigidBody.Sleeping = false;
+			}
+		}
+	}
+
 	internal override void ApplyAddForce(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
 	{
 		if (mode == ForceModeEnum.Force)
@@ -220,6 +241,7 @@ public partial class RigidBody : Physical
 		else if (mode == ForceModeEnum.Acceleration)
 		{
 			GDRigidBody.AddConstantCentralForce(force);
+			UpdateSleepForConstantForces();
 		}
 		else if (mode == ForceModeEnum.Impulse)
 		{
@@ -244,6 +266,7 @@ public partial class RigidBody : Physical
 		else if (mode == ForceModeEnum.Acceleration)
 		{
 			GDRigidBody.AddConstantTorque(force);
+			UpdateSleepForConstantForces();
 		}
 		else if (mode == ForceModeEnum.Impulse)
 		{
@@ -268,6 +291,7 @@ public partial class RigidBody : Physical
 		else if (mode == ForceModeEnum.Acceleration)
 		{
 			GDRigidBody.AddConstantForce(force, position);
+			UpdateSleepForConstantForces();
 		}
 		else if (mode == ForceModeEnum.Impulse)
 		{
@@ -293,6 +317,7 @@ public partial class RigidBody : Physical
 		else if (mode == ForceModeEnum.Acceleration)
 		{
 			GDRigidBody.AddConstantCentralForce(worldForce);
+			UpdateSleepForConstantForces();
 		}
 		else if (mode == ForceModeEnum.Impulse)
 		{
@@ -319,6 +344,7 @@ public partial class RigidBody : Physical
 		else if (mode == ForceModeEnum.Acceleration)
 		{
 			GDRigidBody.AddConstantTorque(worldTorque);
+			UpdateSleepForConstantForces();
 		}
 		else if (mode == ForceModeEnum.Impulse)
 		{


### PR DESCRIPTION
## Summary

A constant force (`ForceMode.Acceleration` → `AddConstantCentralForce` and friends) is stored on the body and applied each simulation step, but only while the body is awake. Jolt wakes the body when the constant force is *set*, not while it acts, so a body that later slows down falls asleep with the force still in place and stops receiving it entirely.

Any object held or driven by a standing force — a hover platform, a lift, a thruster, a conveyor, a script that cancels or replaces gravity — can therefore stop responding once it settles, and hang in place until a contact or impulse happens to wake it. From the script author's side the force is still being applied and simply has no effect, which is difficult to diagnose from the scripting API alone.

- Per-call forces (`ForceMode.Force` applied every tick) are unaffected — each `apply_central_force` wakes the body via Jolt's `_motion_changed()`. Only the set-once constant force path can die
- Sleeping is disallowed while `ConstantForce` or `ConstantTorque` is nonzero, and restored when they return to zero

Verified against `modules/jolt_physics/objects/jolt_body_3d.cpp` on `4.7-stable`: the constant force is applied in `_integrate_forces()`, called from `pre_step()`, which only runs for active bodies.

## Related issue or discussion

No related issue or discussion found.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [ ] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Not included. The behavioural change is limited to sleep state for bodies that have a standing constant force.

Flagging the unticked checklist item deliberately: this was found and verified by inspection against the Jolt module source, and the build was exercised in a local Creator session and in a physics-heavy place of my own, but the physics scripting in both applies per-tick `ForceMode.Force` rather than `ForceMode.Acceleration`, so I have not yet driven the affected path at runtime. Happy to put together a dedicated repro place if that would help review.

## AI/LLM use

AI tools assisted with identifying the defect, verifying the behaviour against the Jolt module source, and drafting in-code documentation. I owned the fix design, local validation, and final technical decisions.
