### PR TITLE
fixed GUI3D scaling bug

### DIFF
--- a/Polytoria/scripts/datamodel/GUI3D.cs
+++ b/Polytoria/scripts/datamodel/GUI3D.cs
@@ -112,6 +112,7 @@ public partial class GUI3D : Dynamic
 	private void UpdateCanvasSize()
 	{
 		_subViewport.Size = new((int)(Size.X * 512), (int)(Size.Y * 512));
+
 		RecomputeChildTransforms();
 	}
 
@@ -249,6 +250,7 @@ public partial class GUI3D : Dynamic
 	internal override void OnNodeSizeChanged(Vector3 newSize)
 	{
 		_mesh.Scale = newSize;
+		_area.Scale = newSize;
 		base.OnNodeSizeChanged(newSize);
 	}
 


### PR DESCRIPTION
## Summary

Fixed GUI3D scaling issue by adding a line that changes the size of Area3D with the mesh.

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

## AI/LLM use

NONE