### PR TITLE
Add `PTColor` constants

### DIFF
--- a/Polytoria/scripts/scripting/datatypes/PTColor.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTColor.cs
@@ -16,6 +16,47 @@ public class PTColor : IScriptGDObject
 	[ScriptProperty] public float B { get => color.B; set => color.B = value; }
 	[ScriptProperty] public float A { get => color.A; set => color.A = value; }
 
+	/// <summary>
+	/// Shorthand for Color.New(0, 0, 0, 0).
+	/// </summary>
+	[ScriptProperty] public static PTColor Transparent => new() { R = 0f, G = 0f, B = 0f, A = 0f };
+	/// <summary>
+	/// Shorthand for Color.New().
+	/// </summary>
+	[ScriptProperty] public static PTColor Black => new() { R = 0f, G = 0f, B = 0f, A = 1f };
+	/// <summary>
+	/// Shorthand for Color.New(0.5).
+	/// </summary>
+	[ScriptProperty] public static PTColor Gray => new() { R = 0.5f, G = 0.5f, B = 0.5f, A = 1f };
+	/// <summary>
+	/// Shorthand for Color.New(1).
+	/// </summary>
+	[ScriptProperty] public static PTColor White => new() { R = 1f, G = 1f, B = 1f, A = 1f };
+	/// <summary>
+	/// Shorthand for Color.New(1, 0, 0).
+	/// </summary>
+	[ScriptProperty] public static PTColor Red => new() { R = 1f, G = 0f, B = 0f, A = 1f };
+	/// <summary>
+	/// Shorthand for Color.New(1, 1, 0).
+	/// </summary>
+	[ScriptProperty] public static PTColor Yellow => new() { R = 1f, G = 1f, B = 0f, A = 1f };
+	/// <summary>
+	/// Shorthand for Color.New(0, 1, 0).
+	/// </summary>
+	[ScriptProperty] public static PTColor Green => new() { R = 0f, G = 1f, B = 0f, A = 1f };
+	/// <summary>
+	/// Shorthand for Color.New(0, 1, 1).
+	/// </summary>
+	[ScriptProperty] public static PTColor Cyan => new() { R = 0f, G = 1f, B = 1f, A = 1f };
+	/// <summary>
+	/// Shorthand for Color.New(0, 0, 1).
+	/// </summary>
+	[ScriptProperty] public static PTColor Blue => new() { R = 0f, G = 0f, B = 1f, A = 1f };
+	/// <summary>
+	/// Shorthand for Color.New(1, 0, 1).
+	/// </summary>
+	[ScriptProperty] public static PTColor Magenta => new() { R = 1f, G = 0f, B = 1f, A = 1f };
+
 	public static PTColor FromGDClass(Color clr)
 	{
 		return new PTColor()


### PR DESCRIPTION
## Summary

adds `Transparent`, `Black`, `Gray`, `White`, `Red`, `Yellow`, `Green`, `Cyan`, `Blue`, and `Magenta` to `PTColor` with doc comments for #410 (coming NEVER)

## Related issue or discussion

Closes #1030
Related to #1177

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None