### PR TITLE
Stop Grabbables slamming into player when panning camera

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -405,6 +405,11 @@ public sealed partial class Camera : Dynamic
 		base.ExitTree();
 	}
 
+	public Vector2 GetMousePos()
+	{
+		return _dragPanning ? _turnStartPos : Root.Input.MousePosition;
+	}
+
 	private void EnforceCurrentCam()
 	{
 		// idk godot

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -273,18 +273,27 @@ public partial class Grabbable : Instance
 					Camera3D camera = viewport.GetCamera3D();
 					Camera? cam = Root.Environment.CurrentCamera;
 					if (cam == null) return;
-					Vector2 mousePos = Root.Input.MousePosition;
-					Vector3 rayOrigin = camera.ProjectRayOrigin(mousePos);
-					Vector3 rayDir = camera.ProjectRayNormal(mousePos);
 
 					Vector3? targetPos = null;
 
 					if (cam.IsFirstPerson)
 					{
+						Vector2 mousePos = Root.Input.MousePosition;
+						Vector3 rayOrigin = camera.ProjectRayOrigin(mousePos);
+						Vector3 rayDir = camera.ProjectRayNormal(mousePos);
 						targetPos = rayOrigin + rayDir * MaxRange;
+					}
+					else if (cam.CtrlLocked && cam.Target != null)
+					{
+						Vector2 mousePos = Root.Input.MousePosition;
+						Vector3 rayDir = camera.ProjectRayNormal(mousePos);
+						targetPos = cam.Target.Position + cam.PositionOffset + rayDir * MaxRange;
 					}
 					else
 					{
+						Vector2 mousePos = cam.GetMousePos();
+						Vector3 rayOrigin = camera.ProjectRayOrigin(mousePos);
+						Vector3 rayDir = camera.ProjectRayNormal(mousePos);
 						RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: [Parent], passthroughMask: 1 << 2);
 						if (hit != null)
 						{


### PR DESCRIPTION
## Summary

When dragging a Grabbable and then drag panning or entering ctrl lock, due to both modes moving the mouse cursor to the center of the screen (where the player character usually is), this leads to the Grabbable slamming into the player character.
This pull requests makes that not happen.

Namely, ctrl lock now behaves like first person and drag panning now uses the saved mouse position from when starting the pan.

## Related issue or discussion

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [x] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [x] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Dragging a Grabbable, then drag panning, then entering ctrl lock.

https://github.com/user-attachments/assets/9d4221a3-1f21-4174-ae59-1b09d3b97034

## AI/LLM use

None