### PR TITLE
Fix incorrect PT-Game-ID header

### DIFF
--- a/Polytoria/scripts/datamodel/services/HttpService.cs
+++ b/Polytoria/scripts/datamodel/services/HttpService.cs
@@ -122,13 +122,19 @@ public sealed partial class HttpService : Instance
 				}
 			}
 		}
-		msg.Headers.Add("PT-World-ID", Root.WorldID.ToString());
+		msg.Headers.Add("PT-Game-ID", Root.WorldID.ToString());
 
 		using HttpResponseMessage res = await _client.SendAsync(msg);
 		Dictionary<string, string> headers = [];
 
 		foreach ((string key, IEnumerable<string> val) in res.Headers)
 		{
+			string normalized = key.ToLowerInvariant().Replace("-", "").Replace("_", "").Replace(" ", "");
+			if (normalized.Contains("ptgameid"))
+			{
+				continue;
+			}
+
 			headers[key] = string.Join(",", val);
 		}
 
@@ -338,6 +344,12 @@ public sealed partial class HttpService : Instance
 		{
 			foreach ((string key, string val) in headers)
 			{
+				string normalized = key.ToLowerInvariant().Replace("-", "").Replace("_", "").Replace(" ", "");
+				if (normalized.Contains("ptgameid"))
+				{
+					continue;
+				}
+
 				if (string.Equals(key, "Content-Type", StringComparison.OrdinalIgnoreCase))
 				{
 					msg.Content?.Headers.ContentType = new MediaTypeHeaderValue(val);


### PR DESCRIPTION
## Summary

Fixes the PT-Game-ID header which was sent as PT-World-ID and adds safeguards for overriding the header

## Related issue or discussion

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None