### PR TITLE
feat: implement Spanish localization and UI Client translation support

### DIFF
--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -432,6 +432,11 @@ search={
 
 pointing/android/enable_pan_and_scale_gestures=true
 
+[internationalization]
+
+locale/translations=PackedStringArray("res://scenes/client/locale/es.po")
+locale/translations_pot_files=PackedStringArray("res://scenes/client/ui/chat/chat.tscn", "res://scenes/client/ui/playerlist/user_options.tscn", "res://scenes/client/ui/menu/game_menu.tscn", "res://scenes/client/ui/menu/views/overview.tscn", "res://scenes/client/ui/health/health_bar.tscn", "res://scenes/client/ui/playerlist/leaderboard.tscn", "res://scenes/client/ui/inventory/inventory.tscn", "res://scenes/client/ui/capture/capture.tscn", "res://scenes/client/ui/core/notification/screenshot_toast.tscn", "res://scenes/client/ui/core/notification/friend_request_toast.tscn", "res://scenes/client/ui/core/disconnected_ui.tscn", "res://scripts/client/ui/menu/views/UIMenuOverview.cs", "res://scripts/client/ui/UILoadingScreen.cs")
+
 [layer_names]
 
 3d_render/layer_6="Character"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -390,7 +390,7 @@ msgid "Rendering method to use. Use compatibility on older hardware."
 msgstr "Método de renderizado a usar. Utilice Compatibilidad para equipos antiguos."
 
 msgid "Auto"
-msgstr "Automatico"
+msgstr "Automático"
 
 msgid "Standard"
 msgstr "Estándar"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -39,7 +39,7 @@ msgstr ""
 
 #: scenes/client/ui/chat/chat.tscn
 msgid "Send a chat message..."
-msgstr "Envia un mensaje por chat..."
+msgstr "Envía un mensaje por el chat..."
 
 #: scenes/client/ui/playerlist/user_options.tscn
 msgid "Add Friend"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -87,7 +87,7 @@ msgstr "Lista de Jugadores"
 
 #: scenes/client/ui/inventory/inventory.tscn
 msgid "Nothing in Inventory"
-msgstr "Inventario Vacio"
+msgstr "Inventario Vacío"
 
 msgid "Press ` to close"
 msgstr "Pulsa ` para cerrar"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -177,7 +177,7 @@ msgid "Server Under Pressure."
 msgstr "Servidor Bajo Presión."
 
 msgid "Radio Silence. The server is not responding right now."
-msgstr "Silencio de Radio. El servidor no responde en este momento."
+msgstr "Sin Respuesta. El servidor no responde en este momento."
 
 #: scripts/client/ui/menu/views/UIMenuOverview.cs
 msgid "Playing for "

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -307,7 +307,7 @@ msgid "Shows hidden advanced settings."
 msgstr "Muestra los ajustes avanzados ocultos."
 
 msgid "Automatic"
-msgstr "Automatico"
+msgstr "Automático"
 
 msgid "Language"
 msgstr "Idioma"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -411,7 +411,7 @@ msgid "MSAA Level"
 msgstr "Nivel de Suavizado (MSAA)"
 
 msgid "MSAA anti-aliasing level."
-msgstr "Nivel de suavizado MSAA."
+msgstr "Nivel de suavizado."
 
 msgid "Shadow Quality"
 msgstr "Calidad de Sombras"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -301,7 +301,7 @@ msgid "Show connection status warnings."
 msgstr "Muestra advertencias sobre el estado de la conexión."
 
 msgid "Show Advanced Settings"
-msgstr "Mostrar Ajustes Avanzadados"
+msgstr "Mostrar Ajustes Avanzados"
 
 msgid "Shows hidden advanced settings."
 msgstr "Muestra los ajustes avanzados ocultos."

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -423,7 +423,7 @@ msgid "Shadow Distance"
 msgstr "Distancia de Sombras"
 
 msgid "How far shadows are visible."
-msgstr "La distancia a la que se ven las sombras."
+msgstr "Hasta qué distancia se ven las sombras."
 
 msgid "Glow"
 msgstr "Resplandor"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -298,7 +298,7 @@ msgid "Show Connection Indicators"
 msgstr "Mostrar Indicadores de Conexión"
 
 msgid "Show connection status warnings."
-msgstr "Muestra advertencias sobre el estado de la conexión."
+msgstr "Mostrar advertencias sobre el estado de la conexión."
 
 msgid "Show Advanced Settings"
 msgstr "Mostrar Ajustes Avanzados"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -408,7 +408,7 @@ msgid "The resolution scale to render graphics at."
 msgstr "La escala de resolución a la que se renderizan los gráficos."
 
 msgid "MSAA Level"
-msgstr "Nivel de MSAA"
+msgstr "Nivel de Suavizado (MSAA)"
 
 msgid "MSAA anti-aliasing level."
 msgstr "Nivel de suavizado MSAA."

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -155,7 +155,7 @@ msgid "Your Polytoria account has been terminated, please visit the website for 
 msgstr "Tu cuenta de Polytoria ha sido suspendida. Visita la página web para obtener más información."
 
 msgid "Authentication failure, Please try again."
-msgstr "Fallo de autenticación. Porfavor inténtalo de nuevo."
+msgstr "Error de autenticación. Por favor inténtelo de nuevo."
 
 msgid "Integrity failure, please update your client."
 msgstr "Fallo de integridad, porfavor actualiza tu cliente."

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -414,7 +414,7 @@ msgid "MSAA anti-aliasing level."
 msgstr "Nivel de suavizado MSAA."
 
 msgid "Shadow Quality"
-msgstr "Calidad de las Sombras"
+msgstr "Calidad de Sombras"
 
 msgid "Shadow quality level."
 msgstr "Nivel de calidad de las sombras."

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -66,7 +66,7 @@ msgid "Showcase"
 msgstr "Resumen"
 
 msgid "Statistics"
-msgstr "Estadisticas"
+msgstr "Estadísticas"
 
 msgid "Screenshot"
 msgstr "Captura de pantalla"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -46,7 +46,7 @@ msgid "Add Friend"
 msgstr "Añadir Amigo"
 
 msgid "Remove Friend"
-msgstr "Remover Amigo"
+msgstr "Eliminar Amigo"
 
 msgid "View Profile"
 msgstr "Ver Perfil"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -1,0 +1,504 @@
+# LANGUAGE translation for Polytoria for the following files:
+# res://scenes/client/ui/chat/chat.tscn
+# res://scenes/client/ui/playerlist/user_options.tscn
+# res://scenes/client/ui/menu/game_menu.tscn
+# res://scenes/client/ui/menu/views/overview.tscn
+# res://scenes/client/ui/health/health_bar.tscn
+# res://scenes/client/ui/playerlist/leaderboard.tscn
+# res://scenes/client/ui/inventory/inventory.tscn
+# res://scenes/client/ui/capture/capture.tscn
+# res://scenes/client/ui/core/notification/screenshot_toast.tscn
+# res://scenes/client/ui/core/notification/friend_request_toast.tscn
+# res://scenes/client/ui/core/disconnected_ui.tscn
+# res://scripts/client/ui/core/DisconnectedUI.cs
+# res://scripts/client/ui/menu/views/UIMenuOverview.cs
+# res://scripts/client/ui/UILoadingScreen.cs
+# res://scripts/client/settings/ClientSettingsRegistry.cs
+# res://scripts/shared/settings/SharedSettingsRegistry.cs
+# res://scenes/shared/settings/licenses_row.tscn
+# res://scripts/client/ui/settings/SettingRow.cs
+# res://scenes/client/ui/core_ui.tscn
+# res://scripts/datamodel/services/NetworkService.cs
+#
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Polytoria v2.0.19\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Angelok1\n"
+"Language-Team: https://github.com/ArxelDev | Angelok1\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.9\n"
+
+#: scenes/client/ui/chat/chat.tscn
+msgid "Send a chat message..."
+msgstr "Envia un mensaje por chat..."
+
+#: scenes/client/ui/playerlist/user_options.tscn
+msgid "Add Friend"
+msgstr "Añadir Amigo"
+
+msgid "Remove Friend"
+msgstr "Remover Amigo"
+
+msgid "View Profile"
+msgstr "Ver Perfil"
+
+#: scenes/client/ui/menu/game_menu.tscn
+msgid "Overview"
+msgstr "Resumen"
+
+msgid "Players"
+msgstr "Jugadores"
+
+msgid "Settings"
+msgstr "Ajustes"
+
+#: scenes/client/ui/menu/views/overview.tscn
+msgid "Showcase"
+msgstr "Resumen"
+
+msgid "Statistics"
+msgstr "Estadisticas"
+
+msgid "Screenshot"
+msgstr "Captura de pantalla"
+
+msgid "Respawn"
+msgstr "Reaparecer"
+
+msgid "Leave"
+msgstr "Salir"
+
+#: scenes/client/ui/health/health_bar.tscn
+msgid "HEALTH"
+msgstr "SALUD"
+
+#: scenes/client/ui/playerlist/leaderboard.tscn
+msgid "Playerlist"
+msgstr "Lista de Jugadores"
+
+#: scenes/client/ui/inventory/inventory.tscn
+msgid "Nothing in Inventory"
+msgstr "Inventario Vacio"
+
+msgid "Press ` to close"
+msgstr "Pulsa ` para cerrar"
+
+#: scenes/client/ui/capture/capture.tscn
+#: scenes/client/ui/core/notification/screenshot_toast.tscn
+msgid "Photo Taken!"
+msgstr "¡Foto Tomada!"
+
+msgid "Save"
+msgstr "Guardar"
+
+#: scenes/client/ui/capture/capture.tscn
+msgid "Memory: Captured"
+msgstr "Memoria: Capturada"
+
+#: scenes/client/ui/capture/capture.tscn
+msgid "Share"
+msgstr "Compartir"
+
+#: scenes/client/ui/capture/capture.tscn
+msgid "Close"
+msgstr "Cerrar"
+
+#: scenes/client/ui/capture/capture.tscn
+msgid "Write Caption Here..."
+msgstr "Escribe aquí un comentario para la foto..."
+
+#: scenes/client/ui/capture/capture.tscn
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: scenes/client/ui/core/notification/screenshot_toast.tscn
+msgid "View"
+msgstr "Ver"
+
+#: scenes/client/ui/core/notification/friend_request_toast.tscn
+msgid "Friend Request from.."
+msgstr "Solicitud de Amistad de..."
+
+#: scenes/client/ui/core/notification/friend_request_toast.tscn
+msgid "Accept"
+msgstr "Aceptar"
+
+#: scenes/client/ui/core/notification/friend_request_toast.tscn
+msgid "Ignore"
+msgstr "Ignorar"
+
+#: scenes/client/ui/core/disconnected_ui.tscn
+msgid "Connection Lost"
+msgstr "Conexión Perdida"
+
+msgid "Quit"
+msgstr "Salir"
+
+#: scripts/client/ui/core/DisconnectedUI.cs
+msgid "Code: "
+msgstr "Código: "
+
+#: scripts/datamodel/services/NetworkService.cs
+msgid "Disconnected from server"
+msgstr "Desconectado del servidor"
+
+msgid "Your Polytoria account has been terminated, please visit the website for more info."
+msgstr "Tu cuenta de Polytoria ha sido suspendida. Visita la página web para obtener más información."
+
+msgid "Authentication failure, Please try again."
+msgstr "Fallo de autenticación. Porfavor inténtalo de nuevo."
+
+msgid "Integrity failure, please update your client."
+msgstr "Fallo de integridad, porfavor actualiza tu cliente."
+
+msgid "Network mode mismatch."
+msgstr "Incompatibilidad del Modo de Red."
+
+msgid "Another device is already playing using this account, please leave the game first then try again."
+msgstr "Otro dispositivo ya está jugando con esta cuenta, por favor sal primero del juego, y vuelve a intentarlo."
+
+msgid "Connection timeout"
+msgstr "Tiempo de espera de conexión agotado"
+
+#: scenes/client/ui/core_ui.tscn
+msgid "High Ping."
+msgstr "Ping Alto."
+
+msgid "Server Under Pressure."
+msgstr "Servidor Bajo Presión."
+
+msgid "Radio Silence. The server is not responding right now."
+msgstr "Silencio de Radio. El servidor no responde en este momento."
+
+#: scripts/client/ui/menu/views/UIMenuOverview.cs
+msgid "Playing for "
+msgstr "Jugando por "
+
+#: scripts/client/ui/menu/views/UIMenuOverview.cs
+msgid " Instance"
+msgid_plural " Instances"
+msgstr[0] " Instancia"
+msgstr[1] " Instancias"
+
+msgid " player in the server"
+msgid_plural " players in the server"
+msgstr[0] " jugador en el servidor"
+msgstr[1] " jugadores en el servidor"
+
+#: scripts/client/ui/UILoadingScreen.cs
+msgid "Constructing ({current}/{max})..."
+msgstr "Construyuendo ({current}/{max})..."
+
+#: scripts/client/ui/UILoadingScreen.cs
+msgid "Connecting..."
+msgstr "Conectando..."
+
+#: scripts/client/ui/UILoadingScreen.cs
+msgid "Waiting for player"
+msgstr "Esperando al jugador..."
+
+#: scripts/client/ui/UILoadingScreen.cs
+msgid "Downloading world..."
+msgstr "Descargando mundo..."
+
+#: scripts/client/ui/UILoadingScreen.cs
+msgid "Ready!"
+msgstr "¡Listo!"
+
+#: scripts/client/ui/UILoadingScreen.cs
+msgid "Waiting for server..."
+msgstr "Esperando al servidor..."
+
+#: scripts/client/ui/UILoadingScreen.cs
+msgid "By "
+msgstr "Por "
+
+msgid "Display"
+msgstr "Pantalla"
+
+msgid "Graphics"
+msgstr "Graficos"
+
+msgid "Post Processing"
+msgstr "Post Procesado"
+
+msgid "Overlay"
+msgstr "Superposición"
+
+msgid "Advanced"
+msgstr "Avanzado"
+
+msgid "Chat Colors"
+msgstr "Colores del Chat"
+
+msgid "Show colored usernames in chat."
+msgstr "Mostrar nombres de usuario coloreados en el chat."
+
+msgid "Chat Font"
+msgstr "Fuente del Chat"
+
+msgid "Font used for chat messages."
+msgstr "Fuente usada para los mensajes del chat."
+
+msgid "Default"
+msgstr "Por Defecto"
+
+msgid "Chat Font Size"
+msgstr "Tamaño de Fuente del Chat"
+
+msgid "Font size for chat messages. 0 uses the theme default."
+msgstr "Tamaño de fuente de los mensajes del chat. El valor 0 utiliza el valor por defecto del tema."
+
+msgid "Ctrl Lock"
+msgstr "Bloqueo Ctrl"
+
+msgid "Allow Ctrl Lock while in third person."
+msgstr "Permitir bloqueo de la vista en tercera persona con Ctrl."
+
+msgid "Volume"
+msgstr "Volumen"
+
+msgid "Master game volume."
+msgstr "Ajusta el volumen del juego."
+
+msgid "Camera Sensitivity"
+msgstr "Sensibilidad de la Cámara"
+
+msgid "Camera movement sensitivity."
+msgstr "Sensibilidad del movimiento de la cámara."
+
+msgid "UI Scale"
+msgstr "Escalda de la IU"
+
+msgid "Scale of the user interface."
+msgstr "Escala de la interfaz de usuario."
+
+msgid "Performance Overlay"
+msgstr "Superposición de Rendimiento"
+
+msgid "Show performance information on the screen."
+msgstr "Mostrar información sobre el rendimiento en la pantalla."
+
+msgid "None"
+msgstr "Ninguno"
+
+msgid "Minimal"
+msgstr "Mínimo"
+
+msgid "Show Connection Indicators"
+msgstr "Mostrar Indicadores de Conexión"
+
+msgid "Show connection status warnings."
+msgstr "Muestra advertencias sobre el estado de la conexión."
+
+msgid "Show Advanced Settings"
+msgstr "Mostrar Ajustes Avanzadados"
+
+msgid "Shows hidden advanced settings."
+msgstr "Muestra los ajustes avanzados ocultos."
+
+msgid "Automatic"
+msgstr "Automatico"
+
+msgid "Language"
+msgstr "Idioma"
+
+msgid "Select the game language."
+msgstr "Selecciona el idioma del juego."
+
+#: scripts/shared/settings/SharedSettingsRegistry.cs
+msgid "Fullscreen"
+msgstr "Pantalla Completa"
+
+msgid "Use fullscreen window mode."
+msgstr "Usa el modo de pantalla completa."
+
+msgid "V-Sync"
+msgstr "Sincronización Vertical (V-Sync)"
+
+msgid "Synchronize frames to display refresh."
+msgstr "Sincronizar los fotogramas con la frecuencia de actualización de la pantalla."
+
+msgid "FPS Preset"
+msgstr "Preajuste de FPS"
+
+msgid ""
+"Set the FPS preset to use.\n"
+"If V-Sync is enabled, framerate won't surpass the display refresh rate."
+msgstr ""
+"Selecciona el ajuste de FPS que desees utilizar.\n"
+"Si la sincronización vertical (V-Sync) está activada, la velocidad de fotogramas no superará la frecuencia de actualización de la pantalla."
+
+msgid "Custom"
+msgstr "Personalizado"
+
+msgid "Reduced (30)"
+msgstr "Reducido (30)"
+
+msgid "Standard (60)"
+msgstr "Estándar (60)"
+
+msgid "Extended (90)"
+msgstr "Extendido (90)"
+
+msgid "Smooth (120)"
+msgstr "Suave (120)"
+
+msgid "Slick (144)"
+msgstr "Supersuave (144)"
+
+msgid "Fluid (240)"
+msgstr "Fluido (240)"
+
+msgid "Limitless"
+msgstr "Sin límites"
+
+msgid "FPS Cap"
+msgstr "Límite de FPS"
+
+msgid "Limit the number of frames per second."
+msgstr "Limita el número de fotogramas por segundo."
+
+msgid "Graphics Preset"
+msgstr "Ajustes Por Defecto de los Gráficos"
+
+msgid "Overall graphics quality preset."
+msgstr "Ajustes por defecto de la calidad general de los gráficos."
+
+msgid "Low"
+msgstr "Bajo"
+
+msgid "Medium"
+msgstr "Medio"
+
+msgid "High"
+msgstr "Alto"
+
+msgid "Rendering Method"
+msgstr "Método de Renderizado"
+
+msgid "Rendering method to use. Use compatibility on older hardware."
+msgstr "Método de renderizado a usar. Utilice Compatibilidad para equipos antiguos."
+
+msgid "Auto"
+msgstr "Automatico"
+
+msgid "Standard"
+msgstr "Estándar"
+
+msgid "Performance"
+msgstr "Rendimiento"
+
+msgid "Compatibility"
+msgstr "Compatibilidad"
+
+msgid "Render Scale"
+msgstr "Escala de Renderizado"
+
+msgid "The resolution scale to render graphics at."
+msgstr "La escala de resolución a la que se renderizan los gráficos."
+
+msgid "MSAA Level"
+msgstr "Nivel de MSAA"
+
+msgid "MSAA anti-aliasing level."
+msgstr "Nivel de suavizado MSAA."
+
+msgid "Shadow Quality"
+msgstr "Calidad de las Sombras"
+
+msgid "Shadow quality level."
+msgstr "Nivel de calidad de las sombras."
+
+msgid "Shadow Distance"
+msgstr "Distancia de Sombras"
+
+msgid "How far shadows are visible."
+msgstr "La distancia a la que se ven las sombras."
+
+msgid "Glow"
+msgstr "Resplandor"
+
+msgid "Toggle glow/bloom effect."
+msgstr "Activa o desactiva el efecto de resplandor/bloom."
+
+# SSAO
+msgid "Toggle ambient occlusion effect."
+msgstr "Activa o desactiva el efecto de oclusión ambiental."
+
+# SSR
+msgid "Toggle screen-space reflections."
+msgstr "Activa o desactiva los reflejos en el espacio de la pantalla."
+
+# SSIL
+msgid "Toggle screen-space illuminated lighting."
+msgstr "Activa o desactiva la iluminación en el espacio de la pantalla."
+
+# SDFGI
+msgid "Toggle SDFGI (semi-real-time global illumination) effect."
+msgstr "Activa o desactiva el efecto SDFGI (iluminación global en tiempo semi-real)."
+
+msgid "Normal Maps"
+msgstr "Mapas Normales"
+
+msgid "Toggle normal maps on part materials."
+msgstr "Activa o desactiva los mapas de normales en los materiales de las piezas."
+
+msgid "SDFGI Cell Size"
+msgstr "Tamaño de Celdas SDFGI"
+
+msgid "Size of SDFGI cells. Larger cells improve performance but reduce quality."
+msgstr "Tamaño de las celdas SDFGI. Las celdas más grandes mejoran el rendimiento, pero reducen la calidad."
+
+msgid "SDFGI Cascades"
+msgstr "Cascadas SDFGI"
+
+msgid "Number of cascades for SDFGI."
+msgstr "Número de cascadas para SDFGI."
+
+msgid "SSIL Radius"
+msgstr "Radio SSIL"
+
+msgid "Radius for SSIL effect"
+msgstr "Radio del efecto SSIL"
+
+msgid "Asset Queue"
+msgstr "Cola de Recursos"
+
+msgid "Change how many assets can load at once. Higher = faster, with more potential lag."
+msgstr "Modifica el número de recursos que se pueden cargar a la vez. Más alto = más rápido, pero con mayor riesgo de retrasos."
+
+msgid "Default (5)"
+msgstr "Por Defecto (5)"
+
+msgid "Fast (15)"
+msgstr "Rápido (15)"
+
+msgid "Aggressive (30)"
+msgstr "Agresivo (30)"
+
+msgid "SPEED (60)"
+msgstr "VELOZ (60)"
+
+#: scenes/shared/settings/licenses_row.tscn
+msgid "Licenses"
+msgstr "Licencias"
+
+msgid "View third party licenses and attributions."
+msgstr "Ver licencias de terceros y atribuciones."
+
+msgid "View Licenses"
+msgstr "Ver Licencias"
+
+#: scripts/client/ui/settings/SettingRow.cs
+msgid "Requires restart"
+msgstr "Requiere reiniciar"

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -277,7 +277,7 @@ msgid "Camera movement sensitivity."
 msgstr "Sensibilidad del movimiento de la cámara."
 
 msgid "UI Scale"
-msgstr "Escalda de la IU"
+msgstr "Escala de la Interfaz"
 
 msgid "Scale of the user interface."
 msgstr "Escala de la interfaz de usuario."

--- a/Polytoria/scenes/client/locale/es.po
+++ b/Polytoria/scenes/client/locale/es.po
@@ -336,7 +336,7 @@ msgid ""
 "If V-Sync is enabled, framerate won't surpass the display refresh rate."
 msgstr ""
 "Selecciona el ajuste de FPS que desees utilizar.\n"
-"Si la sincronización vertical (V-Sync) está activada, la velocidad de fotogramas no superará la frecuencia de actualización de la pantalla."
+"Si la sincronización vertical está activada, la velocidad de fotogramas no superará la frecuencia de actualización de la pantalla."
 
 msgid "Custom"
 msgstr "Personalizado"

--- a/Polytoria/scripts/client/settings/ClientSettingsRegistry.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingsRegistry.cs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+using Godot;
 using Polytoria.Shared.Settings;
 using System.Collections.Generic;
 
@@ -183,6 +184,34 @@ public static class ClientSettingsRegistry
 				ValueKind = SettingValueKind.Bool,
 				ControlKind = SettingControlKind.Toggle,
 				DefaultValue = true,
+			});
+
+		var languageOptions = new List<SettingOption<string>>
+		{
+			new() { Value = "automatic", Label = "Automatic" },
+			new() { Value = "en", Label = "English" }
+		};
+
+		foreach (string locale in TranslationServer.GetLoadedLocales())
+		{
+			languageOptions.Add(new()
+			{
+				Value = locale,
+				Label = TranslationServer.GetLocaleName(locale)
+			});
+		}
+
+		defs.Add(SharedSettingKeys.Localization.Language,
+			new SettingDef<string>
+			{
+				Key = SharedSettingKeys.Localization.Language,
+				SectionKey = "general",
+				Label = "Language",
+				Description = "Select the game language.",
+				ValueKind = SettingValueKind.String,
+				ControlKind = SettingControlKind.Dropdown,
+				DefaultValue = "automatic",
+				Options = languageOptions
 			});
 
 		SettingDef.ValidateAll(defs.Values);

--- a/Polytoria/scripts/client/settings/ClientSettingsService.cs
+++ b/Polytoria/scripts/client/settings/ClientSettingsService.cs
@@ -34,6 +34,13 @@ public sealed partial class ClientSettingsService : SettingsServiceBase
 		MigrateRenderingMethod();
 		ApplyDefaults();
 
+		string savedLanguage = "automatic";
+		if (_values.TryGetValue(SharedSettingKeys.Localization.Language, out object? langValue))
+		{
+			savedLanguage = langValue?.ToString() ?? "automatic";
+		}
+		ApplyLanguage(savedLanguage);
+
 		if (!settingsExists)
 		{
 			GraphicsPreset autoPreset = GraphicsAutoDetector.Detect();
@@ -147,5 +154,22 @@ public sealed partial class ClientSettingsService : SettingsServiceBase
 	protected override void OnAfterSet(string key, object normalizedValue)
 	{
 		GraphicsPresetManager.HandlePresetChange(this, key, normalizedValue);
+
+		if (key == SharedSettingKeys.Localization.Language)
+		{
+			ApplyLanguage(normalizedValue.ToString() ?? "automatic");
+		}
+	}
+
+	private void ApplyLanguage(string language)
+	{
+		if (language == "automatic")
+		{
+			TranslationServer.SetLocale(OS.GetLocaleLanguage());
+		}
+		else
+		{
+			TranslationServer.SetLocale(language);
+		}
 	}
 }

--- a/Polytoria/scripts/client/ui/UILoadingScreen.cs
+++ b/Polytoria/scripts/client/ui/UILoadingScreen.cs
@@ -56,7 +56,7 @@ public partial class UILoadingScreen : Control
 		_gameThumbnailImage.ResourceLoaded += OnGameThumbnailLoaded;
 		_gameIconImage.ResourceLoaded += OnGameIconLoaded;
 
-		SetStatusText("Waiting for server...");
+		SetStatusText(Tr("Waiting for server..."));
 		Visible = true;
 	}
 
@@ -127,7 +127,7 @@ public partial class UILoadingScreen : Control
 		_gameIconImage.LoadResource();
 
 		_gameTitleLabel.Text = info.Name;
-		_gameCreatorLabel.Text = "By " + info.Creator.Name;
+		_gameCreatorLabel.Text = Tr("By ") + info.Creator.Name;
 		AppearInfo();
 	}
 
@@ -152,27 +152,27 @@ public partial class UILoadingScreen : Control
 		Loader = null;
 		_statusProgressbar.Value = current;
 		_statusProgressbar.MaxValue = max;
-		SetStatusText($"Constructing ({current}/{max})...");
+		SetStatusText(Tr($"Constructing ({current}/{max})..."));
 	}
 
 	private void OnWorldReady()
 	{
-		SetStatusText("Waiting for player");
+		SetStatusText(Tr("Waiting for player"));
 	}
 
 	private void OnServerReady()
 	{
-		SetStatusText("Connecting...");
+		SetStatusText(Tr("Connecting..."));
 	}
 
 	private void OnClientConnectedToServer()
 	{
-		SetStatusText("Downloading world...");
+		SetStatusText(Tr("Downloading world..."));
 	}
 
 	private void OnClientReady()
 	{
-		SetStatusText("Ready!");
+		SetStatusText(Tr("Ready!"));
 		_animPlay.Play("load_ready");
 
 		_gameThumbnailImage.ResourceLoaded -= OnGameThumbnailLoaded;

--- a/Polytoria/scripts/client/ui/core/DisconnectedUI.cs
+++ b/Polytoria/scripts/client/ui/core/DisconnectedUI.cs
@@ -40,7 +40,7 @@ public partial class DisconnectedUI : CanvasLayer
 	{
 		Input.MouseMode = Input.MouseModeEnum.Visible;
 		_reasonLabel.Text = reason;
-		_codeLabel.Text = "Code: " + code;
+		_codeLabel.Text = Tr("Code: ") + code;
 		_animPlay.Play("appear");
 	}
 }

--- a/Polytoria/scripts/client/ui/menu/views/UIMenuOverview.cs
+++ b/Polytoria/scripts/client/ui/menu/views/UIMenuOverview.cs
@@ -142,9 +142,9 @@ public sealed partial class UIMenuOverview : UIMenuViewBase
 	public override void _Process(double delta)
 	{
 		World root = Menu.CoreUI.Root;
-		_statInstanceCountLabel.Text = root.InstanceCount.ToString() + " Instances";
-		_statTimePlayedLabel.Text = "Playing for " + TimeUtils.FormatSeconds((long)root.UpTime);
-		_statPlayerCountLabel.Text = root.Players.PlayersCount.ToString() + " players in the server";
+		_statInstanceCountLabel.Text = root.InstanceCount.ToString() + TrN(" Instance", " Instances", root.InstanceCount);
+		_statTimePlayedLabel.Text = Tr("Playing for ") + TimeUtils.FormatSeconds((long)root.UpTime);
+		_statPlayerCountLabel.Text = root.Players.PlayersCount.ToString() + TrN(" player in the server", " players in the server", root.Players.PlayersCount);
 		base._Process(delta);
 	}
 

--- a/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
+++ b/Polytoria/scripts/shared/settings/SharedSettingKeys.cs
@@ -43,4 +43,9 @@ public static class SharedSettingKeys
 	{
 		public const string AssetQueue = "advanced.asset_queue";
 	}
+
+	public static class Localization
+	{
+		public const string Language = "localization.language";
+	}
 }


### PR DESCRIPTION
## Summary
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

<ins>**What changed:**</ins> Added complete Spanish (es) localization support to the client interface, including translation files, localization service integration, and UI text updates using Tr().

<ins>**Why**:</ins> To make Polytoria accessible to Spanish-speaking users, and to allow other language communities to create a translation of the client for their language.

<ins>**Extra:**</ins>
I've attached links to Godot's official documentation, which was used for this new feature.
https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html
https://docs.godotengine.org/en/stable/tutorials/i18n/localization_using_gettext.html
https://docs.godotengine.org/en/stable/tutorials/i18n/internationalizing_games.html#converting-keys-to-text

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

https://github.com/user-attachments/assets/e86d4919-dc0f-4153-8146-4fea9d385003

<img width="688" height="181" alt="Selector_de_Idioma_Polytoria" src="https://github.com/user-attachments/assets/1983f244-25da-48b7-8db9-490989db975d" />

## AI/LLM use
<!-- Describe AI use, or write "None" if not applicable -->

Used solely for technical advice, the AI never interacted with the code.