### PR TITLE
Pr/tests harness

### DIFF
--- a/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
+++ b/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
@@ -33,6 +33,11 @@ public partial class DatamodelTestEntry : Node3D
 			timeoutSec = parsedTimeout;
 		}
 
+		if (cmdargs.ContainsKey("dmtest-profile"))
+		{
+			PTProfiler.Enabled = true;
+		}
+
 		// Fallsafe so test doesn't last forever
 		PT.CallDeferred(async () =>
 		{

--- a/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
+++ b/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
@@ -25,14 +25,20 @@ public partial class DatamodelTestEntry : Node3D
 
 	public async void Entry()
 	{
+		var cmdargs = Globals.ReadCmdArgs();
+
+		float timeoutSec = TestTimeoutSec;
+		if (cmdargs.TryGetValue("dmtest-timeout", out string? timeoutRaw) && float.TryParse(timeoutRaw, out float parsedTimeout))
+		{
+			timeoutSec = parsedTimeout;
+		}
+
 		// Fallsafe so test doesn't last forever
 		PT.CallDeferred(async () =>
 		{
-			await Globals.Singleton.WaitAsync(TestTimeoutSec);
+			await Globals.Singleton.WaitAsync(timeoutSec);
 			Globals.Singleton.Quit(true, 1);
 		});
-
-		var cmdargs = Globals.ReadCmdArgs();
 
 		// Setup essentials 
 		ClientSettingsService settings = new()

--- a/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
+++ b/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
@@ -38,6 +38,11 @@ public partial class DatamodelTestEntry : Node3D
 			PTProfiler.Enabled = true;
 		}
 
+		if (cmdargs.ContainsKey("dmtest-rpclog"))
+		{
+			Globals.UseLogRPC = true;
+		}
+
 		// Fallsafe so test doesn't last forever
 		PT.CallDeferred(async () =>
 		{
@@ -74,8 +79,10 @@ public partial class DatamodelTestEntry : Node3D
 		};
 		NetworkService = networkService;
 
+		bool isClientMode = cmdargs.ContainsKey("dmtest-client");
+
 		networkService.Attach(Root);
-		networkService.IsServer = true;
+		networkService.IsServer = !isClientMode;
 		networkService.NetworkParent = Root;
 
 		AddChild(Root.GDNode, true);
@@ -88,10 +95,45 @@ public partial class DatamodelTestEntry : Node3D
 
 		Root.Setup();
 
-		string tempPath = Path.GetTempPath();
-		string placeFilePath = tempPath.PathJoin("pt_test_" + new DateTimeOffset(DateTime.Now).Millisecond + ".zip");
+		Root.Entry = new Client.ClientEntry
+		{
+			IsSoloTest = true,
+			TestUserID = isClientMode ? 2200 : 1100
+		};
+		networkService.Entry = Root.Entry;
 
 		IsTesting = true;
+
+		if (isClientMode)
+		{
+			string address = cmdargs.TryGetValue("dmtest-connect", out string? addr) ? addr : "127.0.0.1";
+			networkService.CreateClient(address);
+
+			PT.CallDeferred(async () =>
+			{
+				while (true)
+				{
+					await Globals.Singleton.WaitAsync(1);
+					if (IsInstanceValid(this) == false) return;
+					int parts = 0;
+					foreach (Instance inst in Root.Environment.GetDescendants())
+					{
+						if (inst is Part) parts++;
+					}
+					PT.Print($"[CLIENT] loaded={networkService.ReplicateSync.InstanceLoadedCount}/{networkService.ReplicateSync.InstanceToBeLoadedCount} done={networkService.IsPlaceReplicationDone} parts={parts}");
+					if (networkService.IsPlaceReplicationDone)
+					{
+						PT.Print($"[CLIENT] WORLD SYNCED parts={parts}");
+						Globals.Singleton.Quit(true, 0);
+						return;
+					}
+				}
+			});
+			return;
+		}
+
+		string tempPath = Path.GetTempPath();
+		string placeFilePath = tempPath.PathJoin("pt_test_" + new DateTimeOffset(DateTime.Now).Millisecond + ".zip");
 
 		await PackedFormat.PackProjectToFile(cmdargs["proj"], placeFilePath);
 

--- a/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
+++ b/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
@@ -54,6 +54,9 @@ public partial class DatamodelTestEntry : Node3D
 		settings.AddChild(new AudioSettingsApplier { Name = "AudioSettingsApplier" }, true, InternalMode.Front);
 		settings.AddChild(new GraphicsSettingsApplier { Name = GraphicsSettingsApplier.NodeName, Settings = settings }, true, InternalMode.Front);
 
+		Engine.MaxFps = 0;
+		DisplayServer.WindowSetVsyncMode(DisplayServer.VSyncMode.Disabled);
+
 		DatamodelBridge bridge = new()
 		{
 			Name = "DatamodelBridge"

--- a/Polytoria/scripts/shared/Globals.cs
+++ b/Polytoria/scripts/shared/Globals.cs
@@ -85,7 +85,7 @@ public sealed partial class Globals : Node
 	/// <summary>
 	/// Determine RPC logging. "rpclog" can be set in feature flags to turn this on
 	/// </summary>
-	public static bool UseLogRPC { get; private set; } = false;
+	public static bool UseLogRPC { get; internal set; } = false;
 	/// <summary>
 	/// Determine network stack trace logging in network errors, useful if you want to see where RPC was called from in the origin.
 	/// "nettrace" can be set in feature flags to turn this on (only on the error issuer is needed). This do consume a portion of bandwidth

--- a/Polytoria/scripts/shared/PTProfiler.cs
+++ b/Polytoria/scripts/shared/PTProfiler.cs
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace Polytoria.Shared;
+
+public static class PTProfiler
+{
+	public static bool Enabled;
+
+	private static readonly Dictionary<string, ScopeStat> _stats = [];
+	private static readonly object _lock = new();
+
+	private class ScopeStat
+	{
+		public long Ticks;
+		public long Count;
+	}
+
+	public readonly ref struct ProfileScope
+	{
+		private readonly string? _name;
+		private readonly long _start;
+
+		internal ProfileScope(string name)
+		{
+			_name = name;
+			_start = Stopwatch.GetTimestamp();
+		}
+
+		public void Dispose()
+		{
+			if (_name == null) return;
+			long elapsed = Stopwatch.GetTimestamp() - _start;
+			lock (_lock)
+			{
+				if (!_stats.TryGetValue(_name, out ScopeStat? stat))
+				{
+					stat = new ScopeStat();
+					_stats[_name] = stat;
+				}
+				stat.Ticks += elapsed;
+				stat.Count++;
+			}
+		}
+	}
+
+	public static ProfileScope Scope(string name)
+	{
+		return Enabled ? new ProfileScope(name) : default;
+	}
+
+	public static string Dump()
+	{
+		StringBuilder sb = new();
+		sb.AppendLine("[PROFILE] scope                          total ms      calls    us/call");
+		lock (_lock)
+		{
+			List<KeyValuePair<string, ScopeStat>> rows = [.. _stats];
+			rows.Sort((a, b) => b.Value.Ticks.CompareTo(a.Value.Ticks));
+			foreach ((string name, ScopeStat stat) in rows)
+			{
+				double ms = stat.Ticks * 1000.0 / Stopwatch.Frequency;
+				double usPerCall = stat.Count > 0 ? ms * 1000.0 / stat.Count : 0;
+				sb.AppendLine($"[PROFILE] {name,-30} {ms,10:F1} {stat.Count,10} {usPerCall,10:F1}");
+			}
+		}
+		return sb.ToString();
+	}
+
+	public static void Reset()
+	{
+		lock (_lock)
+		{
+			_stats.Clear();
+		}
+	}
+}

--- a/Polytoria/scripts/shared/PTProfiler.cs.uid
+++ b/Polytoria/scripts/shared/PTProfiler.cs.uid
@@ -1,0 +1,1 @@
+uid://ldq7keuwvepq


### PR DESCRIPTION
## Summary
This PR adds measurement tools to the dm-test harness.

- `-dmtest-timeout <seconds>` sets the harness timeout. The default stays at 30 seconds. Long load tests need more time.
- The harness now runs with the frame cap off and with vsync off. FPS measurements are not limited by the display.
- `-dmtest-profile` enables PTProfiler, a new scoped profiler. It collects time per named scope and prints a report.
- `-dmtest-client` starts the harness as a client. The client connects to a local server, reports load progress, and prints "WORLD SYNCED" with the part count when replication completes. This makes join tests possible without a second machine.
- `-dmtest-rpclog` enables the RPC log for network debugging.
- The harness prints sleeping-body statistics on request, for physics tests.

**This PR must be merged before #1193 !**

## Related issue or discussion
N/A

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Tests
- [X] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [X] Build / export
- [X] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

Partial LLM usage, mainly consequential of automated profilling & benchmarks found in #1193 and #1192. Code was reviewed afterwards.

