### PR TITLE
Rework how meshes are scaled to be consistent with the rest of the datamodel

### DIFF
--- a/Polytoria/scripts/datamodel/Mesh.cs
+++ b/Polytoria/scripts/datamodel/Mesh.cs
@@ -19,10 +19,8 @@ public sealed partial class Mesh : Entity
 	private MeshAsset? _asset;
 
 	private int _assetID = 0;
-	private bool _includeOffset;
-
 	private Node3D _meshContainer = null!; // scaled
-	private Node3D? _meshNode = null; // offset only
+	private Node3D? _meshNode = null;
 
 	private CollisionTypeEnum _collisionType = CollisionTypeEnum.Bounds;
 	private TextureFilterEnum _textureFilter;
@@ -34,6 +32,7 @@ public sealed partial class Mesh : Entity
 	private readonly List<MeshInstance3D> _meshInstances = [];
 	private readonly List<Material> _materials = [];
 	private Resource? _prevResource;
+	private Vector3 _nativeMeshSize = Vector3.One;
 
 	[Editable, ScriptProperty]
 	public MeshAsset? Asset
@@ -61,7 +60,11 @@ public sealed partial class Mesh : Entity
 				_asset.ResourceLoaded += OnResourceLoaded;
 				if (_asset.IsResourceLoaded && _asset.Resource != null)
 				{
-					OnResourceLoaded(_asset.Resource);
+					Resource cached = _asset.Resource;
+					Callable.From(() =>
+					{
+						if (!IsDeleted) OnResourceLoaded(cached);
+					}).CallDeferred();
 				}
 				else
 				{
@@ -78,31 +81,14 @@ public sealed partial class Mesh : Entity
 		get => _assetID;
 		set
 		{
+			if (_assetID == value) return;
 			_assetID = value;
-			CreatePTMeshAsset();
-			if (_asset != null)
-			{
-				if (_asset.IsResourceLoaded && _asset.Resource != null)
-				{
-					OnResourceLoaded(_asset.Resource);
-				}
-				else
-				{
-					_asset.QueueLoadResource();
-				}
-			}
-			OnPropertyChanged();
-		}
-	}
 
-	[Editable, ScriptProperty, DefaultValue(false)]
-	public bool IncludeOffset
-	{
-		get => _includeOffset;
-		set
-		{
-			_includeOffset = value;
-			UpdateMeshOffset();
+			PTMeshAsset meshAsset = New<PTMeshAsset>();
+			meshAsset.AssetID = (uint)value;
+			Asset = meshAsset;
+
+			OnPropertyChanged();
 		}
 	}
 
@@ -223,26 +209,11 @@ public sealed partial class Mesh : Entity
 		base.Init();
 	}
 
-	public override void InitOverrides()
-	{
-		Size = Vector3.One * 0.5f;
-		base.InitOverrides();
-	}
-
 	public override void PreDelete()
 	{
 		_materials.Clear();
 		_meshInstances.Clear();
 		base.PreDelete();
-	}
-
-	private void CreatePTMeshAsset()
-	{
-		Asset = New<PTMeshAsset>();
-		if (Asset is PTMeshAsset mesh)
-		{
-			mesh.AssetID = (uint)_assetID;
-		}
 	}
 
 	private static BaseMaterial3D.TextureFilterEnum ToGodotTextureFilter(TextureFilterEnum filter)
@@ -319,6 +290,18 @@ public sealed partial class Mesh : Entity
 				}
 			}
 
+			Aabb? nativeBounds = null;
+			foreach (MeshInstance3D meshInst in _meshInstances)
+			{
+				Aabb meshBounds = meshInst.GetAabb();
+				if (meshBounds.Size != Vector3.Zero)
+				{
+					nativeBounds = nativeBounds == null ? meshInst.Transform * meshBounds : nativeBounds.Value.Merge(meshInst.Transform * meshBounds);
+				}
+			}
+			_nativeMeshSize = new Vector3(Mathf.Max(nativeBounds?.Size.X ?? 1f, 0.001f), Mathf.Max(nativeBounds?.Size.Y ?? 1f, 0.001f), Mathf.Max(nativeBounds?.Size.Z ?? 1f, 0.001f));
+			Size = _nativeMeshSize;
+
 			UpdateColor();
 			UpdateShadows();
 			UpdateTextureFilter();
@@ -334,7 +317,7 @@ public sealed partial class Mesh : Entity
 				}
 			}
 
-			UpdateMeshOffset();
+			ResetMeshNodeState();
 
 			Loading = false;
 			Loaded.Invoke();
@@ -439,23 +422,11 @@ public sealed partial class Mesh : Entity
 		}
 	}
 
-	private void UpdateMeshOffset()
+	private void ResetMeshNodeState()
 	{
-		if (_meshNode == null)
-		{
-			return;
-		}
-		if (IncludeOffset)
-		{
-			_meshNode.Position = Vector3.Zero;
-		}
-		else
-		{
-			_meshNode.ForceUpdateTransform();
-			Vector3 offset = -_meshNode.CalculateBounds().GetCenter();
+		if (_meshNode == null) return;
 
-			_meshNode.Position = offset;
-		}
+		_meshNode.Position = Vector3.Zero;
 		_meshNode.Visible = !IsHidden;
 
 		RecalculateCollision();
@@ -588,7 +559,7 @@ public sealed partial class Mesh : Entity
 
 	internal override void OnNodeSizeChanged(Vector3 newSize)
 	{
-		_meshContainer.Scale = newSize;
+		_meshContainer.Scale = new Vector3(newSize.X / _nativeMeshSize.X, newSize.Y / _nativeMeshSize.Y, newSize.Z / _nativeMeshSize.Z);
 	}
 
 	public struct MeshAnimationInfo : IScriptObject

--- a/Polytoria/scripts/datamodel/services/InsertService.cs
+++ b/Polytoria/scripts/datamodel/services/InsertService.cs
@@ -153,7 +153,6 @@ public sealed partial class InsertService : Instance
 
 		Accessory accessory = New<Accessory>(this);
 		Mesh mesh = New<Mesh>();
-		mesh.Size = Vector3.One;
 		mesh.Parent = accessory;
 		mesh.Asset = meshAsset;
 
@@ -161,7 +160,6 @@ public sealed partial class InsertService : Instance
 		mesh.LocalRotation = Vector3.Zero;
 		accessory.Size = new Vector3(0.5f, 0.5f, 0.5f);
 
-		mesh.IncludeOffset = true;
 		mesh.Name = "Mesh";
 		mesh.CanCollide = false;
 		mesh.Anchored = true;
@@ -205,7 +203,6 @@ public sealed partial class InsertService : Instance
 
 		Tool tool = New<Tool>(this);
 		Mesh mesh = New<Mesh>()!;
-		mesh.Size = Vector3.One;
 		mesh.Parent = tool;
 		mesh.Asset = meshAsset;
 
@@ -216,7 +213,6 @@ public sealed partial class InsertService : Instance
 		mesh.LocalRotation = Vector3.Zero;
 		tool.Size = new Vector3(0.5f, 0.5f, 0.5f);
 
-		mesh.IncludeOffset = true;
 		mesh.Name = "Mesh";
 		mesh.CanCollide = false;
 		mesh.Anchored = true;


### PR DESCRIPTION
## Summary

The way meshes currently work is complete and utter nonsense:
* Meshes defy all conventions established by the rest of the datamodel, often leading to unexpected behaviour.
* Meshes provide no way for creators to know their native size whatsoever (which makes things such as clamping accessory sizes impossible, forcing competitive games to disable user accessories altogether).
* Due to how their size is currently calculated, meshes will almost certainly always end up outputting floats, which come with their own set of issues.
* The current behaviour is overwhelmingly disliked pretty much universally as far as i'm aware.

This addresses that by making meshes work as expected:
* Their default size is their native one.
* Offset is gone, as the exact same can be accomplished via markers (perhaps it could be applied when the mesh is initially loaded to the instance, but I don't think that makes much sense).
* I also went ahead and tried to shorten AssetID.

This is technically a breaking change, but one that is justified and I believe most creators will understand as the alternative is what we currently have. Aditionally, most games could be updated to use the new meshes by simply running this on the command line (if it ever gets merged):
```lua
for _, Inst in world:GetDescendants() do
    if Inst:IsA("Mesh") and Inst.Asset then
        coroutine.wrap(function()
            local OldSize = Inst.Size

            local Temp = Instance.New("Mesh")
            Temp.Asset = Inst.Asset
            Temp.Parent = Environment

            if Temp.Loading then
                Temp.Loaded:Wait()
            end

            local NativeSize = Temp.Size
            Temp:Destroy()

            Inst.Size = Vector3.new((OldSize.X / 0.5) * NativeSize.X, (OldSize.Y / 0.5) * NativeSize.Y, (OldSize.Z / 0.5) * NativeSize.Z)
        end)()
    end
end
```

## Related issue or discussion

https://discord.com/channels/350679908390797313/1504838016903155736

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

Claude was used for troubleshooting and code review, all changes were manually reviewed and tested.