### PR TITLE
Fix Duplication selection box issue

### DIFF
--- a/Polytoria/scripts/datamodel/creator/CreatorSelections.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorSelections.cs
@@ -58,7 +58,7 @@ public sealed partial class CreatorSelections : Instance
 	[ScriptMethod]
 	public void Select(Instance instance)
 	{
-		if (SelectedInstances.Contains(instance))
+		if (SelectedInstances.Any(item => ReferenceEquals(item, instance)))
 		{
 			return;
 		}
@@ -136,7 +136,7 @@ public sealed partial class CreatorSelections : Instance
 	[ScriptMethod]
 	public void Deselect(Instance instance)
 	{
-		if (!SelectedInstances.Contains(instance))
+		if (!SelectedInstances.Any(item => ReferenceEquals(item, instance)))
 		{
 			return;
 		}
@@ -349,7 +349,7 @@ public sealed partial class CreatorSelections : Instance
 	}
 
 	[ScriptMethod]
-	public bool HasSelected(Instance instance) => SelectedInstances.Contains(instance);
+	public bool HasSelected(Instance instance) => SelectedInstances.Any(item => ReferenceEquals(item, instance));
 
 	public Task<Instance> RequestPickInstance()
 	{

--- a/Polytoria/scripts/datamodel/creator/CreatorSelections.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorSelections.cs
@@ -58,7 +58,7 @@ public sealed partial class CreatorSelections : Instance
 	[ScriptMethod]
 	public void Select(Instance instance)
 	{
-		if (SelectedInstances.Any(item => ReferenceEquals(item, instance)))
+		if (SelectedInstances.Contains(instance))
 		{
 			return;
 		}
@@ -136,7 +136,7 @@ public sealed partial class CreatorSelections : Instance
 	[ScriptMethod]
 	public void Deselect(Instance instance)
 	{
-		if (!SelectedInstances.Any(item => ReferenceEquals(item, instance)))
+		if (!SelectedInstances.Contains(instance))
 		{
 			return;
 		}
@@ -349,7 +349,7 @@ public sealed partial class CreatorSelections : Instance
 	}
 
 	[ScriptMethod]
-	public bool HasSelected(Instance instance) => SelectedInstances.Any(item => ReferenceEquals(item, instance));
+	public bool HasSelected(Instance instance) => SelectedInstances.Contains(instance);
 
 	public Task<Instance> RequestPickInstance()
 	{


### PR DESCRIPTION
## Summary

This fixes an issue where if you do ctrl + c & ctrl + v it will keep the selection box on the initial duplicated part.

## Related issue or discussion

Fixes #935 
Related to #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/023620ba-c07d-4ad0-8f42-f830e520a207


## AI/LLM use

none