### PR TITLE
[Bugfix]: Resolving Register Bug

### DIFF
--- a/Polytoria/scripts/creator/ui/docks/properties/tags/InstanceTagView.cs
+++ b/Polytoria/scripts/creator/ui/docks/properties/tags/InstanceTagView.cs
@@ -23,14 +23,24 @@ public partial class InstanceTagView : Control
 
 	private string _searchFilter = "";
 
-	public override void _EnterTree()
+	public override void _Ready()
 	{
-		_newTagEdit.TextSubmitted += (_) => { AddNewTag(); };
+		base._Ready();
+
+		_newTagEdit.TextSubmitted += OnTextSubmitted;
 		_newTagEdit.TextChanged += OnSearch;
 		_plusButton.Pressed += AddNewTag;
+	}
 
-		Clear();
+	public override void _EnterTree()
+	{
 		base._EnterTree();
+		Clear();
+	}
+
+	private void OnTextSubmitted(string text)
+	{
+		AddNewTag();
 	}
 
 	private void OnSearch(string newText)
@@ -68,12 +78,10 @@ public partial class InstanceTagView : Control
 	{
 		foreach (Node child in _container.GetChildren())
 		{
-			if (child is TagLabel label)
-			{
-				bool matchesSearch = string.IsNullOrEmpty(_searchFilter) ||
-									label.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase);
-				label.Visible = matchesSearch;
-			}
+			if (child is not TagLabel label) continue;
+			bool matchesSearch = string.IsNullOrEmpty(_searchFilter) ||
+								 label.Text.Contains(_searchFilter, StringComparison.CurrentCultureIgnoreCase);
+			label.Visible = matchesSearch;
 		}
 	}
 
@@ -88,12 +96,9 @@ public partial class InstanceTagView : Control
 		_tagLayout.Visible = true;
 
 		HashSet<string> allTags = [];
-		foreach (Instance instance in Targets)
+		foreach (var tag in Targets.SelectMany(instance => instance.Tags))
 		{
-			foreach (string tag in instance.Tags)
-			{
-				allTags.Add(tag);
-			}
+			allTags.Add(tag);
 		}
 
 		foreach (string tag in allTags)
@@ -123,5 +128,4 @@ public partial class InstanceTagView : Control
 			_container.AddChild(label);
 		}
 	}
-
 }


### PR DESCRIPTION
## Summary

While working on #1153 I found a bug when moving the Tag Panel, that was caused because when the Panel got moved it tried to connect to the Functions again.

Additionally: Remaining Code Refactored with Rider

ERROR:
```text
ERROR: Signal 'text_submitted' is already connected to given callable 'Delegate::Invoke' in that object.
   at: connect (core/object/object.cpp:1562)
   C# backtrace (most recent call first):
       [0] int Godot.NativeCalls.godot_icall_3_949(nint, nint, Godot.NativeInterop.godot_string_name, Godot.Callable&, uint) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/NativeCalls.cs:8488)
       [1] Godot.Error Godot.GodotObject.Connect(Godot.StringName, Godot.Callable, uint) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/GodotObject.cs:945)
       [2] void Godot.LineEdit.add_TextSubmitted(Godot.LineEdit+TextSubmittedEventHandler) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/LineEdit.cs:1850)
       [3] void Polytoria.Creator.UI.InstanceTagView._EnterTree() (C:\Users\marvi\Desktop\Projects\Pers\Poly\polytoria-game\Polytoria\scripts\creator\ui\docks\properties\tags\InstanceTagView.cs:28)
       [4] bool Godot.Node.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/Node.cs:2612)
       [5] bool Godot.CanvasItem.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/CanvasItem.cs:1845)
       [6] bool Godot.Control.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/Control.cs:4029)
       [7] bool Polytoria.Creator.UI.InstanceTagView.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&) (C:\Users\marvi\Desktop\Projects\Pers\Poly\polytoria-game\Polytoria\.godot\mono\temp\obj\Debug\Godot.SourceGenerators\Godot.SourceGenerators.ScriptMethodsGenerator\Polytoria.Creator.UI.InstanceTagView_ScriptMethods.generated.cs:80)
       [8] Godot.NativeInterop.godot_bool Godot.Bridge.CSharpInstanceBridge.Call(nint, Godot.NativeInterop.godot_string_name*, Godot.NativeInterop.godot_variant**, int, Godot.NativeInterop.godot_variant_call_error*, Godot.NativeInterop.godot_variant*) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs:24)
       [9] void Godot.NativeCalls.godot_icall_3_912(nint, nint, nint, Godot.NativeInterop.godot_bool, int) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/NativeCalls.cs:8061)
       [10] void Godot.Node.AddChild(Godot.Node, bool, Godot.Node+InternalMode) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/Node.cs:848)
       [11] void Polytoria.Creator.UI.Docking.DockHost.AddPanel(Polytoria.Creator.UI.Docking.DockPanel, int, bool) (C:\Users\marvi\Desktop\Projects\Pers\Poly\polytoria-game\Polytoria\scripts\creator\ui\docking\DockHost.cs:83)
       [12] void Polytoria.Creator.UI.Docking.DockRegion.SplitSingleStack(string, bool) (C:\Users\marvi\Desktop\Projects\Pers\Poly\polytoria-game\Polytoria\scripts\creator\ui\docking\DockRegion.cs:168)
       [13] void Polytoria.Creator.UI.Docking.DockRegion.SetSplit(bool, bool, string, bool) (C:\Users\marvi\Desktop\Projects\Pers\Poly\polytoria-game\Polytoria\scripts\creator\ui\docking\DockRegion.cs:86)
       [14] void Polytoria.Creator.UI.Docking.DockRegion.DropDockData(Godot.Variant, Godot.Vector2) (C:\Users\marvi\Desktop\Projects\Pers\Poly\polytoria-game\Polytoria\scripts\creator\ui\docking\DockRegion.cs:52)
       [15] void Polytoria.Creator.UI.Docking.DockDragSurface._DropData(Godot.Vector2, Godot.Variant) (C:\Users\marvi\Desktop\Projects\Pers\Poly\polytoria-game\Polytoria\scripts\creator\ui\docking\DockDragSurface.cs:66)
       [16] bool Godot.Control.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/Control.cs:3959)
       [17] bool Polytoria.Creator.UI.Docking.DockDragSurface.InvokeGodotClassMethod(Godot.NativeInterop.godot_string_name&, Godot.NativeInterop.NativeVariantPtrArgs, Godot.NativeInterop.godot_variant&) (C:\Users\marvi\Desktop\Projects\Pers\Poly\polytoria-game\Polytoria\.godot\mono\temp\obj\Debug\Godot.SourceGenerators\Godot.SourceGenerators.ScriptMethodsGenerator\Polytoria.Creator.UI.Docking.DockDragSurface_ScriptMethods.generated.cs:130)
       [18] Godot.NativeInterop.godot_bool Godot.Bridge.CSharpInstanceBridge.Call(nint, Godot.NativeInterop.godot_string_name*, Godot.NativeInterop.godot_variant**, int, Godot.NativeInterop.godot_variant_call_error*, Godot.NativeInterop.godot_variant*) (/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs:24)
```

## Related issue or discussion

Related to #1153
(But doesn't require it)

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [ ] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
--> Same as in #1153
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Nothing to show. Only that the Error doesn't occur anymore when moving the Tag Panel.

## AI/LLM use

None