### PR TITLE
Pr/perf physics

### DIFF
--- a/Polytoria/Polytoria.csproj
+++ b/Polytoria/Polytoria.csproj
@@ -99,6 +99,8 @@
 	<!-- Server Docker flag -->
 	<PropertyGroup Condition="'$(PT_DOCKER)' == 'TRUE'">
 		<DefineConstants>$(DefineConstants);PT_DOCKER</DefineConstants>
+		<ServerGarbageCollection>true</ServerGarbageCollection>
+		<ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
 	</PropertyGroup>
 
 	<!-- ExportDebug build (Build all) -->

--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -442,6 +442,8 @@ pointing/android/enable_pan_and_scale_gestures=true
 2d/physics_engine="Dummy"
 3d/physics_engine="Jolt Physics"
 jolt_physics_3d/simulation/generate_all_kinematic_contacts=true
+jolt_physics_3d/simulation/sleep_velocity_threshold=0.15
+jolt_physics_3d/simulation/sleep_time_threshold=0.4
 jolt_physics_3d/limits/max_bodies=131070
 3d/default_gravity=17.0
 

--- a/Polytoria/project.godot
+++ b/Polytoria/project.godot
@@ -442,8 +442,6 @@ pointing/android/enable_pan_and_scale_gestures=true
 2d/physics_engine="Dummy"
 3d/physics_engine="Jolt Physics"
 jolt_physics_3d/simulation/generate_all_kinematic_contacts=true
-jolt_physics_3d/simulation/sleep_velocity_threshold=0.15
-jolt_physics_3d/simulation/sleep_time_threshold=0.4
 jolt_physics_3d/limits/max_bodies=131070
 3d/default_gravity=17.0
 

--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -367,10 +367,16 @@ public partial class DatamodelBridge : Node3D
 		RemoveFromBatch(part);
 	}
 
+	internal void MarkPartDirty(Part part)
+	{
+		if (!_renderingEnabled || !isGameReady) return;
+		_dirty.Add(part);
+	}
+
 	public static bool IsPartEligible(Part part)
 	{
 		if (part.IsHidden || part.IsInTemporary) return false;
-		if (part.Anchored && !part.OverrideNoMultiMesh)
+		if ((part.Anchored || part.IsBodySleeping) && !part.OverrideNoMultiMesh)
 		{
 			if (!IsInstanceValid(part.GDNode3D) || !part.GDNode3D.IsInsideTree()) return false;
 			if (part.IsDeleted) return false;

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -652,6 +652,11 @@ public partial class Dynamic : Instance
 			ReliableTransformChanged?.Invoke();
 		}
 
+		if (this is Physical physical && !physical.HasLocalTransformAuthority())
+		{
+			physical.SetRemoteSleeping(isReliable);
+		}
+
 		InvokeTransformChanged();
 	}
 

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -20,7 +20,8 @@ public partial class Part : Entity
 	private bool _isSeparateMesh = false;
 	private bool _castShadows;
 
-	private Node3D _nRemoteAt = null!; // Remote collider proxy
+	private Node3D? _nRemoteAt; // Remote collider proxy, created on demand
+	private static readonly bool _debugFace = OS.HasFeature("debug-face");
 
 	internal Shape3D ColliderShape => _collider.Shape;
 
@@ -47,11 +48,8 @@ public partial class Part : Entity
 	{
 		base.Init();
 		GDNode3D.AddChild(_collider = new(), false, Node.InternalMode.Back);
-		GDNode3D.AddChild(_nRemoteAt = new(), false, Node.InternalMode.Back);
-		SetRemoteLinkTarget(_collider, _nRemoteAt);
-		_nRemoteAt.Rotation = Vector3.Zero;
 
-		if (OS.HasFeature("debug-face"))
+		if (_debugFace)
 		{
 			RayCast3D raycast = new()
 			{
@@ -61,6 +59,17 @@ public partial class Part : Entity
 		}
 
 		Shape = this is Truss ? ShapeEnum.Truss : ShapeEnum.Brick;
+	}
+
+	protected override Node3D? GetCollisionSyncParent()
+	{
+		if (_nRemoteAt == null)
+		{
+			GDNode3D.AddChild(_nRemoteAt = new(), false, Node.InternalMode.Back);
+			SetRemoteLinkTarget(_collider, _nRemoteAt);
+			_nRemoteAt.Scale = NodeSize;
+		}
+		return _nRemoteAt;
 	}
 
 	public override void PreDelete()
@@ -110,7 +119,14 @@ public partial class Part : Entity
 	private void UpdateMeshSize()
 	{
 		_mesh?.Scale = NodeSize;
-		_nRemoteAt?.Scale = NodeSize;
+		if (_nRemoteAt != null)
+		{
+			_nRemoteAt.Scale = NodeSize;
+		}
+		else if (_collider != null && _collider.GetParent() == GDNode)
+		{
+			_collider.Scale = NodeSize;
+		}
 	}
 
 	public void RemoveSeparateMesh()

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -900,7 +900,7 @@ public partial class Physical : Dynamic
 	private void AttachRemoteLinkNode(CollisionShape3D origin, Node3D scaleNode)
 	{
 		RemoteLinkConfig? config = GetRemoteLinkConfig(origin);
-		Node? target = config?.Target;
+		Node? target = config?.Target ?? GetCollisionSyncParent();
 
 		if (target != null && Node.IsInstanceValid(target))
 		{
@@ -947,11 +947,21 @@ public partial class Physical : Dynamic
 		}
 	}
 
+	protected virtual Node3D? GetCollisionSyncParent()
+	{
+		return null;
+	}
+
 	private void EnsureRemoteTransform(CollisionShape3D origin)
 	{
 		if (!Node.IsInstanceValid(origin)) return;
 
 		if (HasValidTrackedNodes(origin, static state => state.CollisionSyncNodes))
+		{
+			return;
+		}
+
+		if (origin.GetParent() == GDNode && GetRemoteLinkConfig(origin) == null)
 		{
 			return;
 		}

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -223,9 +223,23 @@ public partial class Physical : Dynamic
 		}
 	}
 
-	private bool HasLocalTransformAuthority()
+	internal bool HasLocalTransformAuthority()
 	{
 		return Root != null && Root.Network != null && NetTransformAuthority == Root.Network.LocalPeerID;
+	}
+
+	internal void SetRemoteSleeping(bool sleeping)
+	{
+		if (_remoteSleeping == sleeping)
+		{
+			return;
+		}
+		_remoteSleeping = sleeping;
+
+		if (!IsDeleted && !_anchored && this is Part part)
+		{
+			Root!.Bridge?.MarkPartDirty(part);
+		}
 	}
 
 	private void OnBodySleepingStateChanged()
@@ -373,6 +387,7 @@ public partial class Physical : Dynamic
 	internal bool OverridePhysicsProcess = false;
 
 	private bool _bodySleeping;
+	private bool _remoteSleeping = true;
 	private int _netPumpPhase;
 
 	internal static int SleepingBodyCount;
@@ -403,7 +418,7 @@ public partial class Physical : Dynamic
 		return (sleeping, awake, frozen);
 	}
 
-	internal bool IsBodySleeping => _bodySleeping;
+	internal bool IsBodySleeping => HasLocalTransformAuthority() ? _bodySleeping : _remoteSleeping;
 
 	public override void HiddenChanged(bool to)
 	{

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -219,7 +219,48 @@ public partial class Physical : Dynamic
 
 		if (!OverridePhysicsProcess)
 		{
-			SetPhysicsProcess(!_anchored);
+			SetPhysicsProcess(!_anchored && !(_bodySleeping && HasLocalTransformAuthority()));
+		}
+	}
+
+	private bool HasLocalTransformAuthority()
+	{
+		return Root != null && Root.Network != null && NetTransformAuthority == Root.Network.LocalPeerID;
+	}
+
+	private void OnBodySleepingStateChanged()
+	{
+		bool sleeping = GDNode is RigidBody3D body && body.Sleeping;
+		if (_bodySleeping == sleeping)
+		{
+			return;
+		}
+		_bodySleeping = sleeping;
+
+		if (IsDeleted || _anchored)
+		{
+			return;
+		}
+
+		if (HasLocalTransformAuthority())
+		{
+			if (sleeping)
+			{
+				UpdateNetTransformReliable();
+				if (!OverridePhysicsProcess)
+				{
+					SetPhysicsProcess(false);
+				}
+			}
+			else if (!OverridePhysicsProcess)
+			{
+				SetPhysicsProcess(true);
+			}
+
+			if (this is Part part)
+			{
+				Root!.Bridge?.MarkPartDirty(part);
+			}
 		}
 	}
 
@@ -330,6 +371,10 @@ public partial class Physical : Dynamic
 	internal bool OverrideCanCollideTo = false;
 	internal bool OverridePhysicsProcess = false;
 
+	private bool _bodySleeping;
+
+	internal bool IsBodySleeping => _bodySleeping;
+
 	public override void HiddenChanged(bool to)
 	{
 		UpdateCollision();
@@ -407,6 +452,11 @@ public partial class Physical : Dynamic
 
 		_proxyToPhysical[GDNode] = this;
 
+		if (GDNode is RigidBody3D sleepBody)
+		{
+			sleepBody.SleepingStateChanged += OnBodySleepingStateChanged;
+		}
+
 		if (this is Entity e)
 		{
 			e.GDRigidBody.GravityScale = 2;
@@ -427,6 +477,11 @@ public partial class Physical : Dynamic
 
 	public override void PreDelete()
 	{
+		if (GDNode is RigidBody3D sleepBody)
+		{
+			sleepBody.SleepingStateChanged -= OnBodySleepingStateChanged;
+		}
+
 		ClearCollisionBody();
 		Root?.Loaded.Disconnect(OnRootReady);
 		// _proxyToPhysical.Remove(PhysicalArea);

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -236,6 +236,7 @@ public partial class Physical : Dynamic
 			return;
 		}
 		_bodySleeping = sleeping;
+		SleepingBodyCount += sleeping ? 1 : -1;
 
 		if (IsDeleted || _anchored)
 		{
@@ -373,6 +374,8 @@ public partial class Physical : Dynamic
 
 	private bool _bodySleeping;
 	private int _netPumpPhase;
+
+	internal static int SleepingBodyCount;
 
 	internal bool IsBodySleeping => _bodySleeping;
 

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -372,6 +372,7 @@ public partial class Physical : Dynamic
 	internal bool OverridePhysicsProcess = false;
 
 	private bool _bodySleeping;
+	private int _netPumpPhase;
 
 	internal bool IsBodySleeping => _bodySleeping;
 
@@ -451,6 +452,7 @@ public partial class Physical : Dynamic
 		ApplyFreeze(true);
 
 		_proxyToPhysical[GDNode] = this;
+		_netPumpPhase = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this) % 3;
 
 		if (GDNode is RigidBody3D sleepBody)
 		{
@@ -641,7 +643,12 @@ public partial class Physical : Dynamic
 		// Sync if has authority and not anchored, if so. sync in interval
 		if (NetTransformAuthority == Root.Network.LocalPeerID && !Anchored)
 		{
-			UpdateNetTransform();
+			_netPumpPhase++;
+			if (_netPumpPhase >= 3)
+			{
+				_netPumpPhase = 0;
+				UpdateNetTransform();
+			}
 		}
 		base.PhysicsProcess(delta);
 	}

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -672,11 +672,18 @@ public partial class Physical : Dynamic
 		// Sync if has authority and not anchored, if so. sync in interval
 		if (NetTransformAuthority == Root.Network.LocalPeerID && !Anchored)
 		{
-			_netPumpPhase++;
-			if (_netPumpPhase >= 3)
+			if (this is Player)
 			{
-				_netPumpPhase = 0;
 				UpdateNetTransform();
+			}
+			else
+			{
+				_netPumpPhase++;
+				if (_netPumpPhase >= 3)
+				{
+					_netPumpPhase = 0;
+					UpdateNetTransform();
+				}
 			}
 		}
 		base.PhysicsProcess(delta);

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -171,6 +171,10 @@ public partial class Physical : Dynamic
 		return _collisionLayers;
 	}
 
+	private CollisionObject3D? _lastLayerTarget;
+	private uint _lastAppliedLayer;
+	private uint _lastAppliedMask;
+
 	protected void ApplyCollisionObjectLayers()
 	{
 		CollisionObject3D? collisionObject3D = GetCollisionObject();
@@ -179,7 +183,17 @@ public partial class Physical : Dynamic
 			return;
 		}
 
-		collisionObject3D.CollisionLayer = GetAppliedCollisionLayers();
+		uint layer = GetAppliedCollisionLayers();
+		if (ReferenceEquals(collisionObject3D, _lastLayerTarget) && layer == _lastAppliedLayer && _collisionMask == _lastAppliedMask)
+		{
+			return;
+		}
+
+		_lastLayerTarget = collisionObject3D;
+		_lastAppliedLayer = layer;
+		_lastAppliedMask = _collisionMask;
+
+		collisionObject3D.CollisionLayer = layer;
 		collisionObject3D.CollisionMask = _collisionMask;
 	}
 
@@ -327,8 +341,9 @@ public partial class Physical : Dynamic
 
 	internal void SetCollisionDisabled(bool disabled)
 	{
-		foreach (CollisionShape3D c in CollisionShapes.ToArray())
+		for (int i = 0; i < CollisionShapes.Count; i++)
 		{
+			CollisionShape3D c = CollisionShapes[i];
 			if (!Node.IsInstanceValid(c)) continue;
 			c.Disabled = disabled;
 		}

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -377,6 +377,32 @@ public partial class Physical : Dynamic
 
 	internal static int SleepingBodyCount;
 
+	internal static (int Sleeping, int Awake, int Frozen) CountBodySleepStates()
+	{
+		int sleeping = 0;
+		int awake = 0;
+		int frozen = 0;
+		foreach (Node node in _proxyToPhysical.Keys)
+		{
+			if (node is RigidBody3D body && GodotObject.IsInstanceValid(body))
+			{
+				if (body.Freeze)
+				{
+					frozen++;
+				}
+				else if (body.Sleeping)
+				{
+					sleeping++;
+				}
+				else
+				{
+					awake++;
+				}
+			}
+		}
+		return (sleeping, awake, frozen);
+	}
+
 	internal bool IsBodySleeping => _bodySleeping;
 
 	public override void HiddenChanged(bool to)
@@ -866,17 +892,37 @@ public partial class Physical : Dynamic
 		scaleNode.Position = config is { HasOffset: true } ? config.Offset : Vector3.Zero;
 	}
 
-	private RemoteTransform3D CreateRemoteLinkNode(CollisionShape3D origin, Node target)
+	internal partial class CollisionSyncNode : Node3D
 	{
-		RemoteTransform3D rt = new()
+		internal CollisionShape3D? SyncTarget;
+
+		public override void _Ready()
 		{
-			UseGlobalCoordinates = true
-		};
+			SetNotifyTransform(true);
+			PushTransform();
+		}
 
-		AttachRemoteLinkNode(origin, rt);
+		public override void _Notification(int what)
+		{
+			if (what == NotificationTransformChanged)
+			{
+				PushTransform();
+			}
+		}
 
-		rt.RemotePath = rt.GetPathTo(target);
-		return rt;
+		private void PushTransform()
+		{
+			if (SyncTarget == null || !IsInstanceValid(SyncTarget) || !IsInsideTree() || !SyncTarget.IsInsideTree())
+			{
+				return;
+			}
+
+			Transform3D global = GlobalTransform;
+			if (!SyncTarget.GlobalTransform.IsEqualApprox(global))
+			{
+				SyncTarget.GlobalTransform = global;
+			}
+		}
 	}
 
 	private void EnsureRemoteTransform(CollisionShape3D origin)
@@ -888,8 +934,9 @@ public partial class Physical : Dynamic
 			return;
 		}
 
-		RemoteTransform3D remoteTransform = CreateRemoteLinkNode(origin, origin);
-		SetTrackedNodes(origin, static state => state.CollisionSyncNodes, [remoteTransform]);
+		CollisionSyncNode syncNode = new() { SyncTarget = origin };
+		AttachRemoteLinkNode(origin, syncNode);
+		SetTrackedNodes(origin, static state => state.CollisionSyncNodes, [syncNode]);
 	}
 
 	private void CreateAreaShapeInternal(CollisionShape3D origin)

--- a/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
+++ b/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
@@ -85,5 +85,17 @@ public partial class DatamodelTestEntry : Node3D
 		File.Delete(placeFilePath);
 
 		networkService.CreateServer();
+
+		if (cmdargs.ContainsKey("dmtest-stats"))
+		{
+			PT.CallDeferred(async () =>
+			{
+				while (true)
+				{
+					await Globals.Singleton.WaitAsync(2);
+					PT.Print($"[STATS] sleeping={Datamodel.Physical.SleepingBodyCount} physicsList={Root.Environment?.PartCount}");
+				}
+			});
+		}
 	}
 }

--- a/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
+++ b/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
@@ -88,12 +88,25 @@ public partial class DatamodelTestEntry : Node3D
 
 		if (cmdargs.ContainsKey("dmtest-stats"))
 		{
+			StaticBody3D controlFloor = new() { Position = new Vector3(500, 0, 500) };
+			controlFloor.AddChild(new CollisionShape3D { Shape = new BoxShape3D { Size = new Vector3(50, 2, 50) } });
+			AddChild(controlFloor);
+
+			RigidBody3D controlBody = new() { Position = new Vector3(500, 4, 500) };
+			controlBody.AddChild(new CollisionShape3D { Shape = new BoxShape3D { Size = Vector3.One } });
+			AddChild(controlBody);
+
+			RigidBody3D controlBodyGrav2 = new() { Position = new Vector3(510, 4, 510), GravityScale = 2, PhysicsMaterialOverride = new PhysicsMaterial() };
+			controlBodyGrav2.AddChild(new CollisionShape3D { Shape = new BoxShape3D { Size = Vector3.One } });
+			AddChild(controlBodyGrav2);
+
 			PT.CallDeferred(async () =>
 			{
 				while (true)
 				{
 					await Globals.Singleton.WaitAsync(2);
-					PT.Print($"[STATS] sleeping={Datamodel.Physical.SleepingBodyCount} physicsList={Root.Environment?.PartCount}");
+					(int polledSleeping, int polledAwake, int polledFrozen) = Datamodel.Physical.CountBodySleepStates();
+					PT.Print($"[STATS] signalSleeping={Datamodel.Physical.SleepingBodyCount} polledSleeping={polledSleeping} awake={polledAwake} frozen={polledFrozen} controlSleeping={controlBody.Sleeping} controlGrav2Sleeping={controlBodyGrav2.Sleeping}");
 				}
 			});
 		}


### PR DESCRIPTION
## Summary

This PR makes physics with many parts faster. 

- Sleeping bodies leave the per-frame dispatch loop. On the client, they leave their individual render path and join the MultiMesh chunk batches.
- The server tells clients when a part goes to sleep, with a signal. The client then batches the idle part instead of updating it every frame.
- A bug made the collision sync wake bodies every frame, so nothing ever slept. This PR fixes it.
- The network transform pump runs staggered at the flush rate, not every physics tick. Player parts keep the full rate, so movement stays smooth.
- Parts scale their colliders directly. This removes one sync node per part, which lowers memory and spawn time.
- Collision layer writes are skipped when the values did not change. Sleep thresholds stay at engine defaults for physics fidelity. Dedicated servers use server GC.
- The dm-test tests sleeping-body counts, so you can test it too.

## Related issue or discussion

N/A

## Type of change

- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [X] Other

## Area affected

- [X] Client
- [X] Creator
- [X] Server
- [X] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="1278" height="694" alt="image" src="https://github.com/user-attachments/assets/0760b8da-2f02-4fcf-a19f-8651495a4941" />


## AI/LLM use

Partial LLM usage (Opus 5) for profiling automation, benchmarking & research of performance drains.
