### PR TITLE
add Visible property to `Marker3D` for use outside of creator

### DIFF
--- a/Polytoria/scripts/datamodel/Marker3D.cs
+++ b/Polytoria/scripts/datamodel/Marker3D.cs
@@ -13,6 +13,7 @@ public partial class Marker3D : Dynamic
 	private float _length;
 	private bool _appearOnTop;
 	private bool _visibleInDev;
+	private bool _visible;
 
 	[Editable, ScriptProperty, DefaultValue(1)]
 	public float Length
@@ -45,8 +46,20 @@ public partial class Marker3D : Dynamic
 			_visibleInDev = value;
 #if CREATOR
 			_meshInstance.Visible = _visibleInDev;
-#else
-			_meshInstance.Visible = false;
+#endif
+			RenderGizmo();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(false)]
+	public bool Visible
+	{
+		get => _visible;
+		set
+		{
+			_visible = value;
+#if !CREATOR
+			_meshInstance.Visible = _visible;
 #endif
 			RenderGizmo();
 		}


### PR DESCRIPTION
## Summary
adds a `Visible` property. when true and when not in the creator `Marker3D` will be visible to players
<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion

Fixes #1143 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->
None