### PR TITLE
Pr/perf rendering

### DIFF
--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -176,15 +176,15 @@ public partial class DatamodelBridge : Node3D
 	{
 		uint scaleLevel = 1;
 		float size = ChunkBaseSize;
+		Vector3 partSize = part.Size;
 
-		while (part.Size.X > size || part.Size.Y > size || part.Size.Z > size)
+		while (partSize.X > size || partSize.Y > size || partSize.Z > size)
 		{
 			size *= 2;
 			scaleLevel++;
 
 			if (scaleLevel > 10) break;
 		}
-
 
 		Vector3I coord = GetChunkCoord(part.Position, scaleLevel);
 		return new ChunkKey { Coord = coord, Material = part.Material, Shape = part.Shape, IsTransparent = part.Color.A < 1f, CastShadows = part.CastShadows, ScaleLevel = scaleLevel };
@@ -226,7 +226,7 @@ public partial class DatamodelBridge : Node3D
 	{
 		if (!_batches.TryGetValue(key, out var batch))
 		{
-			(Godot.Mesh mesh, _) = Globals.LoadShape(part.Shape.ToString());
+			(Godot.Mesh mesh, _) = Globals.LoadShape(part.Shape);
 
 			MultiMesh mm = new()
 			{
@@ -387,14 +387,14 @@ public partial class DatamodelBridge : Node3D
 		public int Index;
 	}
 
-	private struct ChunkKey
+	private readonly record struct ChunkKey
 	{
-		public Vector3I Coord;
-		public Part.PartMaterialEnum Material;
-		public Part.ShapeEnum Shape;
-		public bool IsTransparent;
-		public bool CastShadows;
-		public uint ScaleLevel;
+		public Vector3I Coord { get; init; }
+		public Part.PartMaterialEnum Material { get; init; }
+		public Part.ShapeEnum Shape { get; init; }
+		public bool IsTransparent { get; init; }
+		public bool CastShadows { get; init; }
+		public uint ScaleLevel { get; init; }
 	}
 
 	private class ChunkBatch

--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -23,6 +23,9 @@ public partial class DatamodelBridge : Node3D
 	private readonly HashSet<Part> _dirty = [];
 	private readonly Dictionary<Part, System.Action> _propertyHandlers = [];
 	private readonly List<Part> _dirtyScratch = [];
+	private readonly Dictionary<ChunkKey, ulong> _emptyBatchExpiry = [];
+	private readonly List<ChunkKey> _expiredBatchScratch = [];
+	private const ulong EmptyBatchKeepAliveMsec = 5000;
 	private Rid _scenario;
 
 	private readonly Dictionary<(Part.PartMaterialEnum, bool), Material> _materials = [];
@@ -81,6 +84,13 @@ public partial class DatamodelBridge : Node3D
 				{
 					RemovePart(item);
 				}
+
+				foreach (ChunkBatch batch in _batches.Values)
+				{
+					RenderingServer.FreeRid(batch.Rid);
+				}
+				_batches.Clear();
+				_emptyBatchExpiry.Clear();
 			}
 
 			Root.Bridge = null!;
@@ -125,6 +135,9 @@ public partial class DatamodelBridge : Node3D
 	public override void _Process(double delta)
 	{
 		if (!_renderingEnabled || !isGameReady) return;
+
+		SweepEmptyBatches();
+
 		if (_dirty.Count == 0) return;
 
 		_dirtyScratch.AddRange(_dirty);
@@ -222,6 +235,31 @@ public partial class DatamodelBridge : Node3D
 		isGameReady = true;
 	}
 
+	private void SweepEmptyBatches()
+	{
+		if (_emptyBatchExpiry.Count == 0) return;
+
+		ulong now = Time.GetTicksMsec();
+		_expiredBatchScratch.Clear();
+		foreach ((ChunkKey key, ulong expireAt) in _emptyBatchExpiry)
+		{
+			if (now >= expireAt)
+			{
+				_expiredBatchScratch.Add(key);
+			}
+		}
+
+		foreach (ChunkKey key in _expiredBatchScratch)
+		{
+			_emptyBatchExpiry.Remove(key);
+			if (_batches.TryGetValue(key, out ChunkBatch? batch) && batch.Count == 0)
+			{
+				_batches.Remove(key);
+				RenderingServer.FreeRid(batch.Rid);
+			}
+		}
+	}
+
 	private void AddToBatch(Part part, ChunkKey key)
 	{
 		if (!_batches.TryGetValue(key, out var batch))
@@ -256,6 +294,10 @@ public partial class DatamodelBridge : Node3D
 			};
 
 			_batches.Add(key, batch);
+		}
+		else
+		{
+			_emptyBatchExpiry.Remove(key);
 		}
 
 		part.RemoveSeparateMesh();
@@ -305,8 +347,7 @@ public partial class DatamodelBridge : Node3D
 
 		if (batch.Count == 0)
 		{
-			RenderingServer.FreeRid(batch.Rid);
-			_batches.Remove(handle.Key);
+			_emptyBatchExpiry[handle.Key] = Time.GetTicksMsec() + EmptyBatchKeepAliveMsec;
 		}
 
 		_handles.Remove(part);

--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -415,7 +415,10 @@ public partial class DatamodelBridge : Node3D
 			part.PropertyChanged.Disconnect(handler);
 		}
 
-		part.CreateSeparateMesh();
+		if (!part.IsDeleted)
+		{
+			part.CreateSeparateMesh();
+		}
 		RemoveFromBatch(part);
 	}
 

--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -21,6 +21,8 @@ public partial class DatamodelBridge : Node3D
 	private readonly Dictionary<Part, PartHandle> _handles = [];
 	private readonly Dictionary<ChunkKey, ChunkBatch> _batches = [];
 	private readonly HashSet<Part> _dirty = [];
+	private readonly Dictionary<Part, System.Action> _propertyHandlers = [];
+	private readonly List<Part> _dirtyScratch = [];
 	private Rid _scenario;
 
 	private readonly Dictionary<(Part.PartMaterialEnum, bool), Material> _materials = [];
@@ -125,7 +127,10 @@ public partial class DatamodelBridge : Node3D
 		if (!_renderingEnabled || !isGameReady) return;
 		if (_dirty.Count == 0) return;
 
-		foreach (Part part in _dirty)
+		_dirtyScratch.AddRange(_dirty);
+		_dirty.Clear();
+
+		foreach (Part part in _dirtyScratch)
 		{
 			bool inBatch = _handles.TryGetValue(part, out PartHandle? handle);
 			bool shouldBatch = IsPartEligible(part);
@@ -164,7 +169,7 @@ public partial class DatamodelBridge : Node3D
 			}
 		}
 
-		_dirty.Clear();
+		_dirtyScratch.Clear();
 	}
 
 	private static ChunkKey GetKeyForPart(Part part)
@@ -343,14 +348,10 @@ public partial class DatamodelBridge : Node3D
 		void propertyChangedHandler() { if (isGameReady) _dirty.Add(part); }
 
 		part.PropertyChanged.Connect(propertyChangedHandler);
+		_propertyHandlers[part] = propertyChangedHandler;
 
 		var key = GetKeyForPart(part);
 		AddToBatch(part, key);
-
-		if (_handles.TryGetValue(part, out var handle))
-		{
-			handle.PropertyChangedHandler = propertyChangedHandler;
-		}
 
 		_dirty.Add(part);
 	}
@@ -358,9 +359,9 @@ public partial class DatamodelBridge : Node3D
 	public void RemovePart(Part part)
 	{
 		if (!_renderingEnabled) return;
-		if (_handles.TryGetValue(part, out var handle))
+		if (_propertyHandlers.Remove(part, out System.Action? handler))
 		{
-			part.PropertyChanged.Disconnect(handle.PropertyChangedHandler);
+			part.PropertyChanged.Disconnect(handler);
 		}
 
 		part.CreateSeparateMesh();
@@ -384,7 +385,6 @@ public partial class DatamodelBridge : Node3D
 	{
 		public ChunkKey Key;
 		public int Index;
-		public System.Action PropertyChangedHandler = null!;
 	}
 
 	private struct ChunkKey

--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -165,7 +165,12 @@ public partial class DatamodelBridge : Node3D
 				{
 					ChunkBatch batch = _batches[handle.Key];
 					batch.MultiMesh.SetInstanceTransform(handle.Index, part.GetGlobalTransform());
-					batch.MultiMesh.SetInstanceColor(handle.Index, part.Color.SrgbToLinear());
+					Color color = part.Color;
+					if (handle.LastColor != color)
+					{
+						handle.LastColor = color;
+						batch.MultiMesh.SetInstanceColor(handle.Index, color.SrgbToLinear());
+					}
 				}
 			}
 			else
@@ -310,9 +315,10 @@ public partial class DatamodelBridge : Node3D
 		batch.MultiMesh.VisibleInstanceCount = batch.Count;
 
 		batch.MultiMesh.SetInstanceTransform(index, part.GetGlobalTransform());
-		batch.MultiMesh.SetInstanceColor(index, part.Color.SrgbToLinear());
+		Color addColor = part.Color;
+		batch.MultiMesh.SetInstanceColor(index, addColor.SrgbToLinear());
 
-		_handles[part] = new PartHandle { Key = key, Index = index };
+		_handles[part] = new PartHandle { Key = key, Index = index, LastColor = addColor };
 	}
 
 	private void RemoveFromBatch(Part part)
@@ -426,6 +432,7 @@ public partial class DatamodelBridge : Node3D
 	{
 		public ChunkKey Key;
 		public int Index;
+		public Color LastColor;
 	}
 
 	private readonly record struct ChunkKey

--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -386,16 +386,20 @@ public partial class DatamodelBridge : Node3D
 	{
 		if (!_renderingEnabled) return;
 		if (_handles.ContainsKey(part)) return;
+
+		if (!_propertyHandlers.ContainsKey(part))
+		{
+			void propertyChangedHandler() { if (isGameReady) _dirty.Add(part); }
+			part.PropertyChanged.Connect(propertyChangedHandler);
+			_propertyHandlers[part] = propertyChangedHandler;
+		}
+
 		if (!IsPartEligible(part))
 		{
 			part.CreateSeparateMesh();
+			_dirty.Add(part);
 			return;
 		}
-
-		void propertyChangedHandler() { if (isGameReady) _dirty.Add(part); }
-
-		part.PropertyChanged.Connect(propertyChangedHandler);
-		_propertyHandlers[part] = propertyChangedHandler;
 
 		var key = GetKeyForPart(part);
 		AddToBatch(part, key);

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -204,7 +204,7 @@ public partial class Part : Entity
 	internal void UpdateShape()
 	{
 		if (_collider == null) return;
-		(Godot.Mesh mesh, Shape3D shape) = Globals.LoadShape(_shape.ToString());
+		(Godot.Mesh mesh, Shape3D shape) = Globals.LoadShape(_shape);
 		if (_isSeparateMesh)
 		{
 			_mesh?.Mesh = mesh;

--- a/Polytoria/scripts/shared/Globals.cs
+++ b/Polytoria/scripts/shared/Globals.cs
@@ -317,6 +317,20 @@ public sealed partial class Globals : Node
 		return LoadCachedTexture(_uiIconsCache, iconName, UIIconsPath, "empty");
 	}
 
+	private static readonly Dictionary<Part.ShapeEnum, (Mesh, Shape3D)> _shapesByEnumCache = [];
+
+	public static (Mesh, Shape3D) LoadShape(Part.ShapeEnum shape)
+	{
+		if (_shapesByEnumCache.TryGetValue(shape, out (Mesh, Shape3D) cachedShape))
+		{
+			return cachedShape;
+		}
+
+		(Mesh, Shape3D) loadedShape = LoadShape(shape.ToString());
+		_shapesByEnumCache[shape] = loadedShape;
+		return loadedShape;
+	}
+
 	public static (Mesh, Shape3D) LoadShape(string shapeName)
 	{
 		if (_shapesCache.TryGetValue(shapeName, out (Mesh, Shape3D) cachedShape))


### PR DESCRIPTION
## Summary

This PR makes the MultiMesh chunk bridge cheaper per frame. 
It also contains two bug fixes.

- Fix: the bridge lost its property-changed handler when a part re-entered a batch. The disconnected handler kept the part dirty forever. The bridge now stores handlers in one map and removes them correctly. The dirty set also drains into a scratch list, so a handler that adds parts during the drain does not break iteration.
- Fix: a part that was not eligible for batching at spawn time never joined a batch later. The bridge now re-checks the part when it becomes eligible.
- Chunk keys are now a record struct. Key lookups do not box. The key builder reads the part transform one time instead of up to three times.
- Shape meshes load through an enum-keyed lookup. The hot path does not convert enums to strings.
- The bridge skips the instance color write when the color did not change.
- An empty chunk batch stays alive for a short time. A part that leaves and returns to the same chunk does not force a batch rebuild. The bridge also skips separate-mesh creation for deleted parts.

Note; IMO, this is priority for merge. Probably worth after #1190 

## Related issue or discussion


## Type of change

- [X] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [X] Server
- [X] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [X] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

Partial LLM usage check #1192 