### PR TITLE
Restore drag panning when exiting first person and ctrl lock

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -44,6 +44,7 @@ public sealed partial class Camera : Dynamic
 	private float _xSpeed = 120.0f;
 	private float _ySpeed = 120.0f;
 	private bool _followLerp = false;
+	private bool _dragPanning = false;
 	private bool _ctrlLocked = false;
 	private bool _alwaysLocked = false;
 
@@ -306,11 +307,14 @@ public sealed partial class Camera : Dynamic
 			_ctrlLocked = value;
 			if (_ctrlLocked)
 			{
-				StartTurning();
+				if (!_dragPanning)
+				{
+					StartTurning();
+				}
 			}
 			else
 			{
-				if (!AlwaysLocked)
+				if (!AlwaysLocked && !_dragPanning)
 				{
 					StopTurning();
 				}
@@ -617,10 +621,13 @@ public sealed partial class Camera : Dynamic
 	{
 		if (Mode != CameraModeEnum.Follow) return;
 		IsFirstPerson = true;
-		Root.Input.CursorLocked = true;
-		Root.Input.CursorVisible = false;
 		_targetZoom = 0;
-		StartTurning();
+		if (!CtrlLocked && !_dragPanning)
+		{
+			Root.Input.CursorVisible = false;
+			Root.Input.CursorLocked = true;
+			StartTurning();
+		}
 		FirstPersonEntered?.Invoke();
 	}
 
@@ -632,7 +639,7 @@ public sealed partial class Camera : Dynamic
 		{
 			_targetZoom = DefaultZoomDistance;
 		}
-		if (!CtrlLocked)
+		if (!CtrlLocked && !_dragPanning)
 		{
 			Root.Input.CursorVisible = true;
 			Root.Input.CursorLocked = false;
@@ -648,7 +655,7 @@ public sealed partial class Camera : Dynamic
 			CtrlLocked = true;
 		}
 
-		if (IsFirstPerson || AlwaysLocked || CtrlLocked)
+		if (IsFirstPerson || AlwaysLocked || CtrlLocked || _dragPanning)
 		{
 			StartTurning();
 		}
@@ -758,23 +765,35 @@ public sealed partial class Camera : Dynamic
 
 		if (@event is InputEventMouseButton btnEvent)
 		{
-			if (btnEvent.ButtonIndex == MouseButton.Right && !(IsFirstPerson || CtrlLocked))
+			if (btnEvent.ButtonIndex == MouseButton.Right)
 			{
-				if (AlwaysLocked) return;
-				if (btnEvent.Pressed)
+				if (IsFirstPerson || CtrlLocked || AlwaysLocked)
+				{
+					if (!btnEvent.Pressed)
+					{
+						_dragPanning = false;
+					}
+					if (AlwaysLocked) return;
+				}
+				else if (btnEvent.Pressed)
 				{
 					if (!Root.Input.CursorLocked)
 					{
+						_dragPanning = true;
 						StartTurning();
 						Root.Input.CursorLocked = true;
 						Root.Input.CursorVisible = false;
 					}
 				}
-				else if (_turning)
+				else
 				{
-					StopTurning();
-					Root.Input.CursorLocked = false;
-					Root.Input.CursorVisible = true;
+					_dragPanning = false;
+					if (_turning)
+					{
+						StopTurning();
+						Root.Input.CursorLocked = false;
+						Root.Input.CursorVisible = true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

When moving the camera using the right mouse button then entering first person or ctrl lock, this drag panning state is lost when exiting first person/ctrl lock.
This pull request fixes this.

## Related issue or discussion

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Moving camera using the right mouse button then entering and exiting first person, then again with ctrl lock.

https://github.com/user-attachments/assets/b0eeea93-fe38-4eb4-a225-76877059c73b

## AI/LLM use

None