### PR TITLE
Remove Performance as default rendering method

### DIFF
--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -450,7 +450,6 @@ jolt_physics_3d/limits/max_bodies=131070
 occlusion_culling/bvh_build_quality=0
 textures/canvas_textures/default_texture_filter=2
 rendering_device/driver.windows="d3d12"
-renderer/rendering_method="mobile"
 textures/vram_compression/import_etc2_astc=true
 lights_and_shadows/directional_shadow/size.mobile=512
 reflections/sky_reflections/ggx_samples.mobile=2


### PR DESCRIPTION
## Summary

Reverted the change that made Performance the default rendering method, because Performance RM has stricter lighting limitations, which can break lighting in some games. 

## Related issue or discussion

Related to #1062

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="1614" height="1008" alt="LightingStandard" src="https://github.com/user-attachments/assets/b82aa50a-24ee-4505-9f09-d0419462abca" />
<img width="1533" height="947" alt="LightingPerformance" src="https://github.com/user-attachments/assets/00975659-aeb8-449e-9a50-d6ed04999588" />

Here you can see a game being affected by this. First screenshot shows the map in Standard rendering method, and second shows in Performance, where the facility lights basically don't illuminate the map. 
This PR removes Performance as the default rendering method, so Auto can use Godot's default rendering behavior again and games don't get broken lighting like this by default.

In games where lighting matters for gameplay, this is not only a visual issue. In my case, players on Auto currently default to Performance on supported hardware and basically get no facility lighting at all, while Standard works normally. This gives them a visibility disadvantage and also makes restoring main power look like it did nothing.

## AI/LLM use

Used AI to help me with this PR since I'm still pretty new to development outside of Polytoria scripting and don't know C#. I mostly used it to understand the relevant code and contribution process. I reviewed the previous RM change myself and tested this change locally


## Additional notes
I understand that RM default was changed to improve performance, but currently, it is not ideal because Performance may sometimes break lighting. It also has other rendering limitations/quality differences compared to Standard. I think the proper solution should be developing a system that would pick the best RM individually for each player, while letting developers detect the actual RM players are using and being able to enforce one if needed. 