### PR TITLE
Add Grabbable.LetGo

### DIFF
--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -151,6 +151,22 @@ public partial class Grabbable : Instance
 		}
 	}
 
+	[ScriptMethod]
+	public void LetGo()
+	{
+		if (_dragger == null) return;
+		RpcId(_dragger.PeerID, nameof(NetLetGo));
+	}
+
+	[NetRpc(AuthorityMode.Any, TransferMode = TransferMode.Reliable)]
+	private void NetLetGo()
+	{
+		if (_dragging)
+		{
+			ReleaseDrag();
+		}
+	}
+
 	private async void OnClicked(Player by)
 	{
 		if (_dragger != null) return;


### PR DESCRIPTION
## Summary

This pr adds a method to forcibly release a Grabbable.

## Related issue or discussion

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Grabbing a Grabbable scripted to release if held for 1 second.

https://github.com/user-attachments/assets/dd121313-d36b-46d9-af48-5ba93e79e53e

## AI/LLM use

None