### PR TITLE
Create new values when accessing datatype constants

### DIFF
--- a/Polytoria/scripts/scripting/datatypes/PTVector2.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTVector2.cs
@@ -16,12 +16,12 @@ public class PTVector2 : IScriptGDObject
 	[ScriptProperty] public float Y { get => vector.Y; set => vector.Y = value; }
 
 
-	[ScriptProperty] public static PTVector2 Down { get; private set; } = new() { X = 0, Y = -1 };
-	[ScriptProperty] public static PTVector2 Left { get; private set; } = new() { X = -1, Y = 0 };
-	[ScriptProperty] public static PTVector2 One { get; private set; } = new() { X = 1, Y = 1 };
-	[ScriptProperty] public static PTVector2 Zero { get; private set; } = new() { X = 0, Y = 0 };
-	[ScriptProperty] public static PTVector2 Right { get; private set; } = new() { X = 1, Y = 0 };
-	[ScriptProperty] public static PTVector2 Up { get; private set; } = new() { X = 0, Y = 1 };
+	[ScriptProperty] public static PTVector2 Down => new() { X = 0, Y = -1 };
+	[ScriptProperty] public static PTVector2 Left => new() { X = -1, Y = 0 };
+	[ScriptProperty] public static PTVector2 One => new() { X = 1, Y = 1 };
+	[ScriptProperty] public static PTVector2 Zero => new() { X = 0, Y = 0 };
+	[ScriptProperty] public static PTVector2 Right => new() { X = 1, Y = 0 };
+	[ScriptProperty] public static PTVector2 Up => new() { X = 0, Y = 1 };
 
 	[ScriptProperty] public float Magnitude => vector.Length();
 	[ScriptProperty] public PTVector2 Normalized => FromGDClass(vector.Normalized());

--- a/Polytoria/scripts/scripting/datatypes/PTVector3.cs
+++ b/Polytoria/scripts/scripting/datatypes/PTVector3.cs
@@ -17,14 +17,14 @@ public class PTVector3 : IScriptGDObject
 	[ScriptProperty] public float Y { get => vector.Y; set => vector.Y = value; }
 	[ScriptProperty] public float Z { get => vector.Z; set => vector.Z = value; }
 
-	[ScriptProperty] public static PTVector3 Forward { get; private set; } = new() { X = 0, Y = 0, Z = -1 };
-	[ScriptProperty] public static PTVector3 Back { get; private set; } = new() { X = 0, Y = 0, Z = 1 };
-	[ScriptProperty] public static PTVector3 Down { get; private set; } = new() { X = 0, Y = -1, Z = 0 };
-	[ScriptProperty] public static PTVector3 Left { get; private set; } = new() { X = -1, Y = 0, Z = 0 };
-	[ScriptProperty] public static PTVector3 One { get; private set; } = new() { X = 1, Y = 1, Z = 1 };
-	[ScriptProperty] public static PTVector3 Zero { get; private set; } = new() { X = 0, Y = 0, Z = 0 };
-	[ScriptProperty] public static PTVector3 Right { get; private set; } = new() { X = 1, Y = 0, Z = 0 };
-	[ScriptProperty] public static PTVector3 Up { get; private set; } = new() { X = 0, Y = 1, Z = 0 };
+	[ScriptProperty] public static PTVector3 Forward => new() { X = 0, Y = 0, Z = -1 };
+	[ScriptProperty] public static PTVector3 Back => new() { X = 0, Y = 0, Z = 1 };
+	[ScriptProperty] public static PTVector3 Down => new() { X = 0, Y = -1, Z = 0 };
+	[ScriptProperty] public static PTVector3 Left => new() { X = -1, Y = 0, Z = 0 };
+	[ScriptProperty] public static PTVector3 One => new() { X = 1, Y = 1, Z = 1 };
+	[ScriptProperty] public static PTVector3 Zero => new() { X = 0, Y = 0, Z = 0 };
+	[ScriptProperty] public static PTVector3 Right => new() { X = 1, Y = 0, Z = 0 };
+	[ScriptProperty] public static PTVector3 Up => new() { X = 0, Y = 1, Z = 0 };
 
 	[ScriptProperty] public float Magnitude => vector.Length();
 	[ScriptProperty] public PTVector3 Normalized => FromGDClass(vector.Normalized());


### PR DESCRIPTION
## Summary

makes `Vector2` and `Vector3`'s constants create a new value when accessed, similar to `Quaternion.Identity`

## Related issue or discussion

Closes #1177

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None