### PR TITLE
Add `RigidBody.CanSleep`

### DIFF
--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -22,6 +22,7 @@ public partial class RigidBody : Physical
 	private float _drag;
 	private float _angularDrag;
 	private float _bounciness;
+	private bool _canSleep;
 
 	[Editable, ScriptProperty, SyncVar(Unreliable = true, AllowAuthorWrite = true)]
 	public override Vector3 Velocity
@@ -185,6 +186,22 @@ public partial class RigidBody : Physical
 			_lockRotation = value;
 
 			GDRigidBody.LockRotation = value;
+
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty, DefaultValue(true)]
+	public bool CanSleep
+	{
+		get => _canSleep;
+		set
+		{
+			if (_canSleep == value) return;
+
+			_canSleep = value;
+
+			GDRigidBody.CanSleep = value;
 
 			OnPropertyChanged();
 		}


### PR DESCRIPTION
## Summary

exposes [`RigidBody3D.CanSleep`](https://docs.godotengine.org/en/stable/classes/class_rigidbody3d.html#class-rigidbody3d-property-can-sleep) to scripts. useful if you're doing stuff that won't wake up a rigidbody (e.g. removing the floor out from under them)

## Related issue or discussion

N/A (I think this is little enough to not need an issue?)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None