### PR TITLE
Pr/perf network

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -535,9 +535,24 @@ public partial class Dynamic : Instance
 		SendNetTransformUnreliable(current, lerp);
 	}
 
+	private TransformPayloadDto? _sendPayloadA;
+	private TransformPayloadDto? _sendPayloadB;
+	private bool _sendPayloadFlip;
+
+	private TransformPayloadDto NextSendPayload(Transform3D current)
+	{
+		_sendPayloadFlip = !_sendPayloadFlip;
+		TransformPayloadDto payload = _sendPayloadFlip
+			? _sendPayloadA ??= new TransformPayloadDto(new byte[16])
+			: _sendPayloadB ??= new TransformPayloadDto(new byte[16]);
+		payload.Position = current.Origin;
+		payload.Rotation = current.Basis.GetRotationQuaternion();
+		return payload;
+	}
+
 	private void SendNetTransformUnreliable(Transform3D current, bool lerp = true)
 	{
-		TransformPayloadDto payload = TransformPayloadDto.FromGDTransform(current);
+		TransformPayloadDto payload = NextSendPayload(current);
 
 		if (!Root.Network.IsServer)
 		{
@@ -568,7 +583,7 @@ public partial class Dynamic : Instance
 
 		if (Root.Network.IsServer)
 		{
-			TransformPayloadDto payload = TransformPayloadDto.FromGDTransform(current);
+			TransformPayloadDto payload = NextSendPayload(current);
 			Root.Network.TransformSync.BroadcastTransformFromServer(this, payload, lerp, reliable: true);
 		}
 

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -44,7 +44,14 @@ public partial class NetworkedObject : IScriptObject
 	private static readonly ConditionalWeakTable<Type, PropertyInfo[]> _syncPropertiesCache = [];
 	private static readonly ConcurrentDictionary<NetworkedObject, Node> _netObjToProxy = new();
 	private static readonly ConcurrentDictionary<Node, NetworkedObject> _proxyToNetObj = new();
-	private static readonly ConcurrentDictionary<Type, Dictionary<string, PropertyInfo?>> _syncPropertyByNameCache = new();
+	private static readonly ConcurrentDictionary<Type, Dictionary<string, SyncPropInfo>> _syncPropInfoCache = new();
+
+	internal readonly struct SyncPropInfo(PropertyInfo prop, SyncVarAttribute? syncVar, Func<NetworkedObject, object?> getter)
+	{
+		public readonly PropertyInfo Prop = prop;
+		public readonly SyncVarAttribute? SyncVar = syncVar;
+		public readonly Func<NetworkedObject, object?> Getter = getter;
+	}
 
 	private static readonly Dictionary<Type, Dictionary<string, int>> _typeRpcIdMap = [];
 	private static readonly Dictionary<Type, Dictionary<int, MethodInfo>> _typeRpcMethodMap = [];
@@ -1097,11 +1104,9 @@ public partial class NetworkedObject : IScriptObject
 		// If during replication process, return
 		if (!_isReplicating) return;
 
-		PropertyInfo? prop = GetSyncProperty(propertyName);
-
-		if (prop != null)
+		if (GetSyncPropInfo(propertyName) is { } prop)
 		{
-			SyncVarAttribute? syncvar = prop.GetCustomAttribute<SyncVarAttribute>();
+			SyncVarAttribute? syncvar = prop.SyncVar;
 
 			bool shouldBroadcast =
 				// If no SyncVar at all -> always broadcast
@@ -1126,7 +1131,7 @@ public partial class NetworkedObject : IScriptObject
 				}
 			}
 
-			object? current = prop.GetValue(this);
+			object? current = prop.Getter(this);
 
 			// Check if last sync value is the same, or else skip if unreliable is on
 			if (!broadcastUnreliable && _lastSyncedValues?.TryGetValue(propertyName, out object? lastValue) == true)
@@ -1162,12 +1167,12 @@ public partial class NetworkedObject : IScriptObject
 				if (Root.Network.IsServer)
 				{
 					// Broadcast to all on server
-					BroadcastPropUpdate(prop.Name, current, broadcastUnreliable);
+					BroadcastPropUpdate(prop.Prop.Name, current, broadcastUnreliable);
 				}
 				else
 				{
 					// Broadcast to server if client
-					BroadcastPropUpdateToServer(prop.Name, current, broadcastUnreliable);
+					BroadcastPropUpdateToServer(prop.Prop.Name, current, broadcastUnreliable);
 				}
 			}
 		}
@@ -1452,13 +1457,30 @@ public partial class NetworkedObject : IScriptObject
 
 	internal PropertyInfo? GetSyncProperty(string propName)
 	{
-		// Get sync property from cache
-		Dictionary<string, PropertyInfo?> nameCache = _syncPropertyByNameCache
-			.GetOrAdd(GetType(), type =>
-				GetSyncProperties().ToDictionary(p => p.Name, p => (PropertyInfo?)p));
+		return GetSyncPropInfo(propName)?.Prop;
+	}
 
-		nameCache.TryGetValue(propName, out PropertyInfo? result);
-		return result;
+	internal SyncPropInfo? GetSyncPropInfo(string propName)
+	{
+		Dictionary<string, SyncPropInfo> nameCache = _syncPropInfoCache.GetOrAdd(GetType(), static type =>
+		{
+			Dictionary<string, SyncPropInfo> map = [];
+			foreach (PropertyInfo prop in BuildSyncProperties(type))
+			{
+				map[prop.Name] = new SyncPropInfo(prop, prop.GetCustomAttribute<SyncVarAttribute>(), CreatePropGetter(prop));
+			}
+			return map;
+		});
+
+		return nameCache.TryGetValue(propName, out SyncPropInfo result) ? result : null;
+	}
+
+	private static Func<NetworkedObject, object?> CreatePropGetter(PropertyInfo prop)
+	{
+		var targetParam = System.Linq.Expressions.Expression.Parameter(typeof(NetworkedObject), "target");
+		var cast = System.Linq.Expressions.Expression.Convert(targetParam, prop.DeclaringType!);
+		var body = System.Linq.Expressions.Expression.Convert(System.Linq.Expressions.Expression.Property(cast, prop), typeof(object));
+		return System.Linq.Expressions.Expression.Lambda<Func<NetworkedObject, object?>>(body, targetParam).Compile();
 	}
 
 	internal void RecvPropUpdate(string propName, byte[] propValueRaw, long sequence)
@@ -2009,8 +2031,13 @@ public partial class NetworkedObject : IScriptObject
 
 	internal IEnumerable<PropertyInfo> GetSyncProperties()
 	{
+		return BuildSyncProperties(GetType());
+	}
+
+	private static PropertyInfo[] BuildSyncProperties(Type targetType)
+	{
 #pragma warning disable IL2070 // Reflection access is already defined
-		return _syncPropertiesCache.GetOrAdd(GetType(), static type =>
+		return _syncPropertiesCache.GetOrAdd(targetType, static type =>
 		[.. type.GetProperties(BindingFlags.Public | BindingFlags.Instance| BindingFlags.FlattenHierarchy)
 			.Where(p =>
 				// Editable or SyncVar, but not NoSync

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -1519,7 +1519,12 @@ public partial class NetworkedObject : IScriptObject
 					PendingProps.Add(propName);
 					NetPropNetworkedObjectRef newRef = nref;
 					newRef.TargetProp = prop;
-					Root.Network.PropSync.PendingRefs[newRef] = this;
+					if (!Root.Network.PropSync.PendingRefs.TryGetValue(nref.NetID, out List<(NetPropNetworkedObjectRef Ref, NetworkedObject Target)>? pendingList))
+					{
+						pendingList = [];
+						Root.Network.PropSync.PendingRefs[nref.NetID] = pendingList;
+					}
+					pendingList.Add((newRef, this));
 				}
 				else
 				{

--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -1418,13 +1418,11 @@ public partial class NetworkedObject : IScriptObject
 
 	public NetPropReplicateData[] GetNetPropReplicateData()
 	{
-		IEnumerable<PropertyInfo> props = GetSyncProperties();
-
 		List<NetPropReplicateData> propData = [];
 
-		foreach (PropertyInfo prop in props)
+		foreach (SyncPropInfo info in GetSyncPropInfoMap().Values)
 		{
-			object? value = prop.GetValue(this);
+			object? value = info.Getter(this);
 
 			if (value is NetworkedObject nobj)
 			{
@@ -1437,11 +1435,12 @@ public partial class NetworkedObject : IScriptObject
 
 			if (value != null)
 			{
+				string propName = info.Prop.Name;
 				propData.Add(new NetPropReplicateData
 				{
-					Name = prop.Name,
+					Name = propName,
 					ValueRaw = NetworkPropSync.SerializePropValue(value),
-					Sequence = GetSequenceForProp(prop.Name)
+					Sequence = GetSequenceForProp(propName)
 				});
 			}
 		}
@@ -1462,7 +1461,12 @@ public partial class NetworkedObject : IScriptObject
 
 	internal SyncPropInfo? GetSyncPropInfo(string propName)
 	{
-		Dictionary<string, SyncPropInfo> nameCache = _syncPropInfoCache.GetOrAdd(GetType(), static type =>
+		return GetSyncPropInfoMap().TryGetValue(propName, out SyncPropInfo result) ? result : null;
+	}
+
+	private Dictionary<string, SyncPropInfo> GetSyncPropInfoMap()
+	{
+		return _syncPropInfoCache.GetOrAdd(GetType(), static type =>
 		{
 			Dictionary<string, SyncPropInfo> map = [];
 			foreach (PropertyInfo prop in BuildSyncProperties(type))
@@ -1471,8 +1475,6 @@ public partial class NetworkedObject : IScriptObject
 			}
 			return map;
 		});
-
-		return nameCache.TryGetValue(propName, out SyncPropInfo result) ? result : null;
 	}
 
 	private static Func<NetworkedObject, object?> CreatePropGetter(PropertyInfo prop)

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -97,6 +97,9 @@ public sealed partial class NetworkService : Instance
 	public bool IsProd = false;
 	public NetworkModeEnum NetworkMode { get; set; } = NetworkModeEnum.Client;
 
+	[ScriptProperty]
+	public float ReplicationRadius { get; set; } = 0f;
+
 	private ulong placeReplicationStartTime = 0;
 	private readonly Dictionary<string, List<NetReplicateData>> _pendingReplications = [];
 	private Godot.Timer _heartbeatTimer = null!;

--- a/Polytoria/scripts/datamodel/services/NetworkService.cs
+++ b/Polytoria/scripts/datamodel/services/NetworkService.cs
@@ -349,14 +349,20 @@ public sealed partial class NetworkService : Instance
 				{
 					lock (_rateLimiterLock)
 					{
-						var rateLimiter = _peerRateLimiters[originFromPeer];
-						if (tfm == TransferMode.Reliable)
+						if (_peerRateLimiters.TryGetValue(originFromPeer, out var rateLimiter))
 						{
-							canSend = rateLimiter.Reliable.TryAccept();
+							if (tfm == TransferMode.Reliable)
+							{
+								canSend = rateLimiter.Reliable.TryAccept();
+							}
+							else
+							{
+								canSend = rateLimiter.Unreliable.TryAccept();
+							}
 						}
 						else
 						{
-							canSend = rateLimiter.Unreliable.TryAccept();
+							canSend = false;
 						}
 					}
 				}

--- a/Polytoria/scripts/network/syncs/NetworkPropSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkPropSync.cs
@@ -33,7 +33,7 @@ public sealed partial class NetworkPropSync : Instance
 	private readonly Dictionary<string, List<NetPropReplicateData>> _pendingProps = [];
 
 	// Queue of pending references (waiting for recipient to spawn)
-	public readonly Dictionary<NetPropNetworkedObjectRef, NetworkedObject> PendingRefs = [];
+	public readonly Dictionary<string, List<(NetPropNetworkedObjectRef Ref, NetworkedObject Target)>> PendingRefs = [];
 
 	// Batch broadcasts list
 	private readonly List<BatchBroadcastData> _batchBroadcasts = [];
@@ -508,20 +508,17 @@ public sealed partial class NetworkPropSync : Instance
 	// Resolve objects that point to another object
 	public void LookForResolvePending(NetworkedObject netObj)
 	{
-		foreach ((NetPropNetworkedObjectRef nref, NetworkedObject target) in PendingRefs)
+		if (!PendingRefs.Remove(netObj.NetworkedObjectID, out List<(NetPropNetworkedObjectRef Ref, NetworkedObject Target)>? refs)) return;
+
+		foreach ((NetPropNetworkedObjectRef nref, NetworkedObject target) in refs)
 		{
-			if (nref.NetID == netObj.NetworkedObjectID)
+			try
 			{
-				try
-				{
-					nref.TargetProp!.SetValue(target, netObj);
-				}
-				catch (Exception ex)
-				{
-					GD.PushError(nref.TargetProp, $" set failure (id {nref.NetID}) ", ex);
-				}
-				PendingRefs.Remove(nref);
-				break;
+				nref.TargetProp!.SetValue(target, netObj);
+			}
+			catch (Exception ex)
+			{
+				GD.PushError(nref.TargetProp, $" set failure (id {nref.NetID}) ", ex);
 			}
 		}
 	}

--- a/Polytoria/scripts/network/syncs/NetworkPropSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkPropSync.cs
@@ -371,7 +371,7 @@ public sealed partial class NetworkPropSync : Instance
 		NetPropReplicateData[] propData = netObj.GetNetPropReplicateData();
 		string netID = netObj.NetworkedObjectID;
 
-		RpcId(toPeerId, nameof(NetRecvPropUpdateBatch), netID, JsonSerializer.Serialize(propData, NetDataGenerationContext.Default.NetPropReplicateDataArray));
+		RpcId(toPeerId, nameof(NetRecvPropUpdateBatch), netID, SerializeUtils.Serialize(propData));
 	}
 
 	public void BroadcastPropUpdateToServer(NetworkedObject netObj, string propName, object? propValue, bool unreliable)
@@ -465,10 +465,10 @@ public sealed partial class NetworkPropSync : Instance
 	}
 
 	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, TransferChannel = 1)]
-	private void NetRecvPropUpdateBatch(string nodePath, string propDataRaw)
+	private void NetRecvPropUpdateBatch(string nodePath, byte[] propDataRaw)
 	{
 		NetworkedObject? netObj = NetService.Root.GetNetObj(nodePath);
-		NetPropReplicateData[] propReplicates = JsonSerializer.Deserialize(propDataRaw, NetDataGenerationContext.Default.NetPropReplicateDataArray)!;
+		NetPropReplicateData[] propReplicates = SerializeUtils.Deserialize<NetPropReplicateData[]>(propDataRaw)!;
 
 		if (netObj != null)
 		{
@@ -523,21 +523,41 @@ public sealed partial class NetworkPropSync : Instance
 		}
 	}
 
+	private readonly Dictionary<(int ExcludePeer, bool IsUnreliable), Dictionary<string, List<BatchPropEntry>>> _broadcastGroupScratch = [];
+
 	// Broadcast Batched Props to peers
 	private void BroadcastBatchedProps()
 	{
 		if (_batchBroadcasts.Count == 0) return;
 
-		var groups = _batchBroadcasts
-			.GroupBy(b => (b.ExcludePeer, b.IsUnreliable));
-
-		foreach (var group in groups)
+		foreach (BatchBroadcastData b in _batchBroadcasts)
 		{
-			var payload = BuildPropPayload([.. group]);
-			var (excludePeer, isUnreliable) = group.Key;
+			(int, bool) groupKey = (b.ExcludePeer, b.IsUnreliable);
+			if (!_broadcastGroupScratch.TryGetValue(groupKey, out Dictionary<string, List<BatchPropEntry>>? byNetID))
+			{
+				byNetID = [];
+				_broadcastGroupScratch[groupKey] = byNetID;
+			}
+			if (!byNetID.TryGetValue(b.NetID, out List<BatchPropEntry>? entries))
+			{
+				entries = [];
+				byNetID[b.NetID] = entries;
+			}
+			entries.Add(new BatchPropEntry { PropName = b.PropName, PropValueRaw = b.PropValueRaw, Sequence = b.Sequence });
+		}
+
+		foreach (((int excludePeer, bool isUnreliable), Dictionary<string, List<BatchPropEntry>> byNetID) in _broadcastGroupScratch)
+		{
+			BatchPropObjectData[] payload = new BatchPropObjectData[byNetID.Count];
+			int i = 0;
+			foreach ((string netID, List<BatchPropEntry> entries) in byNetID)
+			{
+				payload[i++] = new BatchPropObjectData { NetID = netID, Props = [.. entries] };
+			}
 			BroadcastBatchPropExcludePeer(payload, isUnreliable, excludePeer);
 		}
 
+		_broadcastGroupScratch.Clear();
 		_batchBroadcasts.Clear();
 	}
 
@@ -558,23 +578,6 @@ public sealed partial class NetworkPropSync : Instance
 		{
 			NetService.NetInstance.BroadcastMessageExcept(packet, transferMode, 0, excludePeer);
 		}
-	}
-
-	// Groups flat broadcast list into per-NetID objects
-	private static BatchPropObjectData[] BuildPropPayload(List<BatchBroadcastData> broadcasts)
-	{
-		return [.. broadcasts
-			.GroupBy(b => b.NetID)
-			.Select(g => new BatchPropObjectData
-			{
-				NetID = g.Key,
-				Props = [.. g.Select(b => new BatchPropEntry
-				{
-					PropName = b.PropName,
-					PropValueRaw = b.PropValueRaw,
-					Sequence = b.Sequence
-				})]
-			})];
 	}
 
 	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable)]

--- a/Polytoria/scripts/network/syncs/NetworkPropSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkPropSync.cs
@@ -379,9 +379,7 @@ public sealed partial class NetworkPropSync : Instance
 		if (!netObj.IsNetworkReady) return;
 		if (!netObj.Root.IsLoaded) return;
 
-		PropertyInfo? propInfo = netObj.GetSyncProperty(propName);
-
-		if (propInfo == null) return;
+		if (netObj.GetSyncPropInfo(propName) is not { } propInfo) return;
 
 		// Check authority
 		if (!CheckPropHasAuthority(propInfo, netObj, NetService.LocalPeerID)) return;
@@ -425,10 +423,8 @@ public sealed partial class NetworkPropSync : Instance
 
 		if (netObj != null)
 		{
-			PropertyInfo? propInfo = netObj.GetSyncProperty(propName);
-
 			// Target property doesn't exist
-			if (propInfo == null) return;
+			if (netObj.GetSyncPropInfo(propName) is not { } propInfo) return;
 
 			if (CheckPropHasAuthority(propInfo, netObj, peerID))
 			{
@@ -439,9 +435,9 @@ public sealed partial class NetworkPropSync : Instance
 		}
 	}
 
-	public static bool CheckPropHasAuthority(PropertyInfo propInfo, NetworkedObject netObj, int peerID)
+	internal static bool CheckPropHasAuthority(NetworkedObject.SyncPropInfo propInfo, NetworkedObject netObj, int peerID)
 	{
-		SyncVarAttribute? sv = propInfo.GetCustomAttribute<SyncVarAttribute>();
+		SyncVarAttribute? sv = propInfo.SyncVar;
 
 		bool hasAuthority = false;
 

--- a/Polytoria/scripts/network/syncs/NetworkReplicateSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkReplicateSync.cs
@@ -29,6 +29,7 @@ public sealed partial class NetworkReplicateSync : Instance
 	public int InstanceToBeLoadedCount = 0;
 	public event Action<int, int>? InstanceLoadedProgress;
 	private readonly HashSet<string> _removedRef = [];
+	private static readonly StringName _magicAction = "magic";
 	private readonly HashSet<NetReplicateData> _worldReplicateSet = [];
 
 	private static readonly bool _useNetworkLog = false;
@@ -99,15 +100,20 @@ public sealed partial class NetworkReplicateSync : Instance
 				{
 					// Check for deleted parents
 					bool removed = false;
-					foreach (string removedParentPath in _removedRef.ToArray())
+					string? matchedRemovedRef = null;
+					foreach (string removedParentPath in _removedRef)
 					{
 						if (removedParentPath != "" && parentPath.StartsWith(removedParentPath))
 						{
-							if (_useNetworkLog) { PT.Print($"[Net] [{NetService.LocalPeerID}] {data.NodePath} Removed ref {removedParentPath}"); }
-							_removedRef.Remove(removedParentPath);
-							removed = true;
+							matchedRemovedRef = removedParentPath;
 							break;
 						}
+					}
+					if (matchedRemovedRef != null)
+					{
+						if (_useNetworkLog) { PT.Print($"[Net] [{NetService.LocalPeerID}] {data.NodePath} Removed ref {matchedRemovedRef}"); }
+						_removedRef.Remove(matchedRemovedRef);
+						removed = true;
 					}
 
 					if (removed)
@@ -149,7 +155,7 @@ public sealed partial class NetworkReplicateSync : Instance
 		base.Process(delta);
 
 		// Debugging magic key
-		if (Input.IsActionJustPressed("magic"))
+		if (Input.IsActionJustPressed(_magicAction))
 		{
 			foreach (var item in _worldReplicateSet)
 			{

--- a/Polytoria/scripts/network/syncs/NetworkReplicateSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkReplicateSync.cs
@@ -45,22 +45,52 @@ public sealed partial class NetworkReplicateSync : Instance
 		base.Init();
 	}
 
-	public void SyncPlaceToPlayer(Player plr)
+	private const int PlaceSendSliceSize = 4000;
+	private bool _placeFinalChunkSeen;
+
+	public async void SyncPlaceToPlayer(Player plr)
 	{
 		World game = NetService.Root;
 		NetworkedObject[] netObjs = game.GetReplicateDescendants();
 
 		game.NetSendAllPropUpdate(plr.PeerID);
 
-		SendChunk(netObjs, plr, true);
+		int total = netObjs.Length;
+		if (total == 0)
+		{
+			RpcId(plr.PeerID, nameof(NetRecvChunk), ZstdCompressionUtils.Compress(SerializeUtils.Serialize(System.Array.Empty<NetReplicateData>())), true, true);
+			return;
+		}
+
+		for (int start = 0; start < total; start += PlaceSendSliceSize)
+		{
+			if (plr.IsDeleted) return;
+
+			int count = Math.Min(PlaceSendSliceSize, total - start);
+			bool isFinal = start + count >= total;
+
+			NetService.TransformSync.SendChunk(netObjs, plr, start, count);
+			byte[] rawData = ZstdCompressionUtils.Compress(SerializeUtils.Serialize(PackNetObjs(netObjs, start, count)));
+			RpcId(plr.PeerID, nameof(NetRecvChunk), rawData, true, isFinal);
+
+			if (!isFinal)
+			{
+				await Globals.Singleton.WaitFrame();
+			}
+		}
 	}
 
 	[NetRpc(AuthorityMode.Server, TransferMode = TransferMode.Reliable)]
-	private async void NetRecvChunk(byte[] rawBytes, bool isPlaceReplicate)
+	private async void NetRecvChunk(byte[] rawBytes, bool isPlaceReplicate, bool isFinal)
 	{
 		// Wait frame for all deletion to finish
 		await Globals.Singleton.WaitFrame();
 		await Globals.Singleton.WaitFrame();
+
+		if (isPlaceReplicate && isFinal)
+		{
+			_placeFinalChunkSeen = true;
+		}
 
 		NetReplicateData[] netObjsData = SerializeUtils.Deserialize<NetReplicateData[]>(ZstdCompressionUtils.Decompress(rawBytes))!;
 		NetReplicateData[][] chunked = ArrayUtils.Chunk(netObjsData, PlaceReplicationChunkSize);
@@ -139,6 +169,12 @@ public sealed partial class NetworkReplicateSync : Instance
 			// hope and prayers
 			await Globals.Singleton.WaitFrame();
 		}
+
+		if (isPlaceReplicate && _placeFinalChunkSeen && !NetService.IsPlaceReplicationDone
+			&& InstanceToBeLoadedCount != 0 && _worldReplicateSet.Count == 0)
+		{
+			NetService.NetWorldSyncd();
+		}
 	}
 
 	public void SendChunk(NetworkedObject[] netObjs, Player plr, bool isPlaceReplicate = false)
@@ -146,7 +182,7 @@ public sealed partial class NetworkReplicateSync : Instance
 		NetService.TransformSync.SendChunk(netObjs, plr);
 		byte[] rawData = ZstdCompressionUtils.Compress(SerializeUtils.Serialize(PackNetObjs(netObjs)));
 
-		RpcId(plr.PeerID, nameof(NetRecvChunk), rawData, isPlaceReplicate);
+		RpcId(plr.PeerID, nameof(NetRecvChunk), rawData, isPlaceReplicate, true);
 	}
 
 	// Fallsafe for pending replicates
@@ -193,7 +229,7 @@ public sealed partial class NetworkReplicateSync : Instance
 
 		//GD.PushWarning("Broadcast chunk ", netObjs.Length);
 
-		Rpc(nameof(NetRecvChunk), rawData, false);
+		Rpc(nameof(NetRecvChunk), rawData, false, true);
 	}
 
 	public static void MarkChunkOverride(NetworkedObject[] netObjs)
@@ -217,6 +253,7 @@ public sealed partial class NetworkReplicateSync : Instance
 		for (int i = start; i < end; i++)
 		{
 			NetworkedObject netObj = netObjs[i];
+			if (netObj.IsDeleted) continue;
 			// If no sync, continue
 			if (netObj.GetType().IsDefined(typeof(NoSyncAttribute), false)) continue;
 
@@ -269,7 +306,7 @@ public sealed partial class NetworkReplicateSync : Instance
 		{
 			InstanceLoadedProgress?.Invoke(InstanceLoadedCount, InstanceToBeLoadedCount);
 
-			if (_worldReplicateSet.Count == 0)
+			if (_worldReplicateSet.Count == 0 && _placeFinalChunkSeen)
 			{
 				NetService.NetWorldSyncd();
 			}

--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -273,31 +273,20 @@ public partial class NetworkTransformSync : Instance
 		}
 	}
 
-	private void BroadcastGroupedBatch(List<BatchTransformData> batch, string rpcName, TransferMode transferMode, int excludePeer = -1)
-	{
-		if (NetService.NetInstance == null || batch.Count == 0) return;
-
-		byte[] packet = BuildRpcPacket(rpcName, SerializeUtils.Serialize<BatchTransformData[]>([.. batch]));
-
-		if (excludePeer == -1)
-		{
-			NetService.NetInstance.BroadcastMessage(packet, transferMode);
-		}
-		else
-		{
-			NetService.NetInstance.BroadcastMessageExcept(packet, transferMode, 0, excludePeer);
-		}
-	}
+	private readonly List<BatchTransformData> _reliableScratch = [];
+	private readonly List<int> _reliableExcludeScratch = [];
+	private readonly List<BatchTransformData> _unreliableScratch = [];
+	private readonly List<int> _unreliableExcludeScratch = [];
+	private readonly List<BatchTransformData> _peerScratch = [];
 
 	private void BroadcastBatchedTransforms()
 	{
 		if (NetService.NetInstance == null || _pendingBatchUpdate.Count == 0) return;
 
-		Dictionary<int, List<BatchTransformData>> reliableExcept = [];
-		Dictionary<int, List<BatchTransformData>> unreliableExcept = [];
-
-		List<BatchTransformData> reliableAll = [];
-		List<BatchTransformData> unreliableAll = [];
+		_reliableScratch.Clear();
+		_reliableExcludeScratch.Clear();
+		_unreliableScratch.Clear();
+		_unreliableExcludeScratch.Clear();
 
 		foreach (var (k, pending) in _pendingBatchUpdate)
 		{
@@ -309,41 +298,59 @@ public partial class NetworkTransformSync : Instance
 
 			if (pending.Reliable)
 			{
-				if (pending.ExcludePeer == -1)
-				{
-					reliableAll.Add(batchData);
-				}
-				else
-				{
-					GetOrCreateBatch(reliableExcept, pending.ExcludePeer).Add(batchData);
-				}
+				_reliableScratch.Add(batchData);
+				_reliableExcludeScratch.Add(pending.ExcludePeer);
 			}
 			else
 			{
-				if (pending.ExcludePeer == -1)
-				{
-					unreliableAll.Add(batchData);
-				}
-				else
-				{
-					GetOrCreateBatch(unreliableExcept, pending.ExcludePeer).Add(batchData);
-				}
+				_unreliableScratch.Add(batchData);
+				_unreliableExcludeScratch.Add(pending.ExcludePeer);
 			}
 		}
 
-		BroadcastGroupedBatch(reliableAll, nameof(NetRecvBatchedTransformsReliable), TransferMode.Reliable);
-		BroadcastGroupedBatch(unreliableAll, nameof(NetRecvBatchedTransformsUnreliable), TransferMode.UnreliableOrdered);
+		SendBatchesPerPeer(_reliableScratch, _reliableExcludeScratch, nameof(NetRecvBatchedTransformsReliable), TransferMode.Reliable);
+		SendBatchesPerPeer(_unreliableScratch, _unreliableExcludeScratch, nameof(NetRecvBatchedTransformsUnreliable), TransferMode.UnreliableOrdered);
+	}
 
-		// Send reliable batches
-		foreach (var (peerID, batch) in reliableExcept)
-		{
-			BroadcastGroupedBatch(batch, nameof(NetRecvBatchedTransformsReliable), TransferMode.Reliable, peerID);
-		}
+	private void SendBatchesPerPeer(List<BatchTransformData> entries, List<int> excludes, string rpcName, TransferMode transferMode)
+	{
+		if (entries.Count == 0) return;
 
-		// Send unreliable batches
-		foreach (var (peerID, batch) in unreliableExcept)
+		NetworkInstance net = NetService.NetInstance;
+		byte[]? fullPacket = null;
+
+		foreach (int peerID in net.PeerIds)
 		{
-			BroadcastGroupedBatch(batch, nameof(NetRecvBatchedTransformsUnreliable), TransferMode.UnreliableOrdered, peerID);
+			bool excluded = false;
+			for (int i = 0; i < excludes.Count; i++)
+			{
+				if (excludes[i] == peerID)
+				{
+					excluded = true;
+					break;
+				}
+			}
+
+			if (!excluded)
+			{
+				fullPacket ??= BuildRpcPacket(rpcName, SerializeUtils.Serialize<BatchTransformData[]>([.. entries]));
+				net.SendMessage(peerID, fullPacket, transferMode);
+				continue;
+			}
+
+			_peerScratch.Clear();
+			for (int i = 0; i < entries.Count; i++)
+			{
+				if (excludes[i] != peerID)
+				{
+					_peerScratch.Add(entries[i]);
+				}
+			}
+
+			if (_peerScratch.Count == 0) continue;
+
+			byte[] packet = BuildRpcPacket(rpcName, SerializeUtils.Serialize<BatchTransformData[]>([.. _peerScratch]));
+			net.SendMessage(peerID, packet, transferMode);
 		}
 	}
 
@@ -384,17 +391,6 @@ public partial class NetworkTransformSync : Instance
 				dyn.UpdateTransformFromNet(TransformPayloadDto.FromArray(data.Transform), isReliable, data.Lerp);
 			}
 		}
-	}
-
-	private static List<BatchTransformData> GetOrCreateBatch(Dictionary<int, List<BatchTransformData>> dict, int excludePeer)
-	{
-		if (!dict.TryGetValue(excludePeer, out var list))
-		{
-			list = [];
-			dict[excludePeer] = list;
-		}
-
-		return list;
 	}
 
 	private struct PendingBatchTransform(TransformPayloadDto transform, bool lerpTransform, int excludePeer)

--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -74,6 +74,12 @@ public partial class NetworkTransformSync : Instance
 		RpcId(plr.PeerID, nameof(NetRecvChunk), rawData, false);
 	}
 
+	public void SendChunk(NetworkedObject[] netObjs, Player plr, int start, int count)
+	{
+		byte[] rawData = ZstdCompressionUtils.Compress(SerializeUtils.Serialize(PackTransforms(netObjs, start, count)));
+		RpcId(plr.PeerID, nameof(NetRecvChunk), rawData, false);
+	}
+
 	public void BroadcastChunk(NetworkedObject[] netObjs)
 	{
 		byte[] rawData = ZstdCompressionUtils.Compress(SerializeUtils.Serialize(PackTransforms(netObjs)));
@@ -82,10 +88,16 @@ public partial class NetworkTransformSync : Instance
 
 	private static NetBatchTransformData[] PackTransforms(NetworkedObject[] netObjs)
 	{
-		List<NetBatchTransformData> data = [];
-		foreach (NetworkedObject item in netObjs)
+		return PackTransforms(netObjs, 0, netObjs.Length);
+	}
+
+	private static NetBatchTransformData[] PackTransforms(NetworkedObject[] netObjs, int start, int count)
+	{
+		List<NetBatchTransformData> data = new(count);
+		int end = start + count;
+		for (int i = start; i < end; i++)
 		{
-			if (item is Dynamic dyn)
+			if (netObjs[i] is Dynamic dyn && !dyn.IsDeleted)
 			{
 				data.Add(new()
 				{

--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -262,7 +262,7 @@ public partial class NetworkTransformSync : Instance
 			TransformPayloadDto processed = dyn.TransformNetworkPass(fromPeer, transform);
 
 			// If is equal approx to last, return
-			if (processed.IsEqualApprox(TransformPayloadDto.FromGDTransform(dyn.GetLocalTransform())))
+			if (processed.IsEqualApprox(dyn.GetLocalTransform()))
 				return;
 
 			// Update on server

--- a/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
+++ b/Polytoria/scripts/network/syncs/NetworkTransformSync.cs
@@ -231,7 +231,9 @@ public partial class NetworkTransformSync : Instance
 		SetPendingBatch(objID, new(payload, lerpTransform, excludePeer)
 		{
 			Reliable = reliable,
-			Forced = true
+			Forced = true,
+			Position = dyn.GetGlobalTransform().Origin,
+			AlwaysRelevant = dyn is Player
 		}, forced: true);
 	}
 
@@ -269,7 +271,12 @@ public partial class NetworkTransformSync : Instance
 			dyn.UpdateTransformFromNet(processed, false, lerpTransform);
 
 			// Add to batch pending
-			SetPendingBatch(objID, new(processed, lerpTransform, fromPeer) { Reliable = false });
+			SetPendingBatch(objID, new(processed, lerpTransform, fromPeer)
+			{
+				Reliable = false,
+				Position = dyn.GetGlobalTransform().Origin,
+				AlwaysRelevant = dyn is Player
+			});
 		}
 	}
 
@@ -277,6 +284,8 @@ public partial class NetworkTransformSync : Instance
 	private readonly List<int> _reliableExcludeScratch = [];
 	private readonly List<BatchTransformData> _unreliableScratch = [];
 	private readonly List<int> _unreliableExcludeScratch = [];
+	private readonly List<Vector3> _unreliablePositionScratch = [];
+	private readonly List<bool> _unreliableAlwaysScratch = [];
 	private readonly List<BatchTransformData> _peerScratch = [];
 
 	private void BroadcastBatchedTransforms()
@@ -287,6 +296,8 @@ public partial class NetworkTransformSync : Instance
 		_reliableExcludeScratch.Clear();
 		_unreliableScratch.Clear();
 		_unreliableExcludeScratch.Clear();
+		_unreliablePositionScratch.Clear();
+		_unreliableAlwaysScratch.Clear();
 
 		foreach (var (k, pending) in _pendingBatchUpdate)
 		{
@@ -305,22 +316,35 @@ public partial class NetworkTransformSync : Instance
 			{
 				_unreliableScratch.Add(batchData);
 				_unreliableExcludeScratch.Add(pending.ExcludePeer);
+				_unreliablePositionScratch.Add(pending.Position);
+				_unreliableAlwaysScratch.Add(pending.AlwaysRelevant);
 			}
 		}
 
-		SendBatchesPerPeer(_reliableScratch, _reliableExcludeScratch, nameof(NetRecvBatchedTransformsReliable), TransferMode.Reliable);
-		SendBatchesPerPeer(_unreliableScratch, _unreliableExcludeScratch, nameof(NetRecvBatchedTransformsUnreliable), TransferMode.UnreliableOrdered);
+		SendBatchesPerPeer(_reliableScratch, _reliableExcludeScratch, null, null, nameof(NetRecvBatchedTransformsReliable), TransferMode.Reliable);
+		SendBatchesPerPeer(_unreliableScratch, _unreliableExcludeScratch, _unreliablePositionScratch, _unreliableAlwaysScratch, nameof(NetRecvBatchedTransformsUnreliable), TransferMode.UnreliableOrdered);
 	}
 
-	private void SendBatchesPerPeer(List<BatchTransformData> entries, List<int> excludes, string rpcName, TransferMode transferMode)
+	private void SendBatchesPerPeer(List<BatchTransformData> entries, List<int> excludes, List<Vector3>? positions, List<bool>? alwaysRelevant, string rpcName, TransferMode transferMode)
 	{
 		if (entries.Count == 0) return;
 
 		NetworkInstance net = NetService.NetInstance;
+		float radius = NetService.ReplicationRadius;
+		bool filterByDistance = radius > 0f && positions != null && alwaysRelevant != null;
+		float radiusSq = radius * radius;
 		byte[]? fullPacket = null;
 
 		foreach (int peerID in net.PeerIds)
 		{
+			Vector3 peerPosition = default;
+			bool peerFiltered = false;
+			if (filterByDistance && NetService.Root.Players.GetPlayerFromPeerID(peerID) is { } player)
+			{
+				peerPosition = player.GetGlobalTransform().Origin;
+				peerFiltered = true;
+			}
+
 			bool excluded = false;
 			for (int i = 0; i < excludes.Count; i++)
 			{
@@ -331,7 +355,7 @@ public partial class NetworkTransformSync : Instance
 				}
 			}
 
-			if (!excluded)
+			if (!excluded && !peerFiltered)
 			{
 				fullPacket ??= BuildRpcPacket(rpcName, SerializeUtils.Serialize<BatchTransformData[]>([.. entries]));
 				net.SendMessage(peerID, fullPacket, transferMode);
@@ -341,10 +365,9 @@ public partial class NetworkTransformSync : Instance
 			_peerScratch.Clear();
 			for (int i = 0; i < entries.Count; i++)
 			{
-				if (excludes[i] != peerID)
-				{
-					_peerScratch.Add(entries[i]);
-				}
+				if (excludes[i] == peerID) continue;
+				if (peerFiltered && !alwaysRelevant![i] && peerPosition.DistanceSquaredTo(positions![i]) > radiusSq) continue;
+				_peerScratch.Add(entries[i]);
 			}
 
 			if (_peerScratch.Count == 0) continue;
@@ -400,6 +423,8 @@ public partial class NetworkTransformSync : Instance
 		public int ExcludePeer = excludePeer;
 		public bool Reliable = false;
 		public bool Forced = false;
+		public Vector3 Position = default;
+		public bool AlwaysRelevant = false;
 	}
 
 	private struct PendingTransform()

--- a/Polytoria/scripts/utils/dto/TransformPayload.cs
+++ b/Polytoria/scripts/utils/dto/TransformPayload.cs
@@ -85,6 +85,8 @@ public partial class TransformPayloadDto
 
 	public bool IsEqualApprox(TransformPayloadDto other) => Position.IsEqualApprox(other.Position) && Rotation.IsEqualApprox(other.Rotation);
 
+	public bool IsEqualApprox(Transform3D t) => Position.IsEqualApprox(t.Origin) && Rotation.IsEqualApprox(UnitQuaternionDto.FromCompressed(UnitQuaternionDto.ToCompressed(t.Basis.GetRotationQuaternion())));
+
 	// String helpers because memory pack don't like nested objects
 	public static TransformPayloadDto FromString(string str)
 	{


### PR DESCRIPTION
## Summary

This PR makes replication cheaper on the server and faster for a joining player. It also adds one opt-in feature.

- Sync-property metadata is now cached per type, with compiled getters. Property sync does not call GetCustomAttribute or reflection getters on each write.
- The movement broadcast builds one batch per receiver. The old code did per-peer work for each moving part, which cost O(P²) with P peers. The new cost is O(P). The wire format is unchanged.
- Property batches serialize with MemoryPack instead of JSON. Broadcast scratch buffers are reused, not allocated per frame.
- The join path uses the cached getters. Inbound movement packets reuse one transform payload object. Several per-packet allocations are gone.
- The server sends the world to a joining player in slices of 4,000 objects, with a final-chunk marker. The frame loop runs between slices. A large world no longer freezes the server while a player joins.
- New, opt-in: a distance filter for moving parts. The server sends transform updates only to players inside the replication radius. Players are always relevant. The filter is off by default.

Test:
- 48.000 Part replicates without server stall, the join payload compresses 58:1 with Zstd.


**Requires #1194 to be merged first!!**

## Related issue or discussion
N/A

## Type of change

- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [X] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [X] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [X] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

Same as #1192 and #1193 