### PR TITLE
willem's welds rework + some completions

### DIFF
--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -23,6 +23,7 @@ public partial class DatamodelBridge : Node3D
 	private readonly HashSet<Part> _dirty = [];
 	private Rid _scenario;
 
+	// (material, isTransparent)
 	private readonly Dictionary<(Part.PartMaterialEnum, bool), Material> _materials = [];
 
 	private bool isGameReady = false;

--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -110,6 +110,11 @@ public partial class DatamodelBridge : Node3D
 		return mat;
 	}
 
+	public override void _PhysicsProcess(double delta)
+	{
+		_Process(delta);
+	}
+
 	public override void _Process(double delta)
 	{
 		if (!isGameReady) return;

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -845,6 +845,11 @@ public partial class Dynamic : Instance
 
 	internal Transform3D GetGlobalTransform()
 	{
+		if (this is Part part && part.TryGetAssemblyTransform(out Transform3D trans))
+		{
+			return trans;
+		}
+
 		var t = GDNode3D.GlobalTransform;
 		return t * Transform3D.Identity.Scaled(NodeSize);
 	}

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -823,7 +823,7 @@ public partial class Dynamic : Instance
 
 	internal Vector3 GetGlobalPosition()
 	{
-		return GDNode3D.GlobalPosition;
+		return GetGlobalTransform().Origin;
 	}
 
 	internal void SetGlobalPosition(Vector3 to)

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -860,6 +860,26 @@ public partial class Dynamic : Instance
 		return t * Transform3D.Identity.Scaled(NodeSize / GetParentScale());
 	}
 
+	internal Transform3D GetReplicationLocalTransform()
+	{
+		if (this is Part part && part.TryGetAssemblyTransform(out Transform3D aTrans))
+		{
+			return GlobalToLocalTransform(aTrans);
+		}
+
+		return GetLocalTransform();
+	}
+
+	internal Transform3D GlobalToLocalTransform(Transform3D trans)
+	{
+		if (Parent is Dynamic parentDyn)
+		{
+			return parentDyn.GetGlobalTransform().AffineInverse() * trans;
+		}
+
+		return trans;
+	}
+
 	internal void SetGlobalTransformRaw(Transform3D to)
 	{
 		if (!GDNode3D.IsInsideTree()) return;

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -845,7 +845,7 @@ public partial class Dynamic : Instance
 
 	internal Transform3D GetGlobalTransform()
 	{
-		if (this is Part part && part.TryGetAssemblyTransform(out Transform3D trans))
+		if (this is RigidBody part && part.TryGetAssemblyTransform(out Transform3D trans))
 		{
 			return trans;
 		}
@@ -862,7 +862,7 @@ public partial class Dynamic : Instance
 
 	internal Transform3D GetReplicationLocalTransform()
 	{
-		if (this is Part part && part.TryGetAssemblyTransform(out Transform3D aTrans))
+		if (this is RigidBody part && part.TryGetAssemblyTransform(out Transform3D aTrans))
 		{
 			return GlobalToLocalTransform(aTrans);
 		}

--- a/Polytoria/scripts/datamodel/Explosion.cs
+++ b/Polytoria/scripts/datamodel/Explosion.cs
@@ -129,7 +129,7 @@ public partial class Explosion : Dynamic
 		}
 
 		HashSet<Instance> processed = [];
-		HashSet<Part> toCheck = new(ReferenceEqualityComparer.Instance);
+		HashSet<RigidBody> toCheck = new(ReferenceEqualityComparer.Instance);
 		HashSet<Weld> breakWelds = new(ReferenceEqualityComparer.Instance);
 		List<Entity> forceTargets = [];
 		List<Player> playerTargets = [];
@@ -154,15 +154,15 @@ public partial class Explosion : Dynamic
 				}
 			}
 
-			if (item is Entity e && !item.IsDescendantOfClass("Accessory"))
+			if (item is RigidBody e && !item.IsDescendantOfClass("Accessory"))
 			{
 				bool skipForce = e.Anchored && !AffectAnchored && AffectPredicate == null;
 
-				if (_affectWelds && item is Part p)
+				if (_affectWelds && item is RigidBody p)
 				{
 					if (p.Assembly != null && p.Assembly.Physicalized)
 					{
-						foreach (Part assemblyPart in p.Assembly.Parts)
+						foreach (RigidBody assemblyPart in p.Assembly.Parts)
 						{
 							toCheck.Add(assemblyPart);
 						}
@@ -212,11 +212,11 @@ public partial class Explosion : Dynamic
 
 		if (_affectWelds)
 		{
-			foreach (Part part in toCheck)
+			foreach (RigidBody part in toCheck)
 			{
 				foreach (Weld weld in WeldGraph.GetWelds(part).ToArray())
 				{
-					if (!WeldGraph.TryGetParts(weld, out Part a, out Part b))
+					if (!WeldGraph.TryGetParts(weld, out RigidBody a, out RigidBody b))
 					{
 						continue;
 					}
@@ -242,7 +242,7 @@ public partial class Explosion : Dynamic
 		Delete();
 	}
 
-	private bool IsWeldAffected(Part a, Part b)
+	private bool IsWeldAffected(RigidBody a, RigidBody b)
 	{
 		Aabb aa = a.GetSelfBound();
 		Aabb bb = b.GetSelfBound();

--- a/Polytoria/scripts/datamodel/Explosion.cs
+++ b/Polytoria/scripts/datamodel/Explosion.cs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using System.Collections.Generic;
 using Godot;
 using Polytoria.Attributes;
 using Polytoria.Datamodel.Resources;
@@ -127,10 +128,21 @@ public partial class Explosion : Dynamic
 			s.LocalPosition = Vector3.Zero;
 		}
 
+		HashSet<Instance> processed = [];
+		HashSet<Part> toCheck = new(ReferenceEqualityComparer.Instance);
+		HashSet<Weld> breakWelds = new(ReferenceEqualityComparer.Instance);
+		List<Entity> forceTargets = [];
+		List<Player> playerTargets = [];
+
 		Instance[] overlaps = Root.Environment.OverlapSphere(Position, Radius);
 
 		foreach (Instance item in overlaps)
 		{
+			if (!processed.Add(item))
+			{
+				continue;
+			}
+
 			Touched.Invoke(item);
 
 			if (AffectPredicate != null)
@@ -144,7 +156,27 @@ public partial class Explosion : Dynamic
 
 			if (item is Entity e && !item.IsDescendantOfClass("Accessory"))
 			{
-				if (e.Anchored && !AffectAnchored && AffectPredicate == null) continue;
+				bool skipForce = e.Anchored && !AffectAnchored && AffectPredicate == null;
+
+				if (_affectWelds && item is Part p)
+				{
+					if (p.Assembly != null && p.Assembly.Physicalized)
+					{
+						foreach (Part assemblyPart in p.Assembly.Parts)
+						{
+							toCheck.Add(assemblyPart);
+						}
+					}
+					else
+					{
+						toCheck.Add(p);
+					}
+				}
+
+				if (skipForce)
+				{
+					continue;
+				}
 
 				RigidBody3D body = e.GDRigidBody;
 				Vector3 direction = body.GlobalTransform.Origin - GetGlobalTransform().Origin;
@@ -168,13 +200,6 @@ public partial class Explosion : Dynamic
 
 				body.ApplyCentralImpulse(force);
 
-				if (_affectWelds && e is Part p)
-				{
-					foreach (Weld w in WeldGraph.GetWelds(p))
-					{
-						w.Break();
-					}
-				}
 			}
 			else if (item is Player plr)
 			{
@@ -183,6 +208,27 @@ public partial class Explosion : Dynamic
 				plr.TakeDamage(Damage);
 				AddPlrExplosionForce(plr);
 			}
+		}
+
+		if (_affectWelds)
+		{
+			foreach (Part part in toCheck)
+			{
+				foreach (Weld weld in WeldGraph.GetWelds(part).ToArray())
+				{
+					if (!WeldGraph.TryGetParts(weld, out Part a, out Part b))
+					{
+						continue;
+					}
+
+					if (IsWeldAffected(a, b))
+					{
+						breakWelds.Add(weld);
+					}
+				}
+			}
+
+			WeldAssemblyManager.BreakWelds(breakWelds);
 		}
 
 		// Play sound on next frame, needed to be loaded
@@ -194,6 +240,40 @@ public partial class Explosion : Dynamic
 		await Globals.Singleton.WaitAsync(ExplosionParticleTimeSec);
 
 		Delete();
+	}
+
+	private bool IsWeldAffected(Part a, Part b)
+	{
+		Aabb aa = a.GetSelfBound();
+		Aabb bb = b.GetSelfBound();
+
+		Vector3 point = Position;
+
+		Vector3 closestOnContact = new(
+			ClosestContactAxis(point.X, aa.Position.X, aa.End.X, bb.Position.X, bb.End.X),
+			ClosestContactAxis(point.Y, aa.Position.Y, aa.End.Y, bb.Position.Y, bb.End.Y),
+			ClosestContactAxis(point.Z, aa.Position.Z, aa.End.Z, bb.Position.Z, bb.End.Z)
+		);
+
+		return closestOnContact.DistanceTo(point) <= Radius;
+	}
+
+	private static float ClosestContactAxis(float point, float aMin, float aMax, float bMin, float bMax)
+	{
+		if (aMax < bMin)
+		{
+			return (aMax + bMin) * 0.5f;
+		}
+
+		if (bMax < aMin)
+		{
+			return (bMax + aMin) * 0.5f;
+		}
+
+		float overlapMin = Mathf.Max(aMin, bMin);
+		float overlapMax = Mathf.Min(aMax, bMax);
+
+		return Mathf.Clamp(point, overlapMin, overlapMax);
 	}
 
 	private void AddPlrExplosionForce(Player player)

--- a/Polytoria/scripts/datamodel/Explosion.cs
+++ b/Polytoria/scripts/datamodel/Explosion.cs
@@ -5,6 +5,7 @@
 using Godot;
 using Polytoria.Attributes;
 using Polytoria.Datamodel.Resources;
+using Polytoria.Physics;
 using Polytoria.Scripting;
 using Polytoria.Shared;
 
@@ -167,12 +168,11 @@ public partial class Explosion : Dynamic
 
 				body.ApplyCentralImpulse(force);
 
-				if (_affectWelds)
+				if (_affectWelds && e is Part p)
 				{
-					foreach (Weld w in Weld.GetWeldsFor(e))
+					foreach (Weld w in WeldGraph.GetWelds(p))
 					{
-						if (w.Enabled)
-							w.Break();
+						w.Break();
 					}
 				}
 			}

--- a/Polytoria/scripts/datamodel/Explosion.cs
+++ b/Polytoria/scripts/datamodel/Explosion.cs
@@ -198,7 +198,7 @@ public partial class Explosion : Dynamic
 				float forceMagnitude = Force * (1 - (distance / Radius));
 				Vector3 force = direction * forceMagnitude / 100;
 
-				body.ApplyCentralImpulse(force);
+				e.ApplyAddForce(force);
 
 			}
 			else if (item is Player plr)

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -152,6 +152,8 @@ public partial class NetworkedObject : IScriptObject
 	/// </summary>
 	internal Node SlotNode = null!;
 
+	internal Node? GodotParentOverride { get; set; }
+
 	[Editable, ScriptProperty, SaveIgnore]
 	public string Name
 	{
@@ -877,6 +879,16 @@ public partial class NetworkedObject : IScriptObject
 	public virtual void CreatorInserted() { }
 #endif
 
+	internal Node GetGodotParent()
+	{
+		if (GodotParentOverride != null && Node.IsInstanceValid(GodotParentOverride))
+		{
+			return GodotParentOverride;
+		}
+
+		return NetworkParent!.SlotNode;
+	}
+
 	private void EnterTreeRecheck()
 	{
 		if (IsDeleted) return;
@@ -915,13 +927,16 @@ public partial class NetworkedObject : IScriptObject
 		{
 			if (!Node.IsInstanceValid(NetworkParent.SlotNode)) return;
 			Node? parent = GDNode.GetParentOrNull<Node>();
+
+			Node targetParent = GetGodotParent();
+
 			if (parent == null)
 			{
-				NetworkParent.SlotNode.AddChild(GDNode);
+				targetParent.AddChild(GDNode);
 			}
-			else if (parent != NetworkParent.SlotNode)
+			else if (parent != targetParent)
 			{
-				GDNode.Reparent(NetworkParent.SlotNode);
+				GDNode.Reparent(targetParent, keepGlobalTransform: true);
 			}
 		}
 	}

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -4,6 +4,7 @@
 
 using Godot;
 using Polytoria.Attributes;
+using Polytoria.Physics;
 using Polytoria.Shared;
 
 namespace Polytoria.Datamodel;
@@ -23,9 +24,14 @@ public partial class Part : Entity
 	private Node3D _nRemoteAt = null!; // Remote collider proxy
 
 	internal Shape3D ColliderShape => _collider.Shape;
+	internal WeldAssembly? Assembly { get; private set; }
+	internal Transform3D AssemblyLocalTransform = Transform3D.Identity;
 
 	public bool IsMeshSeparated => _isSeparateMesh;
 	public int BridgeID = -1;
+
+	private Node? _originalMeshParent;
+	private Node? _originalRemoteParent;
 
 	public override void EnterTree()
 	{
@@ -253,6 +259,99 @@ public partial class Part : Entity
 		{
 			_mesh?.CastShadow = _castShadows ? GeometryInstance3D.ShadowCastingSetting.On : GeometryInstance3D.ShadowCastingSetting.Off;
 		}
+	}
+
+	internal void AttachToAssembly(WeldAssembly ass, Part root, Transform3D localTrans)
+	{
+		Assembly = ass;
+		AssemblyLocalTransform = localTrans;
+		OverrideNoMultiMesh = true;
+		Root?.Bridge?.RemovePart(this);
+		CreateSeparateMesh();
+
+		if (this != root)
+		{
+			OverridePhysicsProcess = true;
+			SetPhysicsProcess(false);
+			OverrideNetworkTransform = true;
+			AutoUpdateNetTransform = false;
+
+			GDRigidBody.Freeze = true;
+			GDRigidBody.Sleeping = true;
+		}
+
+		Node3D rootBody = root.GDNode3D;
+
+		if (_mesh != null)
+		{
+			_originalMeshParent ??= _mesh.GetParent();
+			_mesh.Reparent(rootBody, keepGlobalTransform: true);
+			_mesh.Transform = localTrans;
+			_mesh.Scale = NodeSize;
+		}
+
+		if (_nRemoteAt != null)
+		{
+			_originalRemoteParent ??= _nRemoteAt.GetParent();
+			_nRemoteAt.Reparent(rootBody, keepGlobalTransform: true);
+			_nRemoteAt.Transform = localTrans;
+			_nRemoteAt.Scale = NodeSize;
+		}
+
+		if (this != root)
+		{
+			SetAssemblyCollisionRoot(root);
+		}
+	}
+
+	internal void DetachFromAssembly()
+	{
+		if (_mesh != null && _originalMeshParent != null && Node.IsInstanceValid(_originalMeshParent))
+		{
+			_mesh.Reparent(_originalMeshParent, keepGlobalTransform: true);
+			_mesh.Transform = Transform3D.Identity;
+			_mesh.Scale = NodeSize;
+		}
+
+		if (_nRemoteAt != null && _originalRemoteParent != null && Node.IsInstanceValid(_originalRemoteParent))
+		{
+			_nRemoteAt.Reparent(_originalRemoteParent, keepGlobalTransform: true);
+			_nRemoteAt.Position = Vector3.Zero;
+			_nRemoteAt.Rotation = Vector3.Zero;
+			_nRemoteAt.Scale = NodeSize;
+		}
+
+		SetAssemblyCollisionRoot(null);
+
+		OverridePhysicsProcess = false;
+		OverrideNetworkTransform = false;
+		AutoUpdateNetTransform = true;
+
+		Assembly = null;
+		AssemblyLocalTransform = Transform3D.Identity;
+
+		_originalMeshParent = null;
+		_originalRemoteParent = null;
+
+		OverrideNoMultiMesh = false;
+		Root?.Bridge?.AddPart(this);
+
+		UpdateFreeze();
+		UpdateCollision();
+	}
+
+	internal bool TryGetAssemblyTransform(out Transform3D trans)
+	{
+		if (Assembly == null || Assembly.Root == null)
+		{
+			trans = default;
+			return false;
+		}
+
+		Transform3D rootBody = Assembly.Root.GDNode3D.GlobalTransform;
+		trans = rootBody * AssemblyLocalTransform * Transform3D.Identity.Scaled(NodeSize);
+
+		return true;
 	}
 
 	public override Aabb GetSelfBound()

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -306,6 +306,20 @@ public partial class Part : Entity
 
 	internal void DetachFromAssembly()
 	{
+		Transform3D currentTrans;
+		if (Assembly == null)
+		{
+			currentTrans = GDNode3D.GlobalTransform;
+		}
+		else
+		{
+			currentTrans = Assembly.Root.GDNode3D.GlobalTransform * AssemblyLocalTransform;
+		}
+
+		GDNode3D.GlobalTransform = currentTrans;
+		ForceUpdateTransform();
+		UpdateCurrentTransformCache();
+
 		if (_mesh != null && _originalMeshParent != null && Node.IsInstanceValid(_originalMeshParent))
 		{
 			_mesh.Reparent(_originalMeshParent, keepGlobalTransform: true);
@@ -342,7 +356,7 @@ public partial class Part : Entity
 
 	internal bool TryGetAssemblyTransform(out Transform3D trans)
 	{
-		if (Assembly == null || Assembly.Root == null)
+		if (Assembly == null || Assembly.Root == this)
 		{
 			trans = default;
 			return false;

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -21,17 +21,12 @@ public partial class Part : Entity
 	private bool _isSeparateMesh = false;
 	private bool _castShadows;
 
-	private Node3D _nRemoteAt = null!; // Remote collider proxy
-
 	internal Shape3D ColliderShape => _collider.Shape;
-	internal WeldAssembly? Assembly { get; private set; }
-	internal Transform3D AssemblyLocalTransform = Transform3D.Identity;
 
 	public bool IsMeshSeparated => _isSeparateMesh;
 	public int BridgeID = -1;
 
 	private Node? _originalMeshParent;
-	private Node? _originalRemoteParent;
 
 	public override void EnterTree()
 	{
@@ -261,7 +256,7 @@ public partial class Part : Entity
 		}
 	}
 
-	internal void AttachToAssembly(WeldAssembly ass, Part root, Transform3D localTrans)
+	internal new void AttachToAssembly(WeldAssembly ass, RigidBody root, Transform3D localTrans)
 	{
 		Assembly = ass;
 		AssemblyLocalTransform = localTrans;
@@ -304,7 +299,7 @@ public partial class Part : Entity
 		}
 	}
 
-	internal void DetachFromAssembly()
+	internal new void DetachFromAssembly()
 	{
 		Transform3D currentTrans;
 		if (Assembly == null)
@@ -352,20 +347,6 @@ public partial class Part : Entity
 
 		UpdateFreeze();
 		UpdateCollision();
-	}
-
-	internal bool TryGetAssemblyTransform(out Transform3D trans)
-	{
-		if (Assembly == null || Assembly.Root == this)
-		{
-			trans = default;
-			return false;
-		}
-
-		Transform3D rootBody = Assembly.Root.GDNode3D.GlobalTransform;
-		trans = rootBody * AssemblyLocalTransform * Transform3D.Identity.Scaled(NodeSize);
-
-		return true;
 	}
 
 	public override Aabb GetSelfBound()

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -258,22 +258,10 @@ public partial class Part : Entity
 
 	internal override void AttachToAssembly(WeldAssembly ass, RigidBody root, Transform3D localTrans)
 	{
-		Assembly = ass;
-		AssemblyLocalTransform = localTrans;
+		base.AttachToAssembly(ass, root, localTrans);
 		OverrideNoMultiMesh = true;
 		Root?.Bridge?.RemovePart(this);
 		CreateSeparateMesh();
-
-		if (this != root)
-		{
-			OverridePhysicsProcess = true;
-			SetPhysicsProcess(false);
-			OverrideNetworkTransform = true;
-			AutoUpdateNetTransform = false;
-
-			GDRigidBody.Freeze = true;
-			GDRigidBody.Sleeping = true;
-		}
 
 		Node3D rootBody = root.GDNode3D;
 
@@ -284,36 +272,11 @@ public partial class Part : Entity
 			_mesh.Transform = localTrans;
 			_mesh.Scale = NodeSize;
 		}
-
-		if (_nRemoteAt != null)
-		{
-			_originalRemoteParent ??= _nRemoteAt.GetParent();
-			_nRemoteAt.Reparent(rootBody, keepGlobalTransform: true);
-			_nRemoteAt.Transform = localTrans;
-			_nRemoteAt.Scale = NodeSize;
-		}
-
-		if (this != root)
-		{
-			SetAssemblyCollisionRoot(root);
-		}
 	}
 
 	internal override void DetachFromAssembly()
 	{
-		Transform3D currentTrans;
-		if (Assembly == null)
-		{
-			currentTrans = GDNode3D.GlobalTransform;
-		}
-		else
-		{
-			currentTrans = Assembly.Root.GDNode3D.GlobalTransform * AssemblyLocalTransform;
-		}
-
-		GDNode3D.GlobalTransform = currentTrans;
-		ForceUpdateTransform();
-		UpdateCurrentTransformCache();
+		base.DetachFromAssembly();
 
 		if (_mesh != null && _originalMeshParent != null && Node.IsInstanceValid(_originalMeshParent))
 		{
@@ -322,31 +285,10 @@ public partial class Part : Entity
 			_mesh.Scale = NodeSize;
 		}
 
-		if (_nRemoteAt != null && _originalRemoteParent != null && Node.IsInstanceValid(_originalRemoteParent))
-		{
-			_nRemoteAt.Reparent(_originalRemoteParent, keepGlobalTransform: true);
-			_nRemoteAt.Position = Vector3.Zero;
-			_nRemoteAt.Rotation = Vector3.Zero;
-			_nRemoteAt.Scale = NodeSize;
-		}
-
-		SetAssemblyCollisionRoot(null);
-
-		OverridePhysicsProcess = false;
-		OverrideNetworkTransform = false;
-		AutoUpdateNetTransform = true;
-
-		Assembly = null;
-		AssemblyLocalTransform = Transform3D.Identity;
-
 		_originalMeshParent = null;
-		_originalRemoteParent = null;
 
 		OverrideNoMultiMesh = false;
 		Root?.Bridge?.AddPart(this);
-
-		UpdateFreeze();
-		UpdateCollision();
 	}
 
 	public override Aabb GetSelfBound()

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -199,7 +199,7 @@ public partial class Part : Entity
 		}
 	}
 
-	// Override this to be excluded from MutliMesh
+	// Override this to be excluded from MultiMesh
 	internal bool OverrideNoMultiMesh = false;
 
 	internal void UpdateShape()
@@ -256,7 +256,7 @@ public partial class Part : Entity
 		}
 	}
 
-	internal new void AttachToAssembly(WeldAssembly ass, RigidBody root, Transform3D localTrans)
+	internal override void AttachToAssembly(WeldAssembly ass, RigidBody root, Transform3D localTrans)
 	{
 		Assembly = ass;
 		AssemblyLocalTransform = localTrans;
@@ -299,7 +299,7 @@ public partial class Part : Entity
 		}
 	}
 
-	internal new void DetachFromAssembly()
+	internal override void DetachFromAssembly()
 	{
 		Transform3D currentTrans;
 		if (Assembly == null)

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -275,9 +275,6 @@ public partial class Part : Entity
 
 	internal override void DetachFromAssembly()
 	{
-		base.DetachFromAssembly();
-		DetachVisualFromAssembly();
-
 		if (_nRemoteAt != null && _originalRemoteParent != null && Node.IsInstanceValid(_originalRemoteParent))
 		{
 			_nRemoteAt.Reparent(_originalRemoteParent, keepGlobalTransform: true);
@@ -285,6 +282,9 @@ public partial class Part : Entity
 			_nRemoteAt.Rotation = Vector3.Zero;
 			_nRemoteAt.Scale = NodeSize;
 		}
+
+		base.DetachFromAssembly();
+		DetachVisualFromAssembly();
 	}
 
 	internal void AttachVisualToAssembly(RigidBody root, Transform3D localTrans)

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -260,19 +260,9 @@ public partial class Part : Entity
 	internal override void AttachToAssembly(WeldAssembly ass, RigidBody root, Transform3D localTrans)
 	{
 		base.AttachToAssembly(ass, root, localTrans);
-		OverrideNoMultiMesh = true;
-		Root?.Bridge?.RemovePart(this);
-		CreateSeparateMesh();
+		AttachVisualToAssembly(root, localTrans);
 
 		Node3D rootBody = root.GDNode3D;
-
-		if (_mesh != null)
-		{
-			_originalMeshParent ??= _mesh.GetParent();
-			_mesh.Reparent(rootBody, keepGlobalTransform: true);
-			_mesh.Transform = localTrans;
-			_mesh.Scale = NodeSize;
-		}
 
 		if (_nRemoteAt != null)
 		{
@@ -286,7 +276,36 @@ public partial class Part : Entity
 	internal override void DetachFromAssembly()
 	{
 		base.DetachFromAssembly();
+		DetachVisualFromAssembly();
 
+		if (_nRemoteAt != null && _originalRemoteParent != null && Node.IsInstanceValid(_originalRemoteParent))
+		{
+			_nRemoteAt.Reparent(_originalRemoteParent, keepGlobalTransform: true);
+			_nRemoteAt.Position = Vector3.Zero;
+			_nRemoteAt.Rotation = Vector3.Zero;
+			_nRemoteAt.Scale = NodeSize;
+		}
+	}
+
+	internal void AttachVisualToAssembly(RigidBody root, Transform3D localTrans)
+	{
+		OverrideNoMultiMesh = true;
+		Root?.Bridge?.RemovePart(this);
+		CreateSeparateMesh();
+
+		Node3D rootBody = root.GDNode3D;
+
+		if (_mesh != null)
+		{
+			_originalMeshParent ??= _mesh.GetParent();
+			_mesh.Reparent(rootBody, keepGlobalTransform: true);
+			_mesh.Transform = localTrans;
+			_mesh.Scale = NodeSize;
+		}
+	}
+
+	internal void DetachVisualFromAssembly()
+	{
 		if (_mesh != null && _originalMeshParent != null && Node.IsInstanceValid(_originalMeshParent))
 		{
 			_mesh.Reparent(_originalMeshParent, keepGlobalTransform: true);
@@ -298,14 +317,6 @@ public partial class Part : Entity
 
 		OverrideNoMultiMesh = false;
 		Root?.Bridge?.AddPart(this);
-
-		if (_nRemoteAt != null && _originalRemoteParent != null && Node.IsInstanceValid(_originalRemoteParent))
-		{
-			_nRemoteAt.Reparent(_originalRemoteParent, keepGlobalTransform: true);
-			_nRemoteAt.Position = Vector3.Zero;
-			_nRemoteAt.Rotation = Vector3.Zero;
-			_nRemoteAt.Scale = NodeSize;
-		}
 	}
 
 	public override Aabb GetSelfBound()

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -27,6 +27,7 @@ public partial class Part : Entity
 	public int BridgeID = -1;
 
 	private Node? _originalMeshParent;
+	protected Node3D _nRemoteAt = null!; // Remote collider proxy
 
 	public override void EnterTree()
 	{
@@ -272,6 +273,14 @@ public partial class Part : Entity
 			_mesh.Transform = localTrans;
 			_mesh.Scale = NodeSize;
 		}
+
+		if (_nRemoteAt != null)
+		{
+			_originalRemoteParent ??= _nRemoteAt.GetParent();
+			_nRemoteAt.Reparent(rootBody, keepGlobalTransform: true);
+			_nRemoteAt.Transform = localTrans;
+			_nRemoteAt.Scale = NodeSize;
+		}
 	}
 
 	internal override void DetachFromAssembly()
@@ -289,6 +298,14 @@ public partial class Part : Entity
 
 		OverrideNoMultiMesh = false;
 		Root?.Bridge?.AddPart(this);
+
+		if (_nRemoteAt != null && _originalRemoteParent != null && Node.IsInstanceValid(_originalRemoteParent))
+		{
+			_nRemoteAt.Reparent(_originalRemoteParent, keepGlobalTransform: true);
+			_nRemoteAt.Position = Vector3.Zero;
+			_nRemoteAt.Rotation = Vector3.Zero;
+			_nRemoteAt.Scale = NodeSize;
+		}
 	}
 
 	public override Aabb GetSelfBound()

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -129,6 +129,18 @@ public partial class Physical : Dynamic
 	{
 		bool finalVal = _anchored;
 
+		if (this is Part part && part.Assembly != null)
+		{
+			if (part.Assembly.Root == part)
+			{
+				finalVal = part.Assembly.Anchored;
+			}
+			else
+			{
+				finalVal = true;
+			}
+		}
+
 		if (Root != null && Root.Network != null)
 		{
 			if (Root.SessionType == World.SessionTypeEnum.Creator || !Root.IsLoaded)
@@ -161,7 +173,7 @@ public partial class Physical : Dynamic
 
 		if (!OverridePhysicsProcess)
 		{
-			SetPhysicsProcess(!_anchored);
+			SetPhysicsProcess(!finalVal);
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -264,10 +264,26 @@ public partial class Physical : Dynamic
 	}
 
 	public Physical? PhysicalRoot { get; private set; }
+	internal Physical? AssemblyCollisionRoot { get; private set; }
 
 	internal bool OverrideCanCollide = false;
 	internal bool OverrideCanCollideTo = false;
 	internal bool OverridePhysicsProcess = false;
+
+	internal void SetAssemblyCollisionRoot(Physical? root)
+	{
+		if (AssemblyCollisionRoot == root)
+		{
+			return;
+		}
+
+		AssemblyCollisionRoot = root;
+
+		foreach (CollisionShape3D shape in CollisionShapes.ToArray())
+		{
+			PostCollisionShapeUpdate(shape);
+		}
+	}
 
 	public override void HiddenChanged(bool to)
 	{
@@ -843,6 +859,11 @@ public partial class Physical : Dynamic
 
 	private Node GetCollisionShapeRoot()
 	{
+		if (AssemblyCollisionRoot != null && Node.IsInstanceValid(AssemblyCollisionRoot.GDNode))
+		{
+			return AssemblyCollisionRoot.GDNode;
+		}
+
 		if (PhysicalRoot != null)
 		{
 			return PhysicalRoot.GDNode;

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -1295,6 +1295,14 @@ public partial class Physical : Dynamic
 
 	internal virtual void ApplyAddRelativeTorque(Vector3 torque, ForceModeEnum mode) { throw new NotImplementedException(ClassName + " does not support this force function"); }
 
+	[ScriptMethod]
+	public void AddRelativeForceAtPosition(Vector3 force, Vector3 position, ForceModeEnum mode = ForceModeEnum.Force)
+	{
+		ApplyAddRelativeForceAtPosition(force, position, mode);
+	}
+
+	internal virtual void ApplyAddRelativeForceAtPosition(Vector3 force, Vector3 position, ForceModeEnum mode) { throw new NotImplementedException(ClassName + " does not support this force function"); }
+
 	[ScriptEnum("ForceMode")]
 	public enum ForceModeEnum
 	{

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -187,7 +187,7 @@ public partial class Physical : Dynamic
 	{
 		bool finalVal = _anchored;
 
-		if (this is Part part && part.Assembly != null)
+		if (this is RigidBody part && part.Assembly != null)
 		{
 			if (part.Assembly.Root == part)
 			{

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -991,8 +991,8 @@ public partial class Physical : Dynamic
 	internal void ApplyForceFromPlayer(Vector3 force)
 	{
 		if (Anchored) return;
-		if (this is not Entity) return;
-		((RigidBody3D)GDNode).ApplyCentralImpulse(force);
+		if (this is not Entity e) return;
+		e.ApplyAddForce(force);
 	}
 
 	private void AreaEntered(Area3D area)

--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -4,6 +4,7 @@
 
 using Godot;
 using Polytoria.Attributes;
+using Polytoria.Physics;
 using Polytoria.Utils;
 using System;
 
@@ -22,6 +23,12 @@ public partial class RigidBody : Physical
 	private float _drag;
 	private float _angularDrag;
 	private float _bounciness;
+
+	protected internal WeldAssembly? Assembly { get; protected set; }
+	internal Transform3D AssemblyLocalTransform = Transform3D.Identity;
+
+	protected Node3D _nRemoteAt = null!; // Remote collider proxy
+	protected Node? _originalRemoteParent;
 
 	[Editable, ScriptProperty, SyncVar(Unreliable = true, AllowAuthorWrite = true)]
 	public override Vector3 Velocity
@@ -213,6 +220,11 @@ public partial class RigidBody : Physical
 
 	internal override void ApplyAddForce(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
 	{
+		if (Assembly is not null && Assembly.Root != this)
+		{
+			Assembly.Root.ApplyAddForce(force, mode);
+			return;
+		}
 		if (mode == ForceModeEnum.Force)
 		{
 			GDRigidBody.ApplyCentralForce(force);
@@ -237,6 +249,11 @@ public partial class RigidBody : Physical
 
 	internal override void ApplyAddTorque(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
 	{
+		if (Assembly is not null && Assembly.Root != this)
+		{
+			Assembly.Root.ApplyAddTorque(force, mode);
+			return;
+		}
 		if (mode == ForceModeEnum.Force)
 		{
 			GDRigidBody.ApplyTorque(force);
@@ -261,6 +278,11 @@ public partial class RigidBody : Physical
 
 	internal override void ApplyAddForceAtPosition(Vector3 force, Vector3 position, ForceModeEnum mode = ForceModeEnum.Force)
 	{
+		if (Assembly is not null && Assembly.Root != this)
+		{
+			Assembly.Root.ApplyAddForceAtPosition(force, position, mode);
+			return;
+		}
 		if (mode == ForceModeEnum.Force)
 		{
 			GDRigidBody.ApplyForce(force, position);
@@ -285,6 +307,11 @@ public partial class RigidBody : Physical
 
 	internal override void ApplyAddRelativeForce(Vector3 force, ForceModeEnum mode = ForceModeEnum.Force)
 	{
+		if (Assembly is not null && Assembly.Root != this)
+		{
+			Assembly.Root.ApplyAddRelativeForce(force, mode);
+			return;
+		}
 		Vector3 worldForce = GDRigidBody.GlobalTransform.Basis * force;
 		if (mode == ForceModeEnum.Force)
 		{
@@ -310,6 +337,11 @@ public partial class RigidBody : Physical
 
 	internal override void ApplyAddRelativeTorque(Vector3 torque, ForceModeEnum mode = ForceModeEnum.Force)
 	{
+		if (Assembly is not null && Assembly.Root != this)
+		{
+			Assembly.Root.ApplyAddRelativeTorque(torque, mode);
+			return;
+		}
 		Vector3 worldTorque = GDRigidBody.GlobalTransform.Basis * torque;
 
 		if (mode == ForceModeEnum.Force)
@@ -338,5 +370,90 @@ public partial class RigidBody : Physical
 	{
 		GDRigidBody.Freeze = to;
 		base.ApplyFreeze(to);
+	}
+
+	internal void AttachToAssembly(WeldAssembly ass, RigidBody root, Transform3D localTrans)
+	{
+		Assembly = ass;
+		AssemblyLocalTransform = localTrans;
+
+		if (this != root)
+		{
+			OverridePhysicsProcess = true;
+			SetPhysicsProcess(false);
+			OverrideNetworkTransform = true;
+			AutoUpdateNetTransform = false;
+
+			GDRigidBody.Freeze = true;
+			GDRigidBody.Sleeping = true;
+		}
+
+		Node3D rootBody = root.GDNode3D;
+
+		if (_nRemoteAt != null)
+		{
+			_originalRemoteParent ??= _nRemoteAt.GetParent();
+			_nRemoteAt.Reparent(rootBody, keepGlobalTransform: true);
+			_nRemoteAt.Transform = localTrans;
+			_nRemoteAt.Scale = NodeSize;
+		}
+
+		if (this != root)
+		{
+			SetAssemblyCollisionRoot(root);
+		}
+	}
+
+	internal void DetachFromAssembly()
+	{
+		Transform3D currentTrans;
+		if (Assembly == null)
+		{
+			currentTrans = GDNode3D.GlobalTransform;
+		}
+		else
+		{
+			currentTrans = Assembly.Root.GDNode3D.GlobalTransform * AssemblyLocalTransform;
+		}
+
+		GDNode3D.GlobalTransform = currentTrans;
+		ForceUpdateTransform();
+		UpdateCurrentTransformCache();
+
+		if (_nRemoteAt != null && _originalRemoteParent != null && Node.IsInstanceValid(_originalRemoteParent))
+		{
+			_nRemoteAt.Reparent(_originalRemoteParent, keepGlobalTransform: true);
+			_nRemoteAt.Position = Vector3.Zero;
+			_nRemoteAt.Rotation = Vector3.Zero;
+			_nRemoteAt.Scale = NodeSize;
+		}
+
+		SetAssemblyCollisionRoot(null);
+
+		OverridePhysicsProcess = false;
+		OverrideNetworkTransform = false;
+		AutoUpdateNetTransform = true;
+
+		Assembly = null;
+		AssemblyLocalTransform = Transform3D.Identity;
+
+		_originalRemoteParent = null;
+
+		UpdateFreeze();
+		UpdateCollision();
+	}
+
+	internal bool TryGetAssemblyTransform(out Transform3D trans)
+	{
+		if (Assembly == null || Assembly.Root == this)
+		{
+			trans = default;
+			return false;
+		}
+
+		Transform3D rootBody = Assembly.Root.GDNode3D.GlobalTransform;
+		trans = rootBody * AssemblyLocalTransform * Transform3D.Identity.Scaled(NodeSize);
+
+		return true;
 	}
 }

--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -372,7 +372,7 @@ public partial class RigidBody : Physical
 		base.ApplyFreeze(to);
 	}
 
-	internal void AttachToAssembly(WeldAssembly ass, RigidBody root, Transform3D localTrans)
+	internal virtual void AttachToAssembly(WeldAssembly ass, RigidBody root, Transform3D localTrans)
 	{
 		Assembly = ass;
 		AssemblyLocalTransform = localTrans;
@@ -404,7 +404,7 @@ public partial class RigidBody : Physical
 		}
 	}
 
-	internal void DetachFromAssembly()
+	internal virtual void DetachFromAssembly()
 	{
 		Transform3D currentTrans;
 		if (Assembly == null)

--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -413,6 +413,14 @@ public partial class RigidBody : Physical
 
 	internal virtual void DetachFromAssembly()
 	{
+		foreach (Instance desc in GetDescendants())
+		{
+			if (desc is Part p)
+			{
+				p.DetachVisualFromAssembly();
+			}
+		}
+
 		Transform3D currentTrans;
 		if (Assembly == null)
 		{
@@ -441,14 +449,6 @@ public partial class RigidBody : Physical
 
 		UpdateFreeze();
 		UpdateCollision();
-
-		foreach (Instance desc in GetDescendants())
-		{
-			if (desc is Part p)
-			{
-				p.DetachVisualFromAssembly();
-			}
-		}
 	}
 
 	internal bool TryGetAssemblyTransform(out Transform3D trans)

--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -395,6 +395,7 @@ public partial class RigidBody : Physical
 
 			GDRigidBody.Freeze = true;
 			GDRigidBody.Sleeping = true;
+			GDNode.Reparent(root.GDNode, keepGlobalTransform: true);
 		}
 
 		Node3D rootBody = root.GDNode3D;
@@ -426,6 +427,7 @@ public partial class RigidBody : Physical
 		}
 
 		GDNode3D.GlobalTransform = currentTrans;
+		GDNode.Reparent(Parent.GDNode, keepGlobalTransform: true);
 		ForceUpdateTransform();
 		UpdateCurrentTransformCache();
 

--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -27,7 +27,6 @@ public partial class RigidBody : Physical
 	protected internal WeldAssembly? Assembly { get; protected set; }
 	internal Transform3D AssemblyLocalTransform = Transform3D.Identity;
 
-	protected Node3D _nRemoteAt = null!; // Remote collider proxy
 	protected Node? _originalRemoteParent;
 
 	[Editable, ScriptProperty, SyncVar(Unreliable = true, AllowAuthorWrite = true)]
@@ -392,6 +391,7 @@ public partial class RigidBody : Physical
 			SetPhysicsProcess(false);
 			OverrideNetworkTransform = true;
 			AutoUpdateNetTransform = false;
+			SetAssemblyCollisionRoot(root);
 
 			GDRigidBody.Freeze = true;
 			GDRigidBody.Sleeping = true;
@@ -400,18 +400,7 @@ public partial class RigidBody : Physical
 
 		Node3D rootBody = root.GDNode3D;
 
-		if (_nRemoteAt != null)
-		{
-			_originalRemoteParent ??= _nRemoteAt.GetParent();
-			_nRemoteAt.Reparent(rootBody, keepGlobalTransform: true);
-			_nRemoteAt.Transform = localTrans;
-			_nRemoteAt.Scale = NodeSize;
-		}
-
-		if (this != root)
-		{
-			SetAssemblyCollisionRoot(root);
-		}
+		UpdateFreeze();
 	}
 
 	internal virtual void DetachFromAssembly()
@@ -430,14 +419,6 @@ public partial class RigidBody : Physical
 		GDNode.Reparent(Parent.GDNode, keepGlobalTransform: true);
 		ForceUpdateTransform();
 		UpdateCurrentTransformCache();
-
-		if (_nRemoteAt != null && _originalRemoteParent != null && Node.IsInstanceValid(_originalRemoteParent))
-		{
-			_nRemoteAt.Reparent(_originalRemoteParent, keepGlobalTransform: true);
-			_nRemoteAt.Position = Vector3.Zero;
-			_nRemoteAt.Rotation = Vector3.Zero;
-			_nRemoteAt.Scale = NodeSize;
-		}
 
 		SetAssemblyCollisionRoot(null);
 

--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -400,6 +400,14 @@ public partial class RigidBody : Physical
 
 		Node3D rootBody = root.GDNode3D;
 
+		foreach (Instance desc in GetDescendants())
+		{
+			if (desc is Part p)
+			{
+				p.AttachVisualToAssembly(root, localTrans * p.GDNode3D.Transform);
+			}
+		}
+
 		UpdateFreeze();
 	}
 
@@ -433,6 +441,14 @@ public partial class RigidBody : Physical
 
 		UpdateFreeze();
 		UpdateCollision();
+
+		foreach (Instance desc in GetDescendants())
+		{
+			if (desc is Part p)
+			{
+				p.DetachVisualFromAssembly();
+			}
+		}
 	}
 
 	internal bool TryGetAssemblyTransform(out Transform3D trans)

--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -197,6 +197,9 @@ public partial class RigidBody : Physical
 		}
 	}
 
+	[ScriptProperty]
+	public RigidBody AssemblyRoot => Assembly is null ? this : Assembly.Root;
+
 	public override Node CreateGDNode()
 	{
 		return new RigidBody3D();
@@ -222,7 +225,7 @@ public partial class RigidBody : Physical
 	{
 		if (Assembly is not null && Assembly.Root != this)
 		{
-			Assembly.Root.ApplyAddForce(force, mode);
+			Assembly.Root.ApplyAddForceAtPosition(force, Position, mode);
 			return;
 		}
 		if (mode == ForceModeEnum.Force)
@@ -364,6 +367,12 @@ public partial class RigidBody : Physical
 		{
 			throw new NotImplementedException(mode + " not implemented");
 		}
+	}
+
+	internal override void ApplyAddRelativeForceAtPosition(Vector3 force, Vector3 position, ForceModeEnum mode = ForceModeEnum.Force)
+	{
+		Vector3 worldForce = GDRigidBody.GlobalTransform.Basis * force;
+		ApplyAddForceAtPosition(worldForce, position, mode);
 	}
 
 	protected override void ApplyFreeze(bool to)

--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -19,6 +19,7 @@ public partial class Weld : Instance
 	private Part? _registered1;
 
 	private bool _refreshQueued;
+	private bool _waitQueued;
 
 	[Editable, ScriptProperty]
 	public Instance? Part0
@@ -147,6 +148,18 @@ public partial class Weld : Instance
 
 		if (Root == null) return false;
 
+		if (Root.SessionType != World.SessionTypeEnum.Creator && !Root.IsLoaded)
+		{
+			WaitForLoad();
+			return false;
+		}
+
+		if (Root.Network != null && Root.SessionType == World.SessionTypeEnum.Client && !Root.Network.IsServer && !Root.Network.IsTransformReplicateDone)
+		{
+			QueueRefresh();
+			return false;
+		}
+
 		if (!IsPropReady)
 		{
 			QueueRefresh();
@@ -185,5 +198,21 @@ public partial class Weld : Instance
 			_refreshQueued = false;
 			RefreshRegistration();
 		}).CallDeferred();
+	}
+
+
+	private void WaitForLoad()
+	{
+		if (_waitQueued) return;
+		_waitQueued = true;
+
+		Root.Loaded.Once(() =>
+		{
+			Callable.From(() =>
+			{
+				_waitQueued = false;
+				RefreshRegistration();
+			}).CallDeferred();
+		});
 	}
 }

--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -15,8 +15,8 @@ public partial class Weld : Instance
 	private Instance? _part0;
 	private Instance? _part1;
 
-	private Part? _registered0;
-	private Part? _registered1;
+	private RigidBody? _registered0;
+	private RigidBody? _registered1;
 
 	private bool _refreshQueued;
 	private bool _waitQueued;
@@ -98,13 +98,13 @@ public partial class Weld : Instance
 
 	private void RefreshRegistration()
 	{
-		Part? active0 = null;
-		Part? active1 = null;
+		RigidBody? active0 = null;
+		RigidBody? active1 = null;
 
 		if (IsActiveWeld())
 		{
-			active0 = _part0 as Part;
-			active1 = _part1 as Part;
+			active0 = _part0 as RigidBody;
+			active1 = _part1 as RigidBody;
 		}
 
 		if (_registered0 == active0 && _registered1 == active1)
@@ -131,8 +131,8 @@ public partial class Weld : Instance
 			return;
 		}
 
-		Part old0 = _registered0;
-		Part old1 = _registered1;
+		RigidBody old0 = _registered0;
+		RigidBody old1 = _registered1;
 
 		_registered0 = null;
 		_registered1 = null;
@@ -166,8 +166,8 @@ public partial class Weld : Instance
 			return false;
 		}
 
-		if (_part0 is not Part p0) return false;
-		if (_part1 is not Part p1) return false;
+		if (_part0 is not RigidBody p0) return false;
+		if (_part1 is not RigidBody p1) return false;
 		if (p0 == p1) return false;
 
 		if (!p0.IsPropReady || !p1.IsPropReady)

--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -15,6 +15,9 @@ public partial class Weld : Instance
 	Instance? _part0;
 	Instance? _part1;
 
+	Part? _registered0;
+	Part? _registered1;
+
 	[Editable, ScriptProperty]
 	public Instance? Part0
 	{
@@ -24,13 +27,10 @@ public partial class Weld : Instance
 			if (_part0 == value) return;
 			if (value != null && value == _part1) return;
 
-			Part? old0 = _part0 as Part;
-			Part? old1 = _part1 as Part;
-
 			_part0 = value;
 			OnPropertyChanged();
 
-			WeldAssemblyManager.OnWeldChanged(this, old0, old1, _part0 as Part, _part1 as Part);
+			RefreshRegistration();
 		}
 	}
 
@@ -43,13 +43,10 @@ public partial class Weld : Instance
 			if (_part1 == value) return;
 			if (value != null && value == _part0) return;
 
-			Part? old0 = _part0 as Part;
-			Part? old1 = _part1 as Part;
-
 			_part1 = value;
 			OnPropertyChanged();
 
-			WeldAssemblyManager.OnWeldChanged(this, old0, old1, _part0 as Part, _part1 as Part);
+			RefreshRegistration();
 		}
 	}
 
@@ -62,7 +59,7 @@ public partial class Weld : Instance
 		OnPropertyChanged(nameof(Part0));
 		OnPropertyChanged(nameof(Part1));
 
-		WeldAssemblyManager.OnWeldRemoved(this);
+		RefreshRegistration();
 	}
 
 	public override void EnterTree()
@@ -72,20 +69,81 @@ public partial class Weld : Instance
 		if (_part0 == null && Parent is Physical)
 		{
 			_part0 = Parent;
+			OnPropertyChanged(nameof(Part0));
 		}
 
-		WeldAssemblyManager.OnWeldChanged(this, null, null, _part0 as Part, _part1 as Part);
+		RefreshRegistration();
+	}
+
+	public override void PostReparent()
+	{
+		base.PostReparent();
+		RefreshRegistration();
 	}
 
 	public override void PreDelete()
 	{
-		WeldAssemblyManager.OnWeldRemoved(this);
+		Unregister();
 		base.PreDelete();
 	}
 
-	public override void ExitTree()
+	void RefreshRegistration()
 	{
-		WeldAssemblyManager.OnWeldRemoved(this);
-		base.ExitTree();
+		Part? active0 = null;
+		Part? active1 = null;
+
+		if (IsActiveWeld())
+		{
+			active0 = _part0 as Part;
+			active1 = _part1 as Part;
+		}
+
+		if (_registered0 == active0 && _registered1 == active1)
+		{
+			return;
+		}
+
+		Unregister();
+
+		if (active0 != null && active1 != null)
+		{
+			_registered0 = active0;
+			_registered1 = active1;
+			WeldAssemblyManager.OnWeldAdded(this, active0, active1);
+		}
+	}
+
+	void Unregister()
+	{
+		if (_registered0 == null || _registered1 == null)
+		{
+			_registered0 = null;
+			_registered1 = null;
+			return;
+		}
+
+		Part old0 = _registered0;
+		Part old1 = _registered1;
+
+		_registered0 = null;
+		_registered1 = null;
+
+		WeldAssemblyManager.OnWeldRemoved(this, old0, old1);
+	}
+
+	bool IsActiveWeld()
+	{
+		if (IsDeleted) return false;
+		if (Parent == null) return false;
+		if (IsInTemporary) return false;
+
+		if (_part0 is not Part p0) return false;
+		if (_part1 is not Part p1) return false;
+		if (p0 == p1) return false;
+
+		if (p0.IsDeleted || p1.IsDeleted) return false;
+		if (p0.IsInTemporary || p1.IsInTemporary) return false;
+
+		return true;
 	}
 }

--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -19,7 +19,6 @@ public partial class Weld : Instance
 	private Part? _registered1;
 
 	private bool _refreshQueued;
-	private bool _refreshLoadQueued;
 
 	[Editable, ScriptProperty]
 	public Instance? Part0
@@ -147,16 +146,28 @@ public partial class Weld : Instance
 		if (IsInTemporary) return false;
 
 		if (Root == null) return false;
-		
-		if (!Root.IsLoaded)
+
+		if (!IsPropReady)
 		{
-			RefreshOnLoad();
+			QueueRefresh();
 			return false;
 		}
 
 		if (_part0 is not Part p0) return false;
 		if (_part1 is not Part p1) return false;
 		if (p0 == p1) return false;
+
+		if (!p0.IsPropReady || !p1.IsPropReady)
+		{
+			QueueRefresh();
+			return false;
+		}
+
+		if (!p0.GDNode3D.IsInsideTree() || !p1.GDNode3D.IsInsideTree())
+		{
+			QueueRefresh();
+			return false;
+		}
 
 		if (p0.IsDeleted || p1.IsDeleted) return false;
 		if (p0.IsInTemporary || p1.IsInTemporary) return false;
@@ -174,19 +185,5 @@ public partial class Weld : Instance
 			_refreshQueued = false;
 			RefreshRegistration();
 		}).CallDeferred();
-	}
-
-	private void RefreshOnLoad()
-	{
-		if (_refreshLoadQueued) return;
-		if (Root == null) return;
-
-		_refreshLoadQueued = true;
-		
-		Root.Loaded.Once(() =>
-		{
-			_refreshLoadQueued = false;
-			QueueRefresh();
-		});
 	}
 }

--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using Godot;
 using Polytoria.Attributes;
+using Polytoria.Physics;
 
 namespace Polytoria.Datamodel;
 
@@ -22,8 +23,14 @@ public partial class Weld : Instance
 		{
 			if (_part0 == value) return;
 			if (value != null && value == _part1) return;
+
+			Part? old0 = _part0 as Part;
+			Part? old1 = _part1 as Part;
+
 			_part0 = value;
 			OnPropertyChanged();
+
+			WeldAssemblyManager.OnWeldChanged(this, old0, old1, _part0 as Part, _part1 as Part);
 		}
 	}
 
@@ -35,16 +42,30 @@ public partial class Weld : Instance
 		{
 			if (_part1 == value) return;
 			if (value != null && value == _part0) return;
+
+			Part? old0 = _part0 as Part;
+			Part? old1 = _part1 as Part;
+
 			_part1 = value;
 			OnPropertyChanged();
+
+			WeldAssemblyManager.OnWeldChanged(this, old0, old1, _part0 as Part, _part1 as Part);
 		}
 	}
 
 	[ScriptMethod]
 	public void Break()
 	{
-		Part0 = null;
-		Part1 = null;
+		Part? old0 = _part0 as Part;
+		Part? old1 = _part1 as Part;
+
+		_part0 = null;
+		_part1 = null;
+
+		OnPropertyChanged(nameof(Part0));
+		OnPropertyChanged(nameof(Part1));
+
+		WeldAssemblyManager.OnWeldRemoved(this, old0, old1);
 	}
 
 	public override void EnterTree()
@@ -55,5 +76,11 @@ public partial class Weld : Instance
 		{
 			Part0 = Parent;
 		}
+	}
+
+	public override void PreDelete()
+	{
+		Break();
+		base.PreDelete();
 	}
 }

--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -11,25 +11,8 @@ namespace Polytoria.Datamodel;
 [Instantiable]
 public partial class Weld : Instance
 {
-	static readonly Dictionary<Instance, List<Weld>> _connections = new();
-	static readonly Dictionary<Instance, System.Action> _handlers = new();
-
 	Instance? _part0;
 	Instance? _part1;
-	Transform3D _c0 = Transform3D.Identity;
-	Transform3D _c1 = Transform3D.Identity;
-	bool _enabled = true;
-	bool _needsRebuild;
-	Generic6DofJoint3D? _joint;
-
-	public static IEnumerable<Weld> GetWeldsFor(Instance part)
-	{
-		if (part == null || part.IsDeleted)
-			return System.Array.Empty<Weld>();
-		if (_connections.TryGetValue(part, out List<Weld>? list))
-			return list.ToArray();
-		return System.Array.Empty<Weld>();
-	}
 
 	[Editable, ScriptProperty]
 	public Instance? Part0
@@ -39,11 +22,8 @@ public partial class Weld : Instance
 		{
 			if (_part0 == value) return;
 			if (value != null && value == _part1) return;
-			Unregister(_part0);
 			_part0 = value;
-			Register(_part0);
 			OnPropertyChanged();
-			RequestRebuild();
 		}
 	}
 
@@ -55,57 +35,14 @@ public partial class Weld : Instance
 		{
 			if (_part1 == value) return;
 			if (value != null && value == _part0) return;
-			Unregister(_part1);
 			_part1 = value;
-			Register(_part1);
 			OnPropertyChanged();
-			RequestRebuild();
-		}
-	}
-
-	[SyncVar, ScriptProperty]
-	public Transform3D C0
-	{
-		get => _c0;
-		set
-		{
-			if (_c0 == value) return;
-			_c0 = value;
-			OnPropertyChanged();
-			RequestRebuild();
-		}
-	}
-
-	[SyncVar, ScriptProperty]
-	public Transform3D C1
-	{
-		get => _c1;
-		set
-		{
-			if (_c1 == value) return;
-			_c1 = value;
-			OnPropertyChanged();
-			RequestRebuild();
-		}
-	}
-
-	[Editable, ScriptProperty, DefaultValue(true)]
-	public bool Enabled
-	{
-		get => _enabled;
-		set
-		{
-			if (_enabled == value) return;
-			_enabled = value;
-			OnPropertyChanged();
-			RequestRebuild();
 		}
 	}
 
 	[ScriptMethod]
 	public void Break()
 	{
-		Enabled = false;
 		Part0 = null;
 		Part1 = null;
 	}
@@ -117,193 +54,6 @@ public partial class Weld : Instance
 		if (_part0 == null && Parent is Physical)
 		{
 			Part0 = Parent;
-		}
-
-		if (_needsRebuild)
-		{
-			RebuildJoint();
-		}
-	}
-
-	public override void ExitTree()
-	{
-		DestroyJoint();
-		_needsRebuild = true;
-		base.ExitTree();
-	}
-
-	public override void PreDelete()
-	{
-		DestroyJoint();
-		Unregister(_part0);
-		Unregister(_part1);
-		base.PreDelete();
-	}
-
-
-	void Register(Instance? part)
-	{
-		if (part == null || part.IsDeleted) return;
-		if (!_connections.TryGetValue(part, out List<Weld>? list))
-		{
-			list = new List<Weld>();
-			_connections[part] = list;
-			System.Action handler = () => OnPartDeleted(part);
-			part.Deleted += handler;
-			_handlers[part] = handler;
-		}
-		if (!list.Contains(this))
-			list.Add(this);
-	}
-
-	void Unregister(Instance? part)
-	{
-		if (part == null) return;
-		if (_connections.TryGetValue(part, out List<Weld>? list))
-		{
-			list.Remove(this);
-			if (list.Count == 0)
-			{
-				_connections.Remove(part);
-				if (_handlers.TryGetValue(part, out var handler))
-				{
-					part.Deleted -= handler;
-					_handlers.Remove(part);
-				}
-			}
-		}
-	}
-
-	static void OnPartDeleted(Instance part)
-	{
-		if (_handlers.TryGetValue(part, out var handler))
-		{
-			part.Deleted -= handler;
-			_handlers.Remove(part);
-		}
-
-		if (_connections.TryGetValue(part, out var list))
-		{
-			foreach (var weld in list.ToArray())
-			{
-				var other = weld._part0 == part ? weld._part1 : weld._part0;
-				if (other != null && _connections.TryGetValue(other, out var otherList))
-				{
-					otherList.Remove(weld);
-					if (otherList.Count == 0)
-					{
-						_connections.Remove(other);
-						if (_handlers.TryGetValue(other, out var otherHandler))
-						{
-							other.Deleted -= otherHandler;
-							_handlers.Remove(other);
-						}
-					}
-				}
-
-				weld._enabled = false;
-				weld._part0 = null;
-				weld._part1 = null;
-				weld.DestroyJoint();
-			}
-			_connections.Remove(part);
-		}
-	}
-
-	void RequestRebuild()
-	{
-		if (GDNode.IsInsideTree())
-		{
-			RebuildJoint();
-		}
-		else
-		{
-			_needsRebuild = true;
-		}
-	}
-
-	void RebuildJoint()
-	{
-		_needsRebuild = false;
-		DestroyJoint();
-
-		if (!_enabled) return;
-		if (_part0 == null || _part1 == null) return;
-		if (_part0 == _part1) return;
-		if (_part0.IsDeleted || _part1.IsDeleted) return;
-		if (_part0 is not Dynamic dyn0 || _part1 is not Dynamic dyn1) return;
-
-		Node3D node0 = dyn0.GDNode3D;
-		Node3D node1 = dyn1.GDNode3D;
-
-		if (node0 == null || node1 == null) return;
-		if (!node0.IsInsideTree() || !node1.IsInsideTree())
-		{
-			_needsRebuild = true;
-			return;
-		}
-
-		if (node0 is not PhysicsBody3D body0 || node1 is not PhysicsBody3D body1) return;
-
-		Transform3D part0Transform = node0.GlobalTransform;
-		TryAutoComputeC0(part0Transform, node1.GlobalTransform);
-
-		Transform3D targetPart1 = part0Transform * _c0 * _c1.AffineInverse();
-
-		Vector3 part1Size = dyn1.Size;
-		dyn1.SetGlobalTransform(new Transform3D(
-			targetPart1.Basis.Orthonormalized().Scaled(part1Size),
-			targetPart1.Origin));
-
-		_joint = new Generic6DofJoint3D();
-		GDNode.AddChild(_joint);
-		_joint.GlobalTransform = part0Transform * _c0;
-		_joint.NodeA = body0.GetPath();
-		_joint.NodeB = body1.GetPath();
-
-		LockLinearAxis("linear_limit_x");
-		LockLinearAxis("linear_limit_y");
-		LockLinearAxis("linear_limit_z");
-		LockAngularAxis("angular_limit_x");
-		LockAngularAxis("angular_limit_y");
-		LockAngularAxis("angular_limit_z");
-	}
-
-	void TryAutoComputeC0(Transform3D part0Transform, Transform3D part1Transform)
-	{
-		if (_c0 == Transform3D.Identity && _c1 == Transform3D.Identity)
-		{
-			_c0 = part0Transform.AffineInverse() * part1Transform;
-			OnPropertyChanged("C0");
-		}
-	}
-
-	void LockLinearAxis(string axis)
-	{
-		if (_joint == null) return;
-		_joint.Set($"{axis}/enabled", true);
-		_joint.Set($"{axis}/lower_distance", 0f);
-		_joint.Set($"{axis}/upper_distance", 0f);
-	}
-
-	void LockAngularAxis(string axis)
-	{
-		if (_joint == null) return;
-		_joint.Set($"{axis}/enabled", true);
-		_joint.Set($"{axis}/lower_angle", 0f);
-		_joint.Set($"{axis}/upper_angle", 0f);
-	}
-
-	void DestroyJoint()
-	{
-		if (_joint != null)
-		{
-			if (Node.IsInstanceValid(_joint))
-			{
-				_joint.QueueFree();
-			}
-
-			_joint = null;
 		}
 	}
 }

--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -12,11 +12,14 @@ namespace Polytoria.Datamodel;
 [Instantiable]
 public partial class Weld : Instance
 {
-	Instance? _part0;
-	Instance? _part1;
+	private Instance? _part0;
+	private Instance? _part1;
 
-	Part? _registered0;
-	Part? _registered1;
+	private Part? _registered0;
+	private Part? _registered1;
+
+	private bool _refreshQueued;
+	private bool _refreshLoadQueued;
 
 	[Editable, ScriptProperty]
 	public Instance? Part0
@@ -87,7 +90,13 @@ public partial class Weld : Instance
 		base.PreDelete();
 	}
 
-	void RefreshRegistration()
+	public override void Ready()
+	{
+		base.Ready();
+		QueueRefresh();
+	}
+
+	private void RefreshRegistration()
 	{
 		Part? active0 = null;
 		Part? active1 = null;
@@ -113,7 +122,7 @@ public partial class Weld : Instance
 		}
 	}
 
-	void Unregister()
+	private void Unregister()
 	{
 		if (_registered0 == null || _registered1 == null)
 		{
@@ -131,11 +140,19 @@ public partial class Weld : Instance
 		WeldAssemblyManager.OnWeldRemoved(this, old0, old1);
 	}
 
-	bool IsActiveWeld()
+	private bool IsActiveWeld()
 	{
 		if (IsDeleted) return false;
 		if (Parent == null) return false;
 		if (IsInTemporary) return false;
+
+		if (Root == null) return false;
+		
+		if (!Root.IsLoaded)
+		{
+			RefreshOnLoad();
+			return false;
+		}
 
 		if (_part0 is not Part p0) return false;
 		if (_part1 is not Part p1) return false;
@@ -145,5 +162,31 @@ public partial class Weld : Instance
 		if (p0.IsInTemporary || p1.IsInTemporary) return false;
 
 		return true;
+	}
+
+	private void QueueRefresh()
+	{
+		if (_refreshQueued) return;
+		_refreshQueued = true;
+
+		Callable.From(() =>
+		{
+			_refreshQueued = false;
+			RefreshRegistration();
+		}).CallDeferred();
+	}
+
+	private void RefreshOnLoad()
+	{
+		if (_refreshLoadQueued) return;
+		if (Root == null) return;
+
+		_refreshLoadQueued = true;
+		
+		Root.Loaded.Once(() =>
+		{
+			_refreshLoadQueued = false;
+			QueueRefresh();
+		});
 	}
 }

--- a/Polytoria/scripts/datamodel/Weld.cs
+++ b/Polytoria/scripts/datamodel/Weld.cs
@@ -56,16 +56,13 @@ public partial class Weld : Instance
 	[ScriptMethod]
 	public void Break()
 	{
-		Part? old0 = _part0 as Part;
-		Part? old1 = _part1 as Part;
-
 		_part0 = null;
 		_part1 = null;
 
 		OnPropertyChanged(nameof(Part0));
 		OnPropertyChanged(nameof(Part1));
 
-		WeldAssemblyManager.OnWeldRemoved(this, old0, old1);
+		WeldAssemblyManager.OnWeldRemoved(this);
 	}
 
 	public override void EnterTree()
@@ -74,13 +71,21 @@ public partial class Weld : Instance
 
 		if (_part0 == null && Parent is Physical)
 		{
-			Part0 = Parent;
+			_part0 = Parent;
 		}
+
+		WeldAssemblyManager.OnWeldChanged(this, null, null, _part0 as Part, _part1 as Part);
 	}
 
 	public override void PreDelete()
 	{
-		Break();
+		WeldAssemblyManager.OnWeldRemoved(this);
 		base.PreDelete();
+	}
+
+	public override void ExitTree()
+	{
+		WeldAssemblyManager.OnWeldRemoved(this);
+		base.ExitTree();
 	}
 }

--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -127,7 +127,7 @@ public partial class NetworkTransformSync : Instance
 		// Check if self has the network authority
 		if (!CheckDynAuthor(dyn, NetService.LocalPeerID)) return;
 
-		if (dyn is Part part && part.Assembly != null && part.Assembly.Physicalized && part.Assembly.Root != part)
+		if (dyn is RigidBody part && part.Assembly != null && part.Assembly.Physicalized && part.Assembly.Root != part)
 		{
 			return;
 		}
@@ -224,7 +224,7 @@ public partial class NetworkTransformSync : Instance
 	{
 		if (!NetService.IsServer) return;
 		if (!dyn.IsNetworkReady) return;
-		if (dyn is Part part && part.Assembly != null && part.Assembly.Physicalized && part.Assembly.Root != part)
+		if (dyn is RigidBody part && part.Assembly != null && part.Assembly.Physicalized && part.Assembly.Root != part)
 		{
 			return;
 		}

--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -90,7 +90,7 @@ public partial class NetworkTransformSync : Instance
 				data.Add(new()
 				{
 					NetID = dyn.NetworkedObjectID,
-					Value = TransformPayloadDto.ToArray(dyn.GetLocalTransform())
+					Value = TransformPayloadDto.ToArray(dyn.GetReplicationLocalTransform())
 				});
 			}
 		}
@@ -126,6 +126,11 @@ public partial class NetworkTransformSync : Instance
 
 		// Check if self has the network authority
 		if (!CheckDynAuthor(dyn, NetService.LocalPeerID)) return;
+
+		if (dyn is Part part && part.Assembly != null && part.Assembly.Physicalized && part.Assembly.Root != part)
+		{
+			return;
+		}
 
 		TransformPayloadDto payload = TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform());
 		string objID = dyn.NetworkedObjectID;
@@ -219,6 +224,11 @@ public partial class NetworkTransformSync : Instance
 	{
 		if (!NetService.IsServer) return;
 		if (!dyn.IsNetworkReady) return;
+		if (dyn is Part part && part.Assembly != null && part.Assembly.Physicalized && part.Assembly.Root != part)
+		{
+			return;
+		}
+
 		string objID = dyn.NetworkedObjectID;
 
 		SetPendingBatch(objID, new(dyn, TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform()), lerpTransform, excludePeer)

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -13,11 +13,16 @@ public class WeldAssembly
 	public Dictionary<Part, Transform3D> LocalTransforms = [];
 	public bool Anchored;
 
+	internal bool Physicalized; // Set to false in creator to let creators manipulate parts in weld assemblies, physics dont apply there anyways
+
 	internal void Destroy()
 	{
-		foreach (Part part in Parts)
-		{
-			part.DetachFromAssembly();
+		if (Physicalized)
+		{	
+			foreach (Part part in Parts)
+			{
+				part.DetachFromAssembly();
+			}
 		}
 
 		Parts.Clear();
@@ -104,17 +109,31 @@ public class WeldAssembly
 			Anchored = hasAnchoreds
 		};
 
+		// in creator we dont want to reparent everything since it will block them from selecting anything other than the root part
+		bool isCreator = root.Root != null && root.Root.SessionType == World.SessionTypeEnum.Creator;
+
 		Color color = (Color)PTColor.Random().ToGDClass(); // random color for debugging
+		Transform3D rootInv = root.GDNode3D.GlobalTransform.AffineInverse();
 
 		// unfortunately we have to loop through the parts again to set up the assembly after root was picked
 		foreach (Part part in parts)
 		{
-			Transform3D localTrans = root.GDNode3D.GlobalTransform.AffineInverse() * part.GDNode3D.GlobalTransform;
+			Transform3D localTrans = rootInv * part.GDNode3D.GlobalTransform;
 			assembly.LocalTransforms[part] = localTrans;
-			part.AttachToAssembly(assembly, root, localTrans);
 			part.Color = color; // debug
+
+			if (!isCreator)
+			{
+				part.AttachToAssembly(assembly, root, localTrans);
+			}
 		}
 
+		if (isCreator)
+		{
+			return assembly;
+		}
+
+		assembly.Physicalized = true;
 		root.GDRigidBody.Mass = totalMass;
 		root.GDRigidBody.Freeze = assembly.Anchored;
 		root.OverridePhysicsProcess = assembly.Anchored;

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -8,9 +8,9 @@ namespace Polytoria.Physics;
 
 public class WeldAssembly
 {
-	public Part Root = null!;
-	public HashSet<Part> Parts = [];
-	public Dictionary<Part, Transform3D> LocalTransforms = [];
+	public RigidBody Root = null!;
+	public HashSet<RigidBody> Parts = [];
+	public Dictionary<RigidBody, Transform3D> LocalTransforms = [];
 	public bool Anchored;
 
 	internal bool Physicalized; // Set to false in creator to let creators manipulate parts in weld assemblies, physics dont apply there anyways
@@ -19,7 +19,7 @@ public class WeldAssembly
 	{
 		if (Physicalized)
 		{
-			foreach (Part part in Parts)
+			foreach (RigidBody part in Parts)
 			{
 				part.DetachFromAssembly();
 			}
@@ -29,7 +29,7 @@ public class WeldAssembly
 		LocalTransforms.Clear();
 	}
 
-	private static bool IsBetterRootCandidate(Part candidate, Part? current, Part? preferredRoot)
+	private static bool IsBetterRootCandidate(RigidBody candidate, RigidBody? current, RigidBody? preferredRoot)
 	{
 		if (current == null)
 			return true;
@@ -49,20 +49,20 @@ public class WeldAssembly
 		return string.CompareOrdinal(candidate.NetworkedObjectID, current.NetworkedObjectID) < 0;
 	}
 
-	public static WeldAssembly Build(HashSet<Part> parts, Part? preferredRoot)
+	public static WeldAssembly Build(HashSet<RigidBody> parts, RigidBody? preferredRoot)
 	{
 		if (parts.Count == 0)
 		{
 			throw new System.ArgumentException("Empty part set given");
 		}
 
-		Part? root = null;
+		RigidBody? root = null;
 		float totalMass = 0;
 		bool hasAnchoreds = false;
 
 		// parts are picked in this order: preferred -> anchored -> largest mass -> lowest network id
 		// try to do as many checks as possible in one loop to avoid looping multiple times
-		foreach (Part part in parts)
+		foreach (RigidBody part in parts)
 		{
 			hasAnchoreds |= part.Anchored;
 			totalMass += Mathf.Max(part.Mass, Physical.MinMass);
@@ -85,7 +85,7 @@ public class WeldAssembly
 		// in creator we dont want to reparent everything since it will block them from selecting anything other than the root part
 		bool isCreator = root.Root != null && root.Root.SessionType == World.SessionTypeEnum.Creator;
 
-		foreach (Part part in parts)
+		foreach (RigidBody part in parts)
 		{
 			part.ForceUpdateTransform();
 		}
@@ -93,7 +93,7 @@ public class WeldAssembly
 		Transform3D rootInv = root.GDNode3D.GlobalTransform.AffineInverse();
 
 		// unfortunately we have to loop through the parts again to set up the assembly after root was picked
-		foreach (Part part in parts)
+		foreach (RigidBody part in parts)
 		{
 			Transform3D localTrans = rootInv * part.GDNode3D.GlobalTransform;
 			assembly.LocalTransforms[part] = localTrans;
@@ -111,7 +111,7 @@ public class WeldAssembly
 
 		assembly.Physicalized = true;
 		root.GDRigidBody.Mass = totalMass;
-		foreach (Part part in parts)
+		foreach (RigidBody part in parts)
 		{
 			part.UpdateFreeze();
 		}

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -14,7 +14,7 @@ public class WeldAssembly
 
 	internal void Destroy()
 	{
-		foreach (Part part in Parts.ToArray())
+		foreach (Part part in Parts)
 		{
 			part.DetachFromAssembly();
 		}
@@ -30,17 +30,18 @@ public class WeldAssembly
 			throw new System.ArgumentException("Empty part set given");
 		}
 
-		Part? root = null;
+		Part? root;
 		float totalMass = 0;
 		bool hasAnchoreds = false;
 
-		// parts are picked in this order: preferred -> anchored -> largest mass -> first in set
+		// parts are picked in this order: preferred -> anchored -> largest mass -> lowest network id
 		// try to do as many checks as possible in one loop to avoid looping multiple times
 		{
 			// keep these variables scoped
 			Part? anchored = null;
 			Part? largestMass = null;
 			Part? first = null;
+			Part? lowestNetID = null;
 			float largestMassValue = float.MinValue;
 
 			foreach (Part part in parts)
@@ -62,7 +63,12 @@ public class WeldAssembly
 					largestMassValue = part.Mass;
 				}
 
-				totalMass += part.Mass;
+				if (lowestNetID == null || part.NetworkedObjectID.Hash() < lowestNetID.NetworkedObjectID.Hash())
+				{
+					lowestNetID = part;
+				}
+
+				totalMass += Mathf.Max(part.Mass, Physical.MinMass);
 			}
 
 			if (preferredRoot != null && parts.Contains(preferredRoot)) // .contains is fine here since it's .Contains is O(1) on a hashset
@@ -79,7 +85,7 @@ public class WeldAssembly
 			}
 			else
 			{
-				root = first!;
+				root = lowestNetID!;
 			}
 		}
 
@@ -98,7 +104,7 @@ public class WeldAssembly
 			part.AttachToAssembly(assembly, root, localTrans);
 		}
 
-		root.GDRigidBody.Mass = Mathf.Max(totalMass, Physical.MinMass);
+		root.GDRigidBody.Mass = totalMass;
 		root.GDRigidBody.Freeze = assembly.Anchored;
 		root.OverridePhysicsProcess = assembly.Anchored;
 

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -75,13 +75,6 @@ public class WeldAssembly
 
 		root ??= preferredRoot ?? throw new System.ArgumentException("Empty part set given");
 
-		GD.Print($"[WeldAssembly] root={root.Name} id={root.NetworkedObjectID} pos={root.Position} loaded={root.Root.IsLoaded} session={root.Root.SessionType}");
-
-		foreach (Part part in parts)
-		{
-			GD.Print($"  part={part.Name} id={part.NetworkedObjectID} pos={part.Position} local={(root.GDNode3D.GlobalTransform.AffineInverse() * part.GDNode3D.GlobalTransform).Origin}");
-		}
-
 		WeldAssembly assembly = new()
 		{
 			Root = root,
@@ -91,8 +84,6 @@ public class WeldAssembly
 
 		// in creator we dont want to reparent everything since it will block them from selecting anything other than the root part
 		bool isCreator = root.Root != null && root.Root.SessionType == World.SessionTypeEnum.Creator;
-
-		Color color = (Color)PTColor.Random().ToGDClass(); // random color for debugging
 
 		foreach (Part part in parts)
 		{
@@ -106,7 +97,6 @@ public class WeldAssembly
 		{
 			Transform3D localTrans = rootInv * part.GDNode3D.GlobalTransform;
 			assembly.LocalTransforms[part] = localTrans;
-			part.Color = color; // debug
 
 			if (!isCreator)
 			{

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Godot;
 using Polytoria.Datamodel;
+using Polytoria.Scripting.Datatypes;
 
 namespace Polytoria.Physics;
 
@@ -103,12 +104,15 @@ public class WeldAssembly
 			Anchored = hasAnchoreds
 		};
 
+		Color color = (Color)PTColor.Random().ToGDClass(); // random color for debugging
+
 		// unfortunately we have to loop through the parts again to set up the assembly after root was picked
 		foreach (Part part in parts)
 		{
 			Transform3D localTrans = root.GDNode3D.GlobalTransform.AffineInverse() * part.GDNode3D.GlobalTransform;
 			assembly.LocalTransforms[part] = localTrans;
 			part.AttachToAssembly(assembly, root, localTrans);
+			part.Color = color; // debug
 		}
 
 		root.GDRigidBody.Mass = totalMass;

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+using Polytoria.Datamodel;
+
+namespace Polytoria.Physics;
+
+public class WeldAssembly
+{
+	public Part Root = null!;
+	public HashSet<Part> Parts = [];
+	public Dictionary<Part, Transform3D> LocalTransforms = [];
+	public bool Anchored;
+
+	internal void Destroy()
+	{
+		foreach (Part part in Parts.ToArray())
+		{
+			part.DetachFromAssembly();
+		}
+
+		Parts.Clear();
+		LocalTransforms.Clear();
+	}
+
+	public static WeldAssembly Build(HashSet<Part> parts, Part? preferredRoot)
+	{
+		if (parts.Count == 0)
+		{
+			throw new System.ArgumentException("Empty part set given");
+		}
+
+		Part? root = null;
+		float totalMass = 0;
+		bool hasAnchoreds = false;
+
+		// parts are picked in this order: preferred -> anchored -> largest mass -> first in set
+		// try to do as many checks as possible in one loop to avoid looping multiple times
+		{
+			// keep these variables scoped
+			Part? anchored = null;
+			Part? largestMass = null;
+			Part? first = null;
+			float largestMassValue = float.MinValue;
+
+			foreach (Part part in parts)
+			{
+				if (first == null)
+				{
+					first = part;
+				}
+
+				if (part.Anchored)
+				{
+					anchored ??= part;
+					hasAnchoreds = true;
+				}
+
+				if (largestMass == null || part.Mass > largestMassValue)
+				{
+					largestMass = part;
+					largestMassValue = part.Mass;
+				}
+
+				totalMass += part.Mass;
+			}
+
+			if (preferredRoot != null && parts.Contains(preferredRoot)) // .contains is fine here since it's .Contains is O(1) on a hashset
+			{
+				root = preferredRoot;
+			}
+			else if (anchored != null)
+			{
+				root = anchored;
+			}
+			else if (largestMass != null)
+			{
+				root = largestMass;
+			}
+			else
+			{
+				root = first!;
+			}
+		}
+
+		WeldAssembly assembly = new()
+		{
+			Root = root,
+			Parts = parts,
+			Anchored = hasAnchoreds
+		};
+
+		// unfortunately we have to loop through the parts again to set up the assembly after root was picked
+		foreach (Part part in parts)
+		{
+			Transform3D localTrans = root.GDNode3D.GlobalTransform.AffineInverse() * part.GDNode3D.GlobalTransform;
+			assembly.LocalTransforms[part] = localTrans;
+			part.AttachToAssembly(assembly, root, localTrans);
+		}
+
+		root.GDRigidBody.Mass = Mathf.Max(totalMass, Physical.MinMass);
+		root.GDRigidBody.Freeze = assembly.Anchored;
+		root.OverridePhysicsProcess = assembly.Anchored;
+
+		if (!assembly.Anchored)
+		{
+			root.SetPhysicsProcess(true);
+		}
+
+		return assembly;
+	}
+}

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -71,13 +71,20 @@ public class WeldAssembly
 				totalMass += Mathf.Max(part.Mass, Physical.MinMass);
 			}
 
-			if (preferredRoot != null && parts.Contains(preferredRoot)) // .contains is fine here since it's .Contains is O(1) on a hashset
+			if (anchored != null)
+			{
+				if (preferredRoot != null && parts.Contains(preferredRoot) && preferredRoot.Anchored)
+				{
+					root = preferredRoot;
+				}
+				else
+				{
+					root = anchored;
+				}
+			}
+			else if (preferredRoot != null && parts.Contains(preferredRoot))
 			{
 				root = preferredRoot;
-			}
-			else if (anchored != null)
-			{
-				root = anchored;
 			}
 			else if (largestMass != null)
 			{

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -29,6 +29,26 @@ public class WeldAssembly
 		LocalTransforms.Clear();
 	}
 
+	private static bool IsBetterRootCandidate(Part candidate, Part? current, Part? preferredRoot)
+	{
+		if (current == null)
+			return true;
+
+		if (candidate == preferredRoot && current != preferredRoot)
+			return true;
+
+		if (current == preferredRoot && candidate != preferredRoot)
+			return false;
+
+		if (candidate.Anchored != current.Anchored)
+			return candidate.Anchored;
+
+		if (!Mathf.IsEqualApprox(candidate.Mass, current.Mass))
+			return candidate.Mass > current.Mass;
+
+		return string.CompareOrdinal(candidate.NetworkedObjectID, current.NetworkedObjectID) < 0;
+	}
+
 	public static WeldAssembly Build(HashSet<Part> parts, Part? preferredRoot)
 	{
 		if (parts.Count == 0)
@@ -36,70 +56,30 @@ public class WeldAssembly
 			throw new System.ArgumentException("Empty part set given");
 		}
 
-		Part? root;
+		Part? root = null;
 		float totalMass = 0;
 		bool hasAnchoreds = false;
 
 		// parts are picked in this order: preferred -> anchored -> largest mass -> lowest network id
 		// try to do as many checks as possible in one loop to avoid looping multiple times
+		foreach (Part part in parts)
 		{
-			// keep these variables scoped
-			Part? anchored = null;
-			Part? largestMass = null;
-			Part? first = null;
-			Part? lowestNetID = null;
-			float largestMassValue = float.MinValue;
+			hasAnchoreds |= part.Anchored;
+			totalMass += Mathf.Max(part.Mass, Physical.MinMass);
 
-			foreach (Part part in parts)
+			if (IsBetterRootCandidate(part, root, preferredRoot))
 			{
-				if (first == null)
-				{
-					first = part;
-				}
-
-				if (part.Anchored)
-				{
-					anchored ??= part;
-					hasAnchoreds = true;
-				}
-
-				if (largestMass == null || part.Mass > largestMassValue)
-				{
-					largestMass = part;
-					largestMassValue = part.Mass;
-				}
-
-				if (lowestNetID == null || part.NetworkedObjectID.Hash() < lowestNetID.NetworkedObjectID.Hash())
-				{
-					lowestNetID = part;
-				}
-
-				totalMass += Mathf.Max(part.Mass, Physical.MinMass);
+				root = part;
 			}
+		}
 
-			if (anchored != null)
-			{
-				if (preferredRoot != null && parts.Contains(preferredRoot) && preferredRoot.Anchored)
-				{
-					root = preferredRoot;
-				}
-				else
-				{
-					root = anchored;
-				}
-			}
-			else if (preferredRoot != null && parts.Contains(preferredRoot))
-			{
-				root = preferredRoot;
-			}
-			else if (largestMass != null)
-			{
-				root = largestMass;
-			}
-			else
-			{
-				root = lowestNetID!;
-			}
+		root ??= preferredRoot ?? throw new System.ArgumentException("Empty part set given");
+
+		GD.Print($"[WeldAssembly] root={root.Name} id={root.NetworkedObjectID} pos={root.Position} loaded={root.Root.IsLoaded} session={root.Root.SessionType}");
+
+		foreach (Part part in parts)
+		{
+			GD.Print($"  part={part.Name} id={part.NetworkedObjectID} pos={part.Position} local={(root.GDNode3D.GlobalTransform.AffineInverse() * part.GDNode3D.GlobalTransform).Origin}");
 		}
 
 		WeldAssembly assembly = new()
@@ -113,6 +93,12 @@ public class WeldAssembly
 		bool isCreator = root.Root != null && root.Root.SessionType == World.SessionTypeEnum.Creator;
 
 		Color color = (Color)PTColor.Random().ToGDClass(); // random color for debugging
+
+		foreach (Part part in parts)
+		{
+			part.ForceUpdateTransform();
+		}
+
 		Transform3D rootInv = root.GDNode3D.GlobalTransform.AffineInverse();
 
 		// unfortunately we have to loop through the parts again to set up the assembly after root was picked

--- a/Polytoria/scripts/physics/WeldAssembly.cs
+++ b/Polytoria/scripts/physics/WeldAssembly.cs
@@ -18,7 +18,7 @@ public class WeldAssembly
 	internal void Destroy()
 	{
 		if (Physicalized)
-		{	
+		{
 			foreach (Part part in Parts)
 			{
 				part.DetachFromAssembly();
@@ -135,12 +135,9 @@ public class WeldAssembly
 
 		assembly.Physicalized = true;
 		root.GDRigidBody.Mass = totalMass;
-		root.GDRigidBody.Freeze = assembly.Anchored;
-		root.OverridePhysicsProcess = assembly.Anchored;
-
-		if (!assembly.Anchored)
+		foreach (Part part in parts)
 		{
-			root.SetPhysicsProcess(true);
+			part.UpdateFreeze();
 		}
 
 		return assembly;

--- a/Polytoria/scripts/physics/WeldAssembly.cs.uid
+++ b/Polytoria/scripts/physics/WeldAssembly.cs.uid
@@ -1,0 +1,1 @@
+uid://ruvb6p8tffyj

--- a/Polytoria/scripts/physics/WeldAssemblyManager.cs
+++ b/Polytoria/scripts/physics/WeldAssemblyManager.cs
@@ -82,6 +82,14 @@ public static class WeldAssemblyManager
 		Build(merged, preferred);
 	}
 
+	internal static void OnWeldRemoved(Weld weld)
+	{
+		if (_welds.TryGetValue(weld, out var tuple))
+		{
+			OnWeldRemoved(weld, tuple.part0, tuple.part1);
+		}
+	}
+
 	internal static void OnWeldRemoved(Weld weld, Part? a, Part? b)
 	{
 		WeldGraph.Remove(weld, a, b);
@@ -99,7 +107,7 @@ public static class WeldAssemblyManager
 			return;
 		}
 
-		HashSet<Part> oldParts = old.Parts;
+		HashSet<Part> oldParts = [.. old.Parts];
 		Part oldRoot = old.Root;
 
 		if (WeldGraph.AreConnected(a, b, oldParts))

--- a/Polytoria/scripts/physics/WeldAssemblyManager.cs
+++ b/Polytoria/scripts/physics/WeldAssemblyManager.cs
@@ -1,0 +1,204 @@
+using System.Collections.Generic;
+using Polytoria.Datamodel;
+
+namespace Polytoria.Physics;
+
+public static class WeldAssemblyManager
+{
+	private static readonly Dictionary<Part, WeldAssembly> _assemblies = [];
+	private static readonly Dictionary<Weld, (Part? part0, Part? part1)> _welds = [];
+
+	internal static void OnWeldChanged(Weld weld, Part? old0, Part? old1, Part? new0, Part? new1)
+	{
+		if (old0 != null && old1 != null)
+		{
+			OnWeldRemoved(weld, old0, old1);
+		}
+
+		if (new0 != null && new1 != null && new0 != new1)
+		{
+			OnWeldAdded(weld, new0, new1);
+		}
+	}
+
+	internal static void OnWeldAdded(Weld weld, Part a, Part b)
+	{
+		WeldGraph.Add(weld, a, b);
+		_welds[weld] = (a, b);
+
+		WeldAssembly? assA = GetAssembly(a);
+		WeldAssembly? assB = GetAssembly(b);
+
+		if (assA != null && assA == assB)
+		{
+			return;
+		}
+
+		HashSet<Part> merged = [];
+
+		if (assA != null)
+		{
+			foreach (Part part in assA.Parts)
+			{
+				merged.Add(part);
+			}
+
+			assA.Destroy();
+		}
+		else
+		{
+			merged.Add(a);
+		}
+
+		if (assB != null)
+		{
+			foreach (Part part in assB.Parts)
+			{
+				merged.Add(part);
+			}
+
+			assB.Destroy();
+		}
+		else
+		{
+			merged.Add(b);
+		}
+
+		Build(merged, assA?.Root ?? assB?.Root ?? a);
+	}
+
+	internal static void OnWeldRemoved(Weld weld, Part? a, Part? b)
+	{
+		WeldGraph.Remove(weld, a, b);
+		_welds.Remove(weld);
+
+		if (a == null || b == null)
+		{
+			return;
+		}
+
+		WeldAssembly? old = GetAssembly(a) ?? GetAssembly(b);
+
+		if (old == null)
+		{
+			return;
+		}
+
+		HashSet<Part> oldParts = old.Parts;
+		Part oldRoot = old.Root;
+
+		if (WeldGraph.AreConnected(a, b, oldParts))
+		{
+			return;
+		}
+
+		HashSet<Part> sideA = WeldGraph.GetComponentWithin(a, oldParts);
+		HashSet<Part> sideB = [];
+
+		foreach (Part part in oldParts)
+		{
+			if (!sideA.Contains(part))
+			{
+				sideB.Add(part);
+			}
+		}
+
+		old.Destroy();
+		Unregister(oldParts);
+
+		Build(sideA, sideA.Contains(oldRoot) ? oldRoot : a);
+		Build(sideB, sideB.Contains(oldRoot) ? oldRoot : b);
+	}
+
+	internal static void OnPartDeleted(Part part)
+	{
+		WeldAssembly? old = GetAssembly(part);
+
+		foreach (Weld weld in WeldGraph.GetWelds(part).ToArray())
+		{
+			Part? other = WeldGraph.GetOtherPart(weld, part);
+			WeldGraph.Remove(weld, part, other);
+			_welds.Remove(weld);
+		}
+
+		if (old == null)
+		{
+			return;
+		}
+
+		HashSet<Part> remaining = [];
+
+		foreach (Part p in old.Parts)
+		{
+			if (p != part && !p.IsDeleted)
+			{
+				remaining.Add(p);
+			}
+		}
+
+		old.Destroy();
+		Unregister(old.Parts);
+
+		HashSet<Part> unvisited = [.. remaining];
+
+		while (unvisited.Count > 0)
+		{
+			Part start = default!;
+			foreach (Part p in unvisited)
+			{
+				start = p;
+				break;
+			}
+
+			HashSet<Part> component = WeldGraph.GetComponentWithin(start, remaining);
+
+			foreach (Part p in component)
+				unvisited.Remove(p);
+
+			Build(component, component.Contains(old.Root) ? old.Root : start);
+		}
+	}
+
+	private static WeldAssembly? GetAssembly(Part part)
+	{
+		if (_assemblies.TryGetValue(part, out WeldAssembly? assembly))
+		{
+			return assembly;
+		}
+
+		return null;
+	}
+
+	private static void Register(WeldAssembly assembly)
+	{
+		foreach (Part part in assembly.Parts)
+		{
+			_assemblies[part] = assembly;
+		}
+	}
+
+	private static void Unregister(HashSet<Part> parts)
+	{
+		foreach (Part part in parts)
+		{
+			_assemblies.Remove(part);
+		}
+	}
+
+	private static void Build(HashSet<Part> parts, Part? preferredRoot)
+	{
+		if (parts.Count <= 1)
+		{
+			foreach (Part part in parts)
+			{
+				_assemblies.Remove(part);
+				part.DetachFromAssembly();
+			}
+
+			return;
+		}
+
+		WeldAssembly assembly = WeldAssembly.Build(parts, preferredRoot);
+		Register(assembly);
+	}
+}

--- a/Polytoria/scripts/physics/WeldAssemblyManager.cs
+++ b/Polytoria/scripts/physics/WeldAssemblyManager.cs
@@ -64,7 +64,22 @@ public static class WeldAssemblyManager
 			merged.Add(b);
 		}
 
-		Build(merged, assA?.Root ?? assB?.Root ?? a);
+		Part? preferred;
+
+		if (assA?.Root != null && assA.Root.Anchored)
+		{
+			preferred = assA.Root;
+		}
+		else if (assB?.Root != null && assB.Root.Anchored)
+		{
+			preferred = assB.Root;
+		}
+		else
+		{
+			preferred = assA?.Root ?? assB?.Root ?? a;
+		}
+
+		Build(merged, preferred);
 	}
 
 	internal static void OnWeldRemoved(Weld weld, Part? a, Part? b)

--- a/Polytoria/scripts/physics/WeldAssemblyManager.cs
+++ b/Polytoria/scripts/physics/WeldAssemblyManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Polytoria.Datamodel;
+using Godot;
 
 namespace Polytoria.Physics;
 
@@ -7,6 +8,12 @@ public static class WeldAssemblyManager
 {
 	private static readonly Dictionary<Part, WeldAssembly> _assemblies = new(ReferenceEqualityComparer.Instance);
 	private static readonly Dictionary<Weld, (Part? part0, Part? part1)> _welds = new(ReferenceEqualityComparer.Instance);
+	private static readonly HashSet<Part> _dirtyParts = new(ReferenceEqualityComparer.Instance);
+	private static readonly HashSet<WeldAssembly> _dirtyAssemblies = new(ReferenceEqualityComparer.Instance);
+
+	private static bool _buildQueued;
+	private static bool _building;
+	private static int _bulkEditDepth;
 
 	internal static void OnWeldChanged(Weld weld, Part? old0, Part? old1, Part? new0, Part? new1)
 	{
@@ -34,52 +41,155 @@ public static class WeldAssemblyManager
 			return;
 		}
 
-		HashSet<Part> merged = [];
+		QueueBuild(a);
+		QueueBuild(b);
+	}
 
-		if (assA != null)
+	private static void QueueBuild(Part part)
+	{
+		if (part.IsDeleted || part.IsInTemporary)
 		{
-			foreach (Part part in assA.Parts)
+			return;
+		}
+
+		_dirtyParts.Add(part);
+
+		if (_buildQueued)
+		{
+			return;
+		}
+
+		_buildQueued = true;
+
+		Callable.From(() =>
+		{
+			_buildQueued = false;
+			FlushBuildQueue();
+		}).CallDeferred();
+	}
+
+	private static void FlushBuildQueue()
+	{
+		if (_building)
+		{
+			return;
+		}
+
+		if (_dirtyParts.Count == 0)
+		{
+			return;
+		}
+
+		_building = true;
+
+		try
+		{
+			HashSet<Part> dirty = new(_dirtyParts, ReferenceEqualityComparer.Instance);
+			_dirtyParts.Clear();
+
+			HashSet<Part> visited = new(ReferenceEqualityComparer.Instance);
+
+			foreach (Part start in dirty)
 			{
-				merged.Add(part);
+				if (visited.Contains(start))
+				{
+					continue;
+				}
+
+				if (start.IsDeleted || start.IsInTemporary)
+				{
+					continue;
+				}
+
+				HashSet<Part> component = WeldGraph.GetComponent(start);
+
+				foreach (Part part in component)
+				{
+					visited.Add(part);
+				}
+
+				if (component.Count <= 1)
+				{
+					continue;
+				}
+
+				HashSet<WeldAssembly> oldAssemblies = new(ReferenceEqualityComparer.Instance);
+				Part? preferredRoot = null;
+
+				foreach (Part part in component)
+				{
+					if (_assemblies.TryGetValue(part, out WeldAssembly? oldAssembly))
+					{
+						if (oldAssemblies.Add(oldAssembly))
+						{
+							if (preferredRoot == null || oldAssembly.Root.Anchored)
+							{
+								preferredRoot = oldAssembly.Root;
+							}
+						}
+					}
+				}
+
+				foreach (WeldAssembly oldAssembly in oldAssemblies)
+				{
+					HashSet<Part> oldParts = new(oldAssembly.Parts, ReferenceEqualityComparer.Instance);
+					oldAssembly.Destroy();
+					Unregister(oldParts);
+				}
+
+				Build(component, preferredRoot ?? start);
 			}
-
-			assA.Destroy();
 		}
-		else
+		finally
 		{
-			merged.Add(a);
+			_building = false;
 		}
+	}
 
-		if (assB != null)
+	internal static void BreakWelds(IEnumerable<Weld> welds)
+	{
+		BeginBulkEdit();
+
+		try
 		{
-			foreach (Part part in assB.Parts)
+			foreach (Weld weld in welds)
 			{
-				merged.Add(part);
+				if (!weld.IsDeleted)
+				{
+					weld.Break();
+				}
 			}
+		}
+		finally
+		{
+			EndBulkEdit();
+		}
+	}
 
-			assB.Destroy();
-		}
-		else
+	internal static void BeginBulkEdit()
+	{
+		if (_bulkEditDepth == 0)
 		{
-			merged.Add(b);
-		}
-
-		Part? preferred;
-
-		if (assA?.Root != null && assA.Root.Anchored)
-		{
-			preferred = assA.Root;
-		}
-		else if (assB?.Root != null && assB.Root.Anchored)
-		{
-			preferred = assB.Root;
-		}
-		else
-		{
-			preferred = assA?.Root ?? assB?.Root ?? a;
+			FlushBuildQueue();
 		}
 
-		Build(merged, preferred);
+		_bulkEditDepth++;
+	}
+
+	internal static void EndBulkEdit()
+	{
+		if (_bulkEditDepth <= 0)
+		{
+			return;
+		}
+
+		_bulkEditDepth--;
+
+		if (_bulkEditDepth == 0)
+		{
+			FlushSplitQueue();
+			FlushBuildQueue();
+		}
 	}
 
 	internal static void OnWeldRemoved(Weld weld)
@@ -92,49 +202,187 @@ public static class WeldAssemblyManager
 
 	internal static void OnWeldRemoved(Weld weld, Part? a, Part? b)
 	{
+		if (_bulkEditDepth == 0)
+		{
+			FlushBuildQueue();
+		}
+
+		WeldAssembly? old = null;
+
+		if (a != null)
+		{
+			old = GetAssembly(a);
+		}
+
+		if (old == null && b != null)
+		{
+			old = GetAssembly(b);
+		}
+
 		WeldGraph.Remove(weld, a, b);
 		_welds.Remove(weld);
 
-		if (a == null || b == null)
+		if (a == null || b == null || old == null)
 		{
 			return;
 		}
 
-		WeldAssembly? old = GetAssembly(a) ?? GetAssembly(b);
+		if (_bulkEditDepth > 0)
+		{
+			_dirtyAssemblies.Add(old);
+			return;
+		}
 
-		if (old == null)
+		RebuildDirtyAssembly(old);
+	}
+
+	private static void FlushSplitQueue()
+	{
+		if (_dirtyAssemblies.Count == 0)
 		{
 			return;
 		}
+
+		HashSet<WeldAssembly> dirty = new(_dirtyAssemblies, ReferenceEqualityComparer.Instance);
+		_dirtyAssemblies.Clear();
+
+		foreach (WeldAssembly old in dirty)
+		{
+			RebuildDirtyAssembly(old);
+		}
+	}
+
+	private static void RebuildDirtyAssembly(WeldAssembly old)
+	{
+		if (old.Parts.Count == 0)
+			return;
 
 		HashSet<Part> oldParts = new(old.Parts, ReferenceEqualityComparer.Instance);
-		Part oldRoot = old.Root;
-
-		if (WeldGraph.AreConnected(a, b, oldParts))
-		{
-			return;
-		}
-
-		HashSet<Part> sideA = WeldGraph.GetComponentWithin(a, oldParts);
-		HashSet<Part> sideB = [];
+		HashSet<Part> validParts = new(ReferenceEqualityComparer.Instance);
 
 		foreach (Part part in oldParts)
 		{
-			if (!sideA.Contains(part))
+			if (!part.IsDeleted && !part.IsInTemporary)
+				validParts.Add(part);
+		}
+
+		if (validParts.Count == 0)
+		{
+			old.Destroy();
+			Unregister(oldParts);
+			return;
+		}
+
+		List<HashSet<Part>> components = [];
+		HashSet<Part> unvisited = new(validParts, ReferenceEqualityComparer.Instance);
+
+		while (unvisited.Count > 0)
+		{
+			Part start = default!;
+
+			foreach (Part part in unvisited)
 			{
-				sideB.Add(part);
+				start = part;
+				break;
+			}
+
+			HashSet<Part> component = WeldGraph.GetComponentWithin(start, validParts);
+
+			foreach (Part part in component)
+				unvisited.Remove(part);
+
+			if (component.Count > 0)
+				components.Add(component);
+		}
+
+		if (components.Count == 1 && components[0].Count == oldParts.Count)
+		{
+			return;
+		}
+
+		HashSet<Part>? retained = null;
+
+		foreach (HashSet<Part> component in components)
+		{
+			if (component.Contains(old.Root))
+			{
+				retained = component;
+				break;
 			}
 		}
 
-		old.Destroy();
-		Unregister(oldParts);
+		if (retained == null)
+		{
+			old.Destroy();
+			Unregister(oldParts);
 
-		Build(sideA, sideA.Contains(oldRoot) ? oldRoot : a);
-		Build(sideB, sideB.Contains(oldRoot) ? oldRoot : b);
+			foreach (HashSet<Part> component in components)
+				Build(component, null);
+
+			return;
+		}
+
+		List<HashSet<Part>> separatedComponents = [];
+
+		foreach (HashSet<Part> component in components)
+		{
+			if (!ReferenceEquals(component, retained))
+				separatedComponents.Add(component);
+		}
+
+		foreach (Part part in oldParts)
+		{
+			if (retained.Contains(part))
+				continue;
+
+			_assemblies.Remove(part);
+			old.Parts.Remove(part);
+			old.LocalTransforms.Remove(part);
+
+			if (old.Physicalized && part.Assembly == old)
+				part.DetachFromAssembly();
+		}
+
+		RefreshAssemblyMetadata(old);
+
+		foreach (HashSet<Part> component in separatedComponents)
+		{
+			if (component.Count <= 1)
+				continue;
+
+			Build(component, null);
+		}
+	}
+
+	private static void RefreshAssemblyMetadata(WeldAssembly assembly)
+	{
+		float totalMass = 0;
+		bool anchored = false;
+
+		foreach (Part part in assembly.Parts)
+		{
+			anchored |= part.Anchored;
+			totalMass += Mathf.Max(part.Mass, Physical.MinMass);
+		}
+
+		assembly.Anchored = anchored;
+
+		if (assembly.Physicalized)
+		{
+			assembly.Root.GDRigidBody.Mass = totalMass;
+
+			foreach (Part part in assembly.Parts)
+				part.UpdateFreeze();
+		}
 	}
 
 	internal static void OnPartDeleted(Part part)
 	{
+		if (_bulkEditDepth == 0)
+		{
+			FlushBuildQueue();
+		}
+
 		WeldAssembly? old = GetAssembly(part);
 
 		foreach (Weld weld in WeldGraph.GetWelds(part).ToArray())
@@ -149,37 +397,13 @@ public static class WeldAssemblyManager
 			return;
 		}
 
-		HashSet<Part> remaining = [];
-
-		foreach (Part p in old.Parts)
+		if (_bulkEditDepth > 0)
 		{
-			if (p != part && !p.IsDeleted)
-			{
-				remaining.Add(p);
-			}
+			_dirtyAssemblies.Add(old);
+			return;
 		}
 
-		old.Destroy();
-		Unregister(old.Parts);
-
-		HashSet<Part> unvisited = [.. remaining];
-
-		while (unvisited.Count > 0)
-		{
-			Part start = default!;
-			foreach (Part p in unvisited)
-			{
-				start = p;
-				break;
-			}
-
-			HashSet<Part> component = WeldGraph.GetComponentWithin(start, remaining);
-
-			foreach (Part p in component)
-				unvisited.Remove(p);
-
-			Build(component, component.Contains(old.Root) ? old.Root : start);
-		}
+		RebuildDirtyAssembly(old);
 	}
 
 	private static WeldAssembly? GetAssembly(Part part)

--- a/Polytoria/scripts/physics/WeldAssemblyManager.cs
+++ b/Polytoria/scripts/physics/WeldAssemblyManager.cs
@@ -6,16 +6,16 @@ namespace Polytoria.Physics;
 
 public static class WeldAssemblyManager
 {
-	private static readonly Dictionary<Part, WeldAssembly> _assemblies = new(ReferenceEqualityComparer.Instance);
-	private static readonly Dictionary<Weld, (Part? part0, Part? part1)> _welds = new(ReferenceEqualityComparer.Instance);
-	private static readonly HashSet<Part> _dirtyParts = new(ReferenceEqualityComparer.Instance);
+	private static readonly Dictionary<RigidBody, WeldAssembly> _assemblies = new(ReferenceEqualityComparer.Instance);
+	private static readonly Dictionary<Weld, (RigidBody? part0, RigidBody? part1)> _welds = new(ReferenceEqualityComparer.Instance);
+	private static readonly HashSet<RigidBody> _dirtyParts = new(ReferenceEqualityComparer.Instance);
 	private static readonly HashSet<WeldAssembly> _dirtyAssemblies = new(ReferenceEqualityComparer.Instance);
 
 	private static bool _buildQueued;
 	private static bool _building;
 	private static int _bulkEditDepth;
 
-	internal static void OnWeldChanged(Weld weld, Part? old0, Part? old1, Part? new0, Part? new1)
+	internal static void OnWeldChanged(Weld weld, RigidBody? old0, RigidBody? old1, RigidBody? new0, RigidBody? new1)
 	{
 		if (old0 != null && old1 != null)
 		{
@@ -28,7 +28,7 @@ public static class WeldAssemblyManager
 		}
 	}
 
-	internal static void OnWeldAdded(Weld weld, Part a, Part b)
+	internal static void OnWeldAdded(Weld weld, RigidBody a, RigidBody b)
 	{
 		WeldGraph.Add(weld, a, b);
 		_welds[weld] = (a, b);
@@ -45,7 +45,7 @@ public static class WeldAssemblyManager
 		QueueBuild(b);
 	}
 
-	private static void QueueBuild(Part part)
+	private static void QueueBuild(RigidBody part)
 	{
 		if (part.IsDeleted || part.IsInTemporary)
 		{
@@ -84,12 +84,12 @@ public static class WeldAssemblyManager
 
 		try
 		{
-			HashSet<Part> dirty = new(_dirtyParts, ReferenceEqualityComparer.Instance);
+			HashSet<RigidBody> dirty = new(_dirtyParts, ReferenceEqualityComparer.Instance);
 			_dirtyParts.Clear();
 
-			HashSet<Part> visited = new(ReferenceEqualityComparer.Instance);
+			HashSet<RigidBody> visited = new(ReferenceEqualityComparer.Instance);
 
-			foreach (Part start in dirty)
+			foreach (RigidBody start in dirty)
 			{
 				if (visited.Contains(start))
 				{
@@ -101,9 +101,9 @@ public static class WeldAssemblyManager
 					continue;
 				}
 
-				HashSet<Part> component = WeldGraph.GetComponent(start);
+				HashSet<RigidBody> component = WeldGraph.GetComponent(start);
 
-				foreach (Part part in component)
+				foreach (RigidBody part in component)
 				{
 					visited.Add(part);
 				}
@@ -114,9 +114,9 @@ public static class WeldAssemblyManager
 				}
 
 				HashSet<WeldAssembly> oldAssemblies = new(ReferenceEqualityComparer.Instance);
-				Part? preferredRoot = null;
+				RigidBody? preferredRoot = null;
 
-				foreach (Part part in component)
+				foreach (RigidBody part in component)
 				{
 					if (_assemblies.TryGetValue(part, out WeldAssembly? oldAssembly))
 					{
@@ -132,7 +132,7 @@ public static class WeldAssemblyManager
 
 				foreach (WeldAssembly oldAssembly in oldAssemblies)
 				{
-					HashSet<Part> oldParts = new(oldAssembly.Parts, ReferenceEqualityComparer.Instance);
+					HashSet<RigidBody> oldParts = new(oldAssembly.Parts, ReferenceEqualityComparer.Instance);
 					oldAssembly.Destroy();
 					Unregister(oldParts);
 				}
@@ -200,7 +200,7 @@ public static class WeldAssemblyManager
 		}
 	}
 
-	internal static void OnWeldRemoved(Weld weld, Part? a, Part? b)
+	internal static void OnWeldRemoved(Weld weld, RigidBody? a, RigidBody? b)
 	{
 		if (_bulkEditDepth == 0)
 		{
@@ -257,10 +257,10 @@ public static class WeldAssemblyManager
 		if (old.Parts.Count == 0)
 			return;
 
-		HashSet<Part> oldParts = new(old.Parts, ReferenceEqualityComparer.Instance);
-		HashSet<Part> validParts = new(ReferenceEqualityComparer.Instance);
+		HashSet<RigidBody> oldParts = new(old.Parts, ReferenceEqualityComparer.Instance);
+		HashSet<RigidBody> validParts = new(ReferenceEqualityComparer.Instance);
 
-		foreach (Part part in oldParts)
+		foreach (RigidBody part in oldParts)
 		{
 			if (!part.IsDeleted && !part.IsInTemporary)
 				validParts.Add(part);
@@ -273,22 +273,22 @@ public static class WeldAssemblyManager
 			return;
 		}
 
-		List<HashSet<Part>> components = [];
-		HashSet<Part> unvisited = new(validParts, ReferenceEqualityComparer.Instance);
+		List<HashSet<RigidBody>> components = [];
+		HashSet<RigidBody> unvisited = new(validParts, ReferenceEqualityComparer.Instance);
 
 		while (unvisited.Count > 0)
 		{
-			Part start = default!;
+			RigidBody start = default!;
 
-			foreach (Part part in unvisited)
+			foreach (RigidBody part in unvisited)
 			{
 				start = part;
 				break;
 			}
 
-			HashSet<Part> component = WeldGraph.GetComponentWithin(start, validParts);
+			HashSet<RigidBody> component = WeldGraph.GetComponentWithin(start, validParts);
 
-			foreach (Part part in component)
+			foreach (RigidBody part in component)
 				unvisited.Remove(part);
 
 			if (component.Count > 0)
@@ -300,9 +300,9 @@ public static class WeldAssemblyManager
 			return;
 		}
 
-		HashSet<Part>? retained = null;
+		HashSet<RigidBody>? retained = null;
 
-		foreach (HashSet<Part> component in components)
+		foreach (HashSet<RigidBody> component in components)
 		{
 			if (component.Contains(old.Root))
 			{
@@ -316,21 +316,21 @@ public static class WeldAssemblyManager
 			old.Destroy();
 			Unregister(oldParts);
 
-			foreach (HashSet<Part> component in components)
+			foreach (HashSet<RigidBody> component in components)
 				Build(component, null);
 
 			return;
 		}
 
-		List<HashSet<Part>> separatedComponents = [];
+		List<HashSet<RigidBody>> separatedComponents = [];
 
-		foreach (HashSet<Part> component in components)
+		foreach (HashSet<RigidBody> component in components)
 		{
 			if (!ReferenceEquals(component, retained))
 				separatedComponents.Add(component);
 		}
 
-		foreach (Part part in oldParts)
+		foreach (RigidBody part in oldParts)
 		{
 			if (retained.Contains(part))
 				continue;
@@ -345,7 +345,7 @@ public static class WeldAssemblyManager
 
 		RefreshAssemblyMetadata(old);
 
-		foreach (HashSet<Part> component in separatedComponents)
+		foreach (HashSet<RigidBody> component in separatedComponents)
 		{
 			if (component.Count <= 1)
 				continue;
@@ -359,7 +359,7 @@ public static class WeldAssemblyManager
 		float totalMass = 0;
 		bool anchored = false;
 
-		foreach (Part part in assembly.Parts)
+		foreach (RigidBody part in assembly.Parts)
 		{
 			anchored |= part.Anchored;
 			totalMass += Mathf.Max(part.Mass, Physical.MinMass);
@@ -371,12 +371,12 @@ public static class WeldAssemblyManager
 		{
 			assembly.Root.GDRigidBody.Mass = totalMass;
 
-			foreach (Part part in assembly.Parts)
+			foreach (RigidBody part in assembly.Parts)
 				part.UpdateFreeze();
 		}
 	}
 
-	internal static void OnPartDeleted(Part part)
+	internal static void OnPartDeleted(RigidBody part)
 	{
 		if (_bulkEditDepth == 0)
 		{
@@ -387,7 +387,7 @@ public static class WeldAssemblyManager
 
 		foreach (Weld weld in WeldGraph.GetWelds(part).ToArray())
 		{
-			Part? other = WeldGraph.GetOtherPart(weld, part);
+			RigidBody? other = WeldGraph.GetOtherPart(weld, part);
 			WeldGraph.Remove(weld, part, other);
 			_welds.Remove(weld);
 		}
@@ -406,7 +406,7 @@ public static class WeldAssemblyManager
 		RebuildDirtyAssembly(old);
 	}
 
-	private static WeldAssembly? GetAssembly(Part part)
+	private static WeldAssembly? GetAssembly(RigidBody part)
 	{
 		if (_assemblies.TryGetValue(part, out WeldAssembly? assembly))
 		{
@@ -418,25 +418,25 @@ public static class WeldAssemblyManager
 
 	private static void Register(WeldAssembly assembly)
 	{
-		foreach (Part part in assembly.Parts)
+		foreach (RigidBody part in assembly.Parts)
 		{
 			_assemblies[part] = assembly;
 		}
 	}
 
-	private static void Unregister(HashSet<Part> parts)
+	private static void Unregister(HashSet<RigidBody> parts)
 	{
-		foreach (Part part in parts)
+		foreach (RigidBody part in parts)
 		{
 			_assemblies.Remove(part);
 		}
 	}
 
-	private static void Build(HashSet<Part> parts, Part? preferredRoot)
+	private static void Build(HashSet<RigidBody> parts, RigidBody? preferredRoot)
 	{
 		if (parts.Count <= 1)
 		{
-			foreach (Part part in parts)
+			foreach (RigidBody part in parts)
 			{
 				_assemblies.Remove(part);
 				part.DetachFromAssembly();

--- a/Polytoria/scripts/physics/WeldAssemblyManager.cs
+++ b/Polytoria/scripts/physics/WeldAssemblyManager.cs
@@ -5,8 +5,8 @@ namespace Polytoria.Physics;
 
 public static class WeldAssemblyManager
 {
-	private static readonly Dictionary<Part, WeldAssembly> _assemblies = [];
-	private static readonly Dictionary<Weld, (Part? part0, Part? part1)> _welds = [];
+	private static readonly Dictionary<Part, WeldAssembly> _assemblies = new(ReferenceEqualityComparer.Instance);
+	private static readonly Dictionary<Weld, (Part? part0, Part? part1)> _welds = new(ReferenceEqualityComparer.Instance);
 
 	internal static void OnWeldChanged(Weld weld, Part? old0, Part? old1, Part? new0, Part? new1)
 	{
@@ -107,7 +107,7 @@ public static class WeldAssemblyManager
 			return;
 		}
 
-		HashSet<Part> oldParts = [.. old.Parts];
+		HashSet<Part> oldParts = new(old.Parts, ReferenceEqualityComparer.Instance);
 		Part oldRoot = old.Root;
 
 		if (WeldGraph.AreConnected(a, b, oldParts))

--- a/Polytoria/scripts/physics/WeldAssemblyManager.cs.uid
+++ b/Polytoria/scripts/physics/WeldAssemblyManager.cs.uid
@@ -1,0 +1,1 @@
+uid://cb5ofxav2tyre

--- a/Polytoria/scripts/physics/WeldGraph.cs
+++ b/Polytoria/scripts/physics/WeldGraph.cs
@@ -84,6 +84,34 @@ public static class WeldGraph
 		return null;
 	}
 
+	internal static bool AreConnected(Part a, Part b)
+	{
+		foreach (Weld weld in GetWelds(a))
+		{
+			Part? other = GetOtherPart(weld, a);
+			if (other == b)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	internal static bool TryGetParts(Weld weld, out Part a, out Part b)
+	{
+		if (weld.Part0 is Part p0 && weld.Part1 is Part p1 && p0 != p1)
+		{
+			a = p0;
+			b = p1;
+			return true;
+		}
+
+		a = null!;
+		b = null!;
+		return false;
+	}
+
 	internal static bool AreConnected(Part start, Part target, HashSet<Part> limit)
 	{
 		if (start == target)
@@ -124,10 +152,56 @@ public static class WeldGraph
 		return false;
 	}
 
+	internal static HashSet<Part> GetComponent(Part start)
+	{
+		HashSet<Part> result = new(ReferenceEqualityComparer.Instance);
+		Queue<Part> queue = new();
+
+		if (start.IsDeleted || start.IsInTemporary)
+		{
+			return result;
+		}
+
+		result.Add(start);
+		queue.Enqueue(start);
+
+		while (queue.Count > 0)
+		{
+			Part part = queue.Dequeue();
+
+			if (!_welds.TryGetValue(part, out List<Weld>? welds))
+			{
+				continue;
+			}
+
+			foreach (Weld weld in welds)
+			{
+				Part? other = GetOtherPart(weld, part);
+
+				if (other == null)
+				{
+					continue;
+				}
+
+				if (other.IsDeleted || other.IsInTemporary)
+				{
+					continue;
+				}
+
+				if (result.Add(other))
+				{
+					queue.Enqueue(other);
+				}
+			}
+		}
+
+		return result;
+	}
+
 	internal static HashSet<Part> GetComponentWithin(Part start, HashSet<Part> limit)
 	{
-		HashSet<Part> visited = [];
-		Queue<Part> queue = [];
+		HashSet<Part> visited = new(ReferenceEqualityComparer.Instance);
+		Queue<Part> queue = new();
 
 		if (!limit.Contains(start))
 		{

--- a/Polytoria/scripts/physics/WeldGraph.cs
+++ b/Polytoria/scripts/physics/WeldGraph.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using Polytoria.Datamodel;
+
+namespace Polytoria.Physics;
+
+public static class WeldGraph
+{
+	private static readonly Dictionary<Part, List<Weld>> _welds = [];
+
+	internal static void Add(Weld weld, Part a, Part b)
+	{
+		AddOne(a, weld);
+		AddOne(b, weld);
+	}
+
+	internal static void Remove(Weld weld, Part? a, Part? b)
+	{
+		if (a != null)
+		{
+			RemoveOne(a, weld);
+		}
+
+		if (b != null)
+		{
+			RemoveOne(b, weld);
+		}
+	}
+
+	private static void AddOne(Part part, Weld weld)
+	{
+		if (!_welds.TryGetValue(part, out List<Weld>? list))
+		{
+			list = [];
+			_welds[part] = list;
+
+			part.Deleted += () =>
+			{
+				WeldAssemblyManager.OnPartDeleted(part);
+			};
+		}
+
+		if (!list.Contains(weld))
+		{
+			list.Add(weld);
+		}
+	}
+
+	private static void RemoveOne(Part part, Weld weld)
+	{
+		if (!_welds.TryGetValue(part, out List<Weld>? list))
+		{
+			return;
+		}
+
+		list.Remove(weld);
+
+		if (list.Count == 0)
+		{
+			_welds.Remove(part);
+		}
+	}
+
+	internal static List<Weld> GetWelds(Part part)
+	{
+		if (!_welds.TryGetValue(part, out List<Weld>? list))
+		{
+			return [];
+		}
+
+		return list;
+	}
+
+	internal static Part? GetOtherPart(Weld weld, Part part)
+	{
+		if (weld.Part0 == part)
+		{
+			return weld.Part1 as Part;
+		}
+		else if (weld.Part1 == part)
+		{
+			return weld.Part0 as Part;
+		}
+
+		return null;
+	}
+
+	internal static bool AreConnected(Part start, Part target, HashSet<Part> limit)
+	{
+		if (start == target)
+		{
+			return true;
+		}
+
+		HashSet<Part> visited = [];
+		Queue<Part> queue = [];
+
+		visited.Add(start);
+		queue.Enqueue(start);
+
+		while (queue.Count > 0)
+		{
+			Part current = queue.Dequeue();
+
+			foreach (Weld weld in GetWelds(current))
+			{
+				Part? next = GetOtherPart(weld, current);
+				if (next == null || next.IsDeleted || !limit.Contains(next))
+				{
+					continue;
+				}
+
+				if (next == target)
+				{
+					return true;
+				}
+
+				if (visited.Add(next))
+				{
+					queue.Enqueue(next);
+				}
+			}
+		}
+
+		return false;
+	}
+
+	internal static HashSet<Part> GetComponentWithin(Part start, HashSet<Part> limit)
+	{
+		HashSet<Part> visited = [];
+		Queue<Part> queue = [];
+
+		if (!limit.Contains(start))
+		{
+			return visited;
+		}
+
+		visited.Add(start);
+		queue.Enqueue(start);
+
+		while (queue.Count > 0)
+		{
+			Part current = queue.Dequeue();
+
+			foreach (Weld weld in GetWelds(current))
+			{
+				Part? next = GetOtherPart(weld, current);
+				if (next == null || next.IsDeleted || !limit.Contains(next))
+				{
+					continue;
+				}
+
+				if (visited.Add(next))
+				{
+					queue.Enqueue(next);
+				}
+			}
+		}
+
+		return visited;
+	}
+}

--- a/Polytoria/scripts/physics/WeldGraph.cs
+++ b/Polytoria/scripts/physics/WeldGraph.cs
@@ -5,15 +5,15 @@ namespace Polytoria.Physics;
 
 public static class WeldGraph
 {
-	private static readonly Dictionary<Part, List<Weld>> _welds = [];
+	private static readonly Dictionary<RigidBody, List<Weld>> _welds = [];
 
-	internal static void Add(Weld weld, Part a, Part b)
+	internal static void Add(Weld weld, RigidBody a, RigidBody b)
 	{
 		AddOne(a, weld);
 		AddOne(b, weld);
 	}
 
-	internal static void Remove(Weld weld, Part? a, Part? b)
+	internal static void Remove(Weld weld, RigidBody? a, RigidBody? b)
 	{
 		if (a != null)
 		{
@@ -26,7 +26,7 @@ public static class WeldGraph
 		}
 	}
 
-	private static void AddOne(Part part, Weld weld)
+	private static void AddOne(RigidBody part, Weld weld)
 	{
 		if (!_welds.TryGetValue(part, out List<Weld>? list))
 		{
@@ -45,7 +45,7 @@ public static class WeldGraph
 		}
 	}
 
-	private static void RemoveOne(Part part, Weld weld)
+	private static void RemoveOne(RigidBody part, Weld weld)
 	{
 		if (!_welds.TryGetValue(part, out List<Weld>? list))
 		{
@@ -60,7 +60,7 @@ public static class WeldGraph
 		}
 	}
 
-	internal static List<Weld> GetWelds(Part part)
+	internal static List<Weld> GetWelds(RigidBody part)
 	{
 		if (!_welds.TryGetValue(part, out List<Weld>? list))
 		{
@@ -70,25 +70,25 @@ public static class WeldGraph
 		return list;
 	}
 
-	internal static Part? GetOtherPart(Weld weld, Part part)
+	internal static RigidBody? GetOtherPart(Weld weld, RigidBody part)
 	{
 		if (weld.Part0 == part)
 		{
-			return weld.Part1 as Part;
+			return weld.Part1 as RigidBody;
 		}
 		else if (weld.Part1 == part)
 		{
-			return weld.Part0 as Part;
+			return weld.Part0 as RigidBody;
 		}
 
 		return null;
 	}
 
-	internal static bool AreConnected(Part a, Part b)
+	internal static bool AreConnected(RigidBody a, RigidBody b)
 	{
 		foreach (Weld weld in GetWelds(a))
 		{
-			Part? other = GetOtherPart(weld, a);
+			RigidBody? other = GetOtherPart(weld, a);
 			if (other == b)
 			{
 				return true;
@@ -98,9 +98,9 @@ public static class WeldGraph
 		return false;
 	}
 
-	internal static bool TryGetParts(Weld weld, out Part a, out Part b)
+	internal static bool TryGetParts(Weld weld, out RigidBody a, out RigidBody b)
 	{
-		if (weld.Part0 is Part p0 && weld.Part1 is Part p1 && p0 != p1)
+		if (weld.Part0 is RigidBody p0 && weld.Part1 is RigidBody p1 && p0 != p1)
 		{
 			a = p0;
 			b = p1;
@@ -112,26 +112,26 @@ public static class WeldGraph
 		return false;
 	}
 
-	internal static bool AreConnected(Part start, Part target, HashSet<Part> limit)
+	internal static bool AreConnected(RigidBody start, RigidBody target, HashSet<RigidBody> limit)
 	{
 		if (start == target)
 		{
 			return true;
 		}
 
-		HashSet<Part> visited = [];
-		Queue<Part> queue = [];
+		HashSet<RigidBody> visited = [];
+		Queue<RigidBody> queue = [];
 
 		visited.Add(start);
 		queue.Enqueue(start);
 
 		while (queue.Count > 0)
 		{
-			Part current = queue.Dequeue();
+			RigidBody current = queue.Dequeue();
 
 			foreach (Weld weld in GetWelds(current))
 			{
-				Part? next = GetOtherPart(weld, current);
+				RigidBody? next = GetOtherPart(weld, current);
 				if (next == null || next.IsDeleted || !limit.Contains(next))
 				{
 					continue;
@@ -152,10 +152,10 @@ public static class WeldGraph
 		return false;
 	}
 
-	internal static HashSet<Part> GetComponent(Part start)
+	internal static HashSet<RigidBody> GetComponent(RigidBody start)
 	{
-		HashSet<Part> result = new(ReferenceEqualityComparer.Instance);
-		Queue<Part> queue = new();
+		HashSet<RigidBody> result = new(ReferenceEqualityComparer.Instance);
+		Queue<RigidBody> queue = new();
 
 		if (start.IsDeleted || start.IsInTemporary)
 		{
@@ -167,7 +167,7 @@ public static class WeldGraph
 
 		while (queue.Count > 0)
 		{
-			Part part = queue.Dequeue();
+			RigidBody part = queue.Dequeue();
 
 			if (!_welds.TryGetValue(part, out List<Weld>? welds))
 			{
@@ -176,7 +176,7 @@ public static class WeldGraph
 
 			foreach (Weld weld in welds)
 			{
-				Part? other = GetOtherPart(weld, part);
+				RigidBody? other = GetOtherPart(weld, part);
 
 				if (other == null)
 				{
@@ -198,10 +198,10 @@ public static class WeldGraph
 		return result;
 	}
 
-	internal static HashSet<Part> GetComponentWithin(Part start, HashSet<Part> limit)
+	internal static HashSet<RigidBody> GetComponentWithin(RigidBody start, HashSet<RigidBody> limit)
 	{
-		HashSet<Part> visited = new(ReferenceEqualityComparer.Instance);
-		Queue<Part> queue = new();
+		HashSet<RigidBody> visited = new(ReferenceEqualityComparer.Instance);
+		Queue<RigidBody> queue = new();
 
 		if (!limit.Contains(start))
 		{
@@ -213,11 +213,11 @@ public static class WeldGraph
 
 		while (queue.Count > 0)
 		{
-			Part current = queue.Dequeue();
+			RigidBody current = queue.Dequeue();
 
 			foreach (Weld weld in GetWelds(current))
 			{
-				Part? next = GetOtherPart(weld, current);
+				RigidBody? next = GetOtherPart(weld, current);
 				if (next == null || next.IsDeleted || !limit.Contains(next))
 				{
 					continue;

--- a/Polytoria/scripts/physics/WeldGraph.cs.uid
+++ b/Polytoria/scripts/physics/WeldGraph.cs.uid
@@ -1,0 +1,1 @@
+uid://cj58wihtup4kw


### PR DESCRIPTION
## Summary

BASED ON AND IS MEANT TO COMPLETE willemsteller'S WELD REWORK

- welds are now rigid by assmeblies

## Related issue or discussion

Fixes #795

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

## AI/LLM use

none