### PR TITLE
Pr/perf load creator

### DIFF
--- a/Polytoria/scripts/creator/CreatorSession.cs
+++ b/Polytoria/scripts/creator/CreatorSession.cs
@@ -240,7 +240,7 @@ public partial class CreatorSession : Node, IDisposable
 		StartBackupTimer();
 	}
 
-	public World OpenWorld(string filePath, World? worldOverride = null, bool migrateCoords = false)
+	public async System.Threading.Tasks.Task<World> OpenWorld(string filePath, World? worldOverride = null, bool migrateCoords = false)
 	{
 		filePath = filePath.SanitizePath();
 		if (WorldPathToRoot.ContainsKey(filePath)) throw new InvalidOperationException("World already opened");
@@ -320,7 +320,7 @@ public partial class CreatorSession : Node, IDisposable
 			// Load world
 			try
 			{
-				PolyFormat.LoadWorld(root, worldData, migrateCoords);
+				await PolyFormat.LoadWorldAsync(root, worldData, migrateCoords);
 				root.InvokeReady();
 			}
 			catch (Exception ex)
@@ -358,7 +358,7 @@ public partial class CreatorSession : Node, IDisposable
 		root.ForceDelete();
 	}
 
-	public World? OpenMainWorld(World? worldOverride = null)
+	public System.Threading.Tasks.Task<World> OpenMainWorld(World? worldOverride = null)
 	{
 		return OpenWorld(Metadata.MainWorld, worldOverride);
 	}

--- a/Polytoria/scripts/creator/Gizmos.cs
+++ b/Polytoria/scripts/creator/Gizmos.cs
@@ -704,12 +704,15 @@ public sealed partial class Gizmos : Node
 					foreach (Rid rid in p2.GetRids())
 						excludeArray.Add(rid);
 				}
-				if (n is Dynamic d)
+				if (n is Dynamic d && d.HasBound)
 				{
 					excludeArray.Add(d.GetBoundRid());
 				}
 			}
-			excludeArray.Add(item.GetBoundRid());
+			if (item.HasBound)
+			{
+				excludeArray.Add(item.GetBoundRid());
+			}
 			item.UpdateCreatorBounds();
 		}
 

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -661,6 +661,12 @@ public partial class Dynamic : Instance
 		if (Root == null) return;
 		if (Root.SessionType != World.SessionTypeEnum.Creator) return;
 
+		if (this is IGroup or Camera or Physical)
+		{
+			UpdateCreatorBounds();
+			return;
+		}
+
 		_boundArea3D = new()
 		{
 			Monitorable = true,
@@ -684,7 +690,6 @@ public partial class Dynamic : Instance
 
 	internal void UpdateCreatorBounds()
 	{
-		if (_boundShape == null) return;
 		if (Root == null) return;
 		if (Root.SessionType != World.SessionTypeEnum.Creator) return;
 
@@ -692,6 +697,7 @@ public partial class Dynamic : Instance
 
 		CreatorBounds = bound;
 
+		if (_boundShape == null) return;
 		_boundShape.Size = bound.Size;
 		_boundCollider.Position = bound.GetCenter();
 	}
@@ -704,7 +710,7 @@ public partial class Dynamic : Instance
 
 	internal Rid GetBoundRid()
 	{
-		return _boundArea3D.GetRid();
+		return _boundArea3D != null ? _boundArea3D.GetRid() : default;
 	}
 
 	internal void RefreshCreatorBound()

--- a/Polytoria/scripts/datamodel/creator/CreatorService.cs
+++ b/Polytoria/scripts/datamodel/creator/CreatorService.cs
@@ -211,11 +211,11 @@ public sealed partial class CreatorService : Node, IScriptObject
 		// Open world
 		if (targetPlace != null)
 		{
-			session.OpenWorld(Path.GetRelativePath(folder, targetPlace).SanitizePath(), worldOverride);
+			await session.OpenWorld(Path.GetRelativePath(folder, targetPlace).SanitizePath(), worldOverride);
 		}
 		else
 		{
-			session.OpenMainWorld(worldOverride);
+			await session.OpenMainWorld(worldOverride);
 		}
 
 		Interface.LoadOverlay?.Hide();
@@ -357,7 +357,7 @@ public sealed partial class CreatorService : Node, IScriptObject
 
 		if (ext == "poly")
 		{
-			CurrentSession.OpenWorld(pathRelative);
+			_ = CurrentSession.OpenWorld(pathRelative);
 			return;
 		}
 		else if (ext == "model")
@@ -624,7 +624,7 @@ public sealed partial class CreatorService : Node, IScriptObject
 	{
 		string worldFilePath = root.WorldFilePath!;
 		root.ForceDelete();
-		root.LinkedSession.OpenWorld(worldFilePath, migrateCoords: true);
+		_ = root.LinkedSession.OpenWorld(worldFilePath, migrateCoords: true);
 	}
 
 	private void CleanupLocalTest()

--- a/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
+++ b/Polytoria/scripts/datamodeltest/DatamodelTestEntry.cs
@@ -81,7 +81,23 @@ public partial class DatamodelTestEntry : Node3D
 
 		await PackedFormat.PackProjectToFile(cmdargs["proj"], placeFilePath);
 
-		PackedFormat.LoadPackedWorldFile(Root, placeFilePath);
+		if (cmdargs.ContainsKey("dmtest-paced"))
+		{
+			ulong framesBefore = Engine.GetProcessFrames();
+			System.Diagnostics.Stopwatch loadSw = System.Diagnostics.Stopwatch.StartNew();
+			await PackedFormat.LoadPackedWorldFileAsync(Root, placeFilePath);
+			loadSw.Stop();
+			int loadedParts = 0;
+			foreach (Instance inst in Root.Environment.GetDescendants())
+			{
+				if (inst is Part) loadedParts++;
+			}
+			PT.Print($"[PACED] loadMs={loadSw.ElapsedMilliseconds} framesDuringLoad={Engine.GetProcessFrames() - framesBefore} parts={loadedParts}");
+		}
+		else
+		{
+			PackedFormat.LoadPackedWorldFile(Root, placeFilePath);
+		}
 		File.Delete(placeFilePath);
 
 		networkService.CreateServer();

--- a/Polytoria/scripts/formats/PackedFormat.cs
+++ b/Polytoria/scripts/formats/PackedFormat.cs
@@ -408,6 +408,31 @@ public static partial class PackedFormat
 		return LoadPackedWorldFromArchive(root, archive, entryPath);
 	}
 
+	[ThreadStatic] private static bool _pacedLoad;
+	[ThreadStatic] private static System.Threading.Tasks.Task? _pacedLoadTask;
+
+	private static async System.Threading.Tasks.Task<WorldData> LoadPackedWorldFromArchiveAsync(World root, ZipArchive archive, string? entryPath = null)
+	{
+		_pacedLoad = true;
+		WorldData data;
+		System.Threading.Tasks.Task? loadTask;
+		try
+		{
+			data = LoadPackedWorldFromArchive(root, archive, entryPath);
+			loadTask = _pacedLoadTask;
+		}
+		finally
+		{
+			_pacedLoad = false;
+			_pacedLoadTask = null;
+		}
+		if (loadTask != null)
+		{
+			await loadTask;
+		}
+		return data;
+	}
+
 	private static WorldData LoadPackedWorldFromArchive(World root, ZipArchive archive, string? entryPath = null)
 	{
 		CreatorProjectMetadata metadata;
@@ -471,7 +496,15 @@ public static partial class PackedFormat
 		// Load world
 		if (files.TryGetValue(entryPath, out byte[]? entryBytes))
 		{
-			PolyFormat.LoadWorld(root, entryBytes);
+			if (_pacedLoad)
+			{
+				System.Threading.Tasks.Task t = PolyFormat.LoadWorldAsync(root, entryBytes);
+				_pacedLoadTask = t;
+			}
+			else
+			{
+				PolyFormat.LoadWorld(root, entryBytes);
+			}
 		}
 
 		return new()
@@ -485,6 +518,13 @@ public static partial class PackedFormat
 		using FileStream fs = File.OpenRead(filePath);
 		using ZipArchive archive = new(fs, ZipArchiveMode.Read);
 		LoadPackedWorldFromArchive(root, archive, entryPath);
+	}
+
+	public static async System.Threading.Tasks.Task LoadPackedWorldFileAsync(World root, string filePath, string? entryPath = null)
+	{
+		using FileStream fs = File.OpenRead(filePath);
+		using ZipArchive archive = new(fs, ZipArchiveMode.Read);
+		await LoadPackedWorldFromArchiveAsync(root, archive, entryPath);
 	}
 
 	public static ModelData? ReadModelData(byte[] data)

--- a/Polytoria/scripts/formats/PolyFormat.cs
+++ b/Polytoria/scripts/formats/PolyFormat.cs
@@ -15,6 +15,7 @@ using Semver;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -153,6 +154,25 @@ public static partial class PolyFormat
 		}
 	}
 
+	public sealed class LoadPacing
+	{
+		private readonly long _budgetTicks;
+		private long _sliceStart;
+
+		public LoadPacing(double budgetMs)
+		{
+			_budgetTicks = (long)(Stopwatch.Frequency * budgetMs / 1000.0);
+			Begin();
+		}
+
+		public void Begin()
+		{
+			_sliceStart = Stopwatch.GetTimestamp();
+		}
+
+		public bool Exceeded => Stopwatch.GetTimestamp() - _sliceStart > _budgetTicks;
+	}
+
 	public static Instance? LoadModel(World root, byte[] content, NetworkedObject? parent = null, PolyObject? overrides = null, PolyLoadContext? globalLoadContext = null, PolyLoadContext? subLoadContext = null)
 	{
 		PolyRootData data = ReadRootDataBytes(content);
@@ -161,8 +181,13 @@ public static partial class PolyFormat
 
 	public static Instance? LoadModelFromRootData(World root, PolyRootData data, NetworkedObject? parent = null, PolyObject? overrides = null, PolyLoadContext? globalLoadContext = null, PolyLoadContext? subLoadContext = null)
 	{
+		return RunSync(LoadModelFromRootDataAsync(root, data, parent, overrides, globalLoadContext, subLoadContext));
+	}
+
+	private static async ValueTask<Instance?> LoadModelFromRootDataAsync(World root, PolyRootData data, NetworkedObject? parent = null, PolyObject? overrides = null, PolyLoadContext? globalLoadContext = null, PolyLoadContext? subLoadContext = null)
+	{
 		parent ??= root.TemporaryContainer;
-		PolyLoadContext context = new() { RootData = data, Root = root, LoadType = data.FileType, IndexToFile = subLoadContext?.IndexToFile ?? [], AssignModelRoot = globalLoadContext?.AssignModelRoot ?? true };
+		PolyLoadContext context = new() { RootData = data, Root = root, LoadType = data.FileType, IndexToFile = subLoadContext?.IndexToFile ?? [], AssignModelRoot = globalLoadContext?.AssignModelRoot ?? true, Pacing = globalLoadContext?.Pacing };
 
 		if (globalLoadContext != null)
 		{
@@ -173,7 +198,7 @@ public static partial class PolyFormat
 		{
 			foreach (PolyObject item in data.NonInstanceObjects)
 			{
-				FromPolyObject(item, context);
+				await FromPolyObjectAsync(item, context);
 			}
 
 			context.IsRootHint = true;
@@ -184,7 +209,7 @@ public static partial class PolyFormat
 
 			PolyObject rootObj = data.Objects[0];
 
-			NetworkedObject? netObj = FromPolyObject(rootObj, context, parent);
+			NetworkedObject? netObj = await FromPolyObjectAsync(rootObj, context, parent);
 
 			if (netObj is Instance rootInstance)
 			{
@@ -197,7 +222,7 @@ public static partial class PolyFormat
 				// Add childs
 				foreach (PolyObject child in rootObj.Children)
 				{
-					FromPolyObject(child, context, netObj);
+					await FromPolyObjectAsync(child, context, netObj);
 				}
 			}
 
@@ -205,7 +230,7 @@ public static partial class PolyFormat
 			{
 				if (overrides != null && globalLoadContext != null)
 				{
-					LoadEditableOverrides(overrides, i, context, globalLoadContext);
+					await LoadEditableOverridesAsync(overrides, i, context, globalLoadContext);
 				}
 				if (rootObj.LinkedModel != null)
 				{
@@ -266,14 +291,37 @@ public static partial class PolyFormat
 		if (rawdata.Length == 0) return;
 
 		PolyRootData data = ReadRootDataBytes(rawdata);
-		InternalLoadWorld(root, data, forceMigrateCords);
+		RunSync(InternalLoadWorldAsync(root, data, forceMigrateCords, null));
 	}
 
-	private static void InternalLoadWorld(World root, PolyRootData data, bool forceMigrateCords = false)
+	public static async Task LoadWorldAsync(World root, byte[] rawdata, bool forceMigrateCords = false, double sliceBudgetMs = 12)
+	{
+		// Empty world file
+		if (rawdata.Length == 0) return;
+
+		PolyRootData data = ReadRootDataBytes(rawdata);
+		await InternalLoadWorldAsync(root, data, forceMigrateCords, new LoadPacing(sliceBudgetMs));
+	}
+
+	private static void RunSync(ValueTask task)
+	{
+		if (!task.IsCompleted)
+			throw new InvalidOperationException("Paced load requires the async load path");
+		task.GetAwaiter().GetResult();
+	}
+
+	private static T RunSync<T>(ValueTask<T> task)
+	{
+		if (!task.IsCompleted)
+			throw new InvalidOperationException("Paced load requires the async load path");
+		return task.Result;
+	}
+
+	private static async ValueTask InternalLoadWorldAsync(World root, PolyRootData data, bool forceMigrateCords, LoadPacing? pacing)
 	{
 		Stopwatch sw = new();
 		sw.Start();
-		PolyLoadContext context = new() { RootData = data, Root = root, ForceCordMigration = forceMigrateCords };
+		PolyLoadContext context = new() { RootData = data, Root = root, ForceCordMigration = forceMigrateCords, Pacing = pacing };
 
 		// Empty world
 		if (data.Objects == null || data.Objects.Length == 0) return;
@@ -284,17 +332,28 @@ public static partial class PolyFormat
 
 		foreach (PolyObject item in data.NonInstanceObjects)
 		{
-			FromPolyObject(item, context);
+			await FromPolyObjectAsync(item, context);
 		}
 
 		foreach (PolyObject item in rootObj.Children)
 		{
-			FromPolyObject(item, context, root);
+			await FromPolyObjectAsync(item, context, root);
 		}
 	}
 
 	public static NetworkedObject? FromPolyObject(PolyObject obj, PolyLoadContext loadContext, NetworkedObject? parent = null)
 	{
+		return RunSync(FromPolyObjectAsync(obj, loadContext, parent));
+	}
+
+	private static async ValueTask<NetworkedObject?> FromPolyObjectAsync(PolyObject obj, PolyLoadContext loadContext, NetworkedObject? parent = null)
+	{
+		if (loadContext.Pacing is { Exceeded: true } pacing)
+		{
+			await Globals.Singleton.WaitFrame();
+			pacing.Begin();
+		}
+
 		string className = ConvertClassName(obj.ClassName);
 
 		// Prevent spawning player
@@ -339,7 +398,7 @@ public static partial class PolyFormat
 
 			try
 			{
-				netObj = LoadModelFromRootData(loadContext.Root, data, parent, obj, loadContext);
+				netObj = await LoadModelFromRootDataAsync(loadContext.Root, data, parent, obj, loadContext);
 			}
 			finally
 			{
@@ -414,7 +473,7 @@ public static partial class PolyFormat
 			// Load child
 			foreach (PolyObject child in obj.Children)
 			{
-				FromPolyObject(child, loadContext, netObj);
+				await FromPolyObjectAsync(child, loadContext, netObj);
 			}
 		}
 
@@ -431,7 +490,7 @@ public static partial class PolyFormat
 		return netObj;
 	}
 
-	private static void LoadEditableOverrides(PolyObject obj, Instance rootInstance, PolyLoadContext loadContext, PolyLoadContext globalLoadContext)
+	private static async ValueTask LoadEditableOverridesAsync(PolyObject obj, Instance rootInstance, PolyLoadContext loadContext, PolyLoadContext globalLoadContext)
 	{
 		// NOTE: Retrieve via ID doesn't work for some reason
 		foreach (PolyObject child in GetDescendants(obj))
@@ -455,7 +514,7 @@ public static partial class PolyFormat
 			if (rootInstance.FindChild(child.Name) == null)
 			{
 				// Add extra children
-				FromPolyObject(child, globalLoadContext, rootInstance);
+				await FromPolyObjectAsync(child, globalLoadContext, rootInstance);
 			}
 		}
 	}
@@ -894,6 +953,7 @@ public static partial class PolyFormat
 		public bool DoParentCheck = true;
 		public PolyFileType LoadType = PolyFileType.World;
 		public bool InsertChild = true;
+		public LoadPacing? Pacing;
 		public HashSet<string> LoadingModelChain = [];
 		public Dictionary<string, string> IndexToFile = [];
 		public Dictionary<string, PolyRootData> LoadedModel = [];

--- a/Polytoria/scripts/formats/PolyFormat.cs
+++ b/Polytoria/scripts/formats/PolyFormat.cs
@@ -100,16 +100,49 @@ public static partial class PolyFormat
 
 		switch (element.ValueKind)
 		{
+			case JsonValueKind.True:
+				if (targetType == typeof(bool)) return true;
+				break;
+			case JsonValueKind.False:
+				if (targetType == typeof(bool)) return false;
+				break;
+			case JsonValueKind.Number:
+				if (targetType == typeof(float)) return element.GetSingle();
+				if (targetType == typeof(int)) return element.GetInt32();
+				if (targetType == typeof(double)) return element.GetDouble();
+				if (targetType == typeof(uint)) return element.GetUInt32();
+				if (targetType == typeof(long)) return element.GetInt64();
+				break;
 			case JsonValueKind.String:
+				if (targetType == typeof(string)) return element.GetString();
 				if (targetType == typeof(Color))
-					return JsonSerializer.Deserialize(element.GetRawText(), PolyJSONGenerationContext.Default.Color);
+				{
+					string? hex = element.GetString();
+					return hex == null ? null : Color.FromString(hex, new Color(1, 1, 1));
+				}
 				break;
 			case JsonValueKind.Array:
 				// Handle Vector arrays
 				if (targetType == typeof(Vector2))
-					return JsonSerializer.Deserialize(element.GetRawText(), PolyJSONGenerationContext.Default.Vector2);
+				{
+					JsonElement.ArrayEnumerator e2 = element.EnumerateArray();
+					e2.MoveNext();
+					float v2x = e2.Current.GetSingle();
+					e2.MoveNext();
+					float v2y = e2.Current.GetSingle();
+					return new Vector2(v2x, v2y);
+				}
 				if (targetType == typeof(Vector3))
-					return JsonSerializer.Deserialize(element.GetRawText(), PolyJSONGenerationContext.Default.Vector3);
+				{
+					JsonElement.ArrayEnumerator e3 = element.EnumerateArray();
+					e3.MoveNext();
+					float v3x = e3.Current.GetSingle();
+					e3.MoveNext();
+					float v3y = e3.Current.GetSingle();
+					e3.MoveNext();
+					float v3z = e3.Current.GetSingle();
+					return new Vector3(v3x, v3y, v3z);
+				}
 				if (targetType == typeof(Quaternion))
 					return JsonSerializer.Deserialize(element.GetRawText(), PolyJSONGenerationContext.Default.Quaternion);
 				if (targetType == typeof(Variant))
@@ -573,6 +606,7 @@ public static partial class PolyFormat
 		Type dataModelType = netObj.GetType();
 
 		Dictionary<string, PropertyInfo> propertyCache = GetOrCreatePropertyCache(dataModelType);
+		Dictionary<PropertyInfo, Action<object, object?>> setterCache = GetOrCreateSetterCache(dataModelType);
 
 		foreach (KeyValuePair<string, object?> prop in obj.Properties)
 		{
@@ -642,13 +676,53 @@ public static partial class PolyFormat
 
 			try
 			{
-				property.SetValue(netObj, val);
+				if (setterCache.TryGetValue(property, out Action<object, object?>? setter))
+				{
+					setter(netObj, val);
+				}
+				else
+				{
+					property.SetValue(netObj, val);
+				}
 			}
 			catch (Exception ex)
 			{
 				GD.PushError(ex);
 			}
 		}
+	}
+
+	private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<Type, Dictionary<PropertyInfo, Action<object, object?>>> _setterCache = [];
+
+	private static Dictionary<PropertyInfo, Action<object, object?>> GetOrCreateSetterCache(
+		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+	{
+		return _setterCache.GetValue(type, static t =>
+		{
+			Dictionary<PropertyInfo, Action<object, object?>> map = [];
+			if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+			{
+				return map;
+			}
+
+			foreach (PropertyInfo prop in GetOrCreatePropertyCache(t).Values)
+			{
+				if (!prop.CanWrite || prop.SetMethod == null || prop.DeclaringType == null) continue;
+				try
+				{
+					System.Linq.Expressions.ParameterExpression objParam = System.Linq.Expressions.Expression.Parameter(typeof(object));
+					System.Linq.Expressions.ParameterExpression valParam = System.Linq.Expressions.Expression.Parameter(typeof(object));
+					System.Linq.Expressions.Expression body = System.Linq.Expressions.Expression.Assign(
+						System.Linq.Expressions.Expression.Property(System.Linq.Expressions.Expression.Convert(objParam, prop.DeclaringType), prop),
+						System.Linq.Expressions.Expression.Convert(valParam, prop.PropertyType));
+					map[prop] = System.Linq.Expressions.Expression.Lambda<Action<object, object?>>(body, objParam, valParam).Compile();
+				}
+				catch
+				{
+				}
+			}
+			return map;
+		});
 	}
 
 	private static Dictionary<string, PropertyInfo> GetOrCreatePropertyCache(


### PR DESCRIPTION
## Summary

This PR makes place loading faster and keeps the Studio editor responsive during a load.

- The JSON loader decodes bools, numbers, strings, colors, and vectors directly from the parsed elements. The old path serialized each value back to a string first.
- Property writes go through compiled setters instead of PropertyInfo.SetValue. On runtimes without dynamic code (AOT builds), the loader falls back to reflection automatically.
- The world loader now has a paced async path. It works in slices of 12 ms and yields to the frame loop between slices. The Studio open path uses it, so the editor draws frames and responds during a load. The synchronous path stays available and unchanged for callers that need it.
- The editor created a hidden picking-bounds node for every physical part. Most parts do not need one. The editor now skips them. In a 90,000-part scene this removes about 180,000 nodes and their per-frame cost.

Test:

My editor no longer hangs when loading big projects (>90k parts), offering a much smoother experience when using the editor.

## Related issue or discussion
N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Tests
- [X] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

Shows loading, it actually hangs for a second on the last loading process, might look into that in the future.

New:
https://cdn.discordapp.com/attachments/1542079751165050910/1542601400729739357/2026-08-27_20-25-10.mp4?ex=6a91d302&is=6a908182&hm=a4e30c37e9c9d70f17ad6fea9abd5197e04df55fc97ed183c30e1760c8fe0fb6&

Old:
https://cdn.discordapp.com/attachments/1542079751165050910/1542602241691746324/2026-08-27_20-28-53.mp4?ex=6a91d3ca&is=6a90824a&hm=5083bb8d753120d2f018f69807e2c0aa3b4bb7959736685278299d60519a6284&

## AI/LLM use
None