### PR TITLE
NetMessage `Add*` methods return the same NetMessage

### DIFF
--- a/Polytoria/scripts/datamodel/data/NetMessage.cs
+++ b/Polytoria/scripts/datamodel/data/NetMessage.cs
@@ -29,69 +29,91 @@ public partial class NetMessage : IScriptObject
 	public Dictionary<string, byte[]> Buffers = [];
 
 	[ScriptMethod]
-	public void AddString(string key, string value)
+	public NetMessage AddString(string key, string value)
 	{
 		Strings.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddInt(string key, int value)
+	public NetMessage AddInt(string key, int value)
 	{
 		Ints.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddBool(string key, bool value)
+	public NetMessage AddBool(string key, bool value)
 	{
 		Bools.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddNumber(string key, float value)
+	public NetMessage AddNumber(string key, float value)
 	{
 		Numbers.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddVector2(string key, Vector2 value)
+	public NetMessage AddVector2(string key, Vector2 value)
 	{
 		Vec2s.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddVector3(string key, Vector3 value)
+	public NetMessage AddVector3(string key, Vector3 value)
 	{
 		Vec3s.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddColor(string key, Color value)
+	public NetMessage AddColor(string key, Color value)
 	{
 		Colors.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddQuaternion(string key, Quaternion value)
+	public NetMessage AddQuaternion(string key, Quaternion value)
 	{
 		Quaternions.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddVariant(string key, Variant value)
+	public NetMessage AddVariant(string key, Variant value)
 	{
 		Variants.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddInstance(string key, Instance value)
+	public NetMessage AddInstance(string key, Instance value)
 	{
 		Instances.Add(key, value);
+
+		return this;
 	}
 
 	[ScriptMethod]
-	public void AddBuffer(string key, byte[] buffer)
+	public NetMessage AddBuffer(string key, byte[] buffer)
 	{
 		Buffers.Add(key, buffer);
+
+		return this;
 	}
 
 	[ScriptMethod]


### PR DESCRIPTION
## Summary

`Add*` methods like `AddString` of `NetMessage` will now return the same `NetMessage` to allow chaining methods.

Example:
```lua
local NetMsg = NetMessage.New():AddBool("Example1", true):AddNumber("Example2", 5)
```

## Related issue or discussion

Closes #1136

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None