### PR TITLE
Add Physical.IgnoreMouse

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -966,6 +966,13 @@ public sealed partial class Camera : Dynamic
 		}
 	}
 
+	public (Vector3, Vector3) Project(Vector2 point)
+	{
+		Vector3 origin = Camera3D.ProjectRayOrigin(point);
+		Vector3 direction = Camera3D.ProjectRayNormal(point);
+		return (origin, direction);
+	}
+
 	[ScriptMethod]
 	public bool IsPositionInView(Vector3 pos)
 	{

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -345,6 +345,54 @@ public sealed partial class Environment : Instance
 		return [.. rayResults];
 	}
 
+	public RayResult? RaycastMouse(Vector3 origin, Vector3 direction, float maxDistance = 1000f)
+	{
+		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
+		Godot.Collections.Array<Rid> ignoreRids = [];
+		RayResult? rayResult = null;
+
+		while (true)
+		{
+			Godot.Collections.Dictionary result = spaceState.IntersectRay(new PhysicsRayQueryParameters3D
+			{
+				From = origin,
+				To = origin + direction.Normalized() * maxDistance,
+				CollideWithAreas = true,
+				CollideWithBodies = true,
+				Exclude = ignoreRids
+			});
+
+			if (result.Count == 0)
+				break;
+
+			Rid colliderRid = (Rid)result["rid"];
+			ignoreRids.Add(colliderRid);
+
+			Node collider = (Node)(GodotObject)result["collider"];
+			Instance? instance = ColliderToInstance(collider);
+			if (instance == null) continue;
+			if (instance is Physical p)
+			{
+				if (p.IgnoreMouse) continue;
+			}
+
+			Vector3 hitPos = (Vector3)result["position"];
+			Vector3 normal = (Vector3)result["normal"];
+			rayResult = new()
+			{
+				Origin = origin,
+				Direction = direction.Normalized(),
+				Position = hitPos,
+				Normal = normal,
+				Distance = (origin - hitPos).Length(),
+				Instance = instance
+			};
+			break;
+		}
+
+		return rayResult;
+	}
+
 	private static Instance? ColliderToInstance(Node collider)
 	{
 		Instance? instance = null;

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -376,10 +376,7 @@ public sealed partial class Environment : Instance
 			Node collider = (Node)(GodotObject)result["collider"];
 			Instance? instance = ColliderToInstance(collider);
 			if (instance == null) continue;
-			if (instance is Physical p)
-			{
-				if (p.IgnoreMouse) continue;
-			}
+			if (instance is Physical p && p.IgnoreMouse) continue;
 
 			Vector3 hitPos = (Vector3)result["position"];
 			Vector3 normal = (Vector3)result["normal"];

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -345,11 +345,16 @@ public sealed partial class Environment : Instance
 		return [.. rayResults];
 	}
 
-	public RayResult? RaycastMouse(Vector3 origin, Vector3 direction, float maxDistance = 1000f)
+	public RayResult? RaycastMouse(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null)
 	{
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
 		Godot.Collections.Array<Rid> ignoreRids = [];
 		RayResult? rayResult = null;
+
+		if (ignoreList != null)
+		{
+			ignoreRids = PhysicalsToArray(ignoreList);
+		}
 
 		while (true)
 		{

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -285,7 +285,7 @@ public partial class Grabbable : Instance
 					}
 					else
 					{
-						RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: [Parent]);
+						RayResult? hit = Root.Environment.RaycastMouse(rayOrigin, rayDir, ignoreList: [Parent]);
 						if (hit != null)
 						{
 							targetPos = hit.Value.Position;

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -44,6 +44,7 @@ public partial class Physical : Dynamic
 	private uint _collisionLayers = 1, _collisionMask = 1;
 	private Vector3 _velocity = Vector3.Zero;
 	private Vector3 _angularVelocity = Vector3.Zero;
+	private bool _ignoreMouse = false;
 
 	private bool _netEnsureTouchArea = false;
 
@@ -320,6 +321,20 @@ public partial class Physical : Dynamic
 		set
 		{
 			_angularVelocity = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public virtual bool IgnoreMouse
+	{
+		get
+		{
+			return _ignoreMouse;
+		}
+		set
+		{
+			_ignoreMouse = value;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -664,6 +664,14 @@ public sealed partial class Player : NPC
 		}
 	}
 
+	internal Environment.RayResult? CastMouseRay()
+	{
+		Camera? camera = Root.Environment.CurrentCamera;
+		if (camera == null) return null;
+		(Vector3 origin, Vector3 direction) = camera.Project(Root.Input.MousePosition);
+		return Root.Environment.RaycastMouse(origin, direction);
+	}
+
 	public override void PhysicsProcess(double delta)
 	{
 		base.PhysicsProcess(delta);
@@ -677,7 +685,7 @@ public sealed partial class Player : NPC
 			return;
 		}
 
-		Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition);
+		Environment.RayResult? ray = CastMouseRay();
 		if (ray.HasValue && ray.Value.Instance is Physical p)
 		{
 			if (_mouseHoveringOn != null && _mouseHoveringOn != p)
@@ -795,7 +803,7 @@ public sealed partial class Player : NPC
 
 		if (@event.IsActionPressed("activate"))
 		{
-			Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition);
+			Environment.RayResult? ray = CastMouseRay();
 			if (ray.HasValue && ray.Value.Instance is Physical p)
 			{
 				p.InvokeClicked(this);

--- a/Polytoria/scripts/datamodel/services/InputService.cs
+++ b/Polytoria/scripts/datamodel/services/InputService.cs
@@ -610,7 +610,7 @@ public sealed partial class InputService : Instance
 		Vector3 rayOrigin = camera.ProjectRayOrigin(mousePos);
 		Vector3 rayDir = camera.ProjectRayNormal(mousePos);
 
-		RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: ignoreList);
+		RayResult? hit = Root.Environment.RaycastMouse(rayOrigin, rayDir, ignoreList: ignoreList);
 		return hit != null ? hit.Value.Position : rayOrigin + rayDir * 1000f;
 	}
 


### PR DESCRIPTION
## Summary

Adds a field to Physical to exclude it from mouse raycast operations (.MouseEnter/Exit, .Clicked, Grabbable, Input.GetMouseWorldPosition).
This is useful for when a Part is used for detecting presence or in other cases where a Physical shouldn't block mouse clicks or Grabbable interactions.

## Related issue or discussion

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Dragging a grabbable out and in of a transparent part.

https://github.com/user-attachments/assets/a27923d7-445e-4126-9945-c1825a42b1fb

## AI/LLM use

None