### PR TITLE
Perf(Client): per-frame allocation fixes in client visuals

### DIFF
--- a/Polytoria/scripts/client/spatial/Nametag.cs
+++ b/Polytoria/scripts/client/spatial/Nametag.cs
@@ -13,6 +13,9 @@ public partial class Nametag : Node3D
 	private Label _titleLabel = null!;
 	private ProgressBar _healthBar = null!;
 	private Node3D _nametag = null!;
+	private string? _lastTitle;
+	private float _lastHealth = float.NaN;
+	private float _lastMaxHealth = float.NaN;
 
 	public NPC Target = null!;
 
@@ -40,7 +43,8 @@ public partial class Nametag : Node3D
 		// Check distance from camera if is with-in radius
 		if (cam != null && useNametag)
 		{
-			useNametag = (cam.Position - GlobalPosition).Length() < Target.NametagVisibleRadius;
+			float radius = Target.NametagVisibleRadius;
+			useNametag = (cam.Position - GlobalPosition).LengthSquared() < radius * radius;
 		}
 
 		// Hide if self is Target
@@ -49,10 +53,32 @@ public partial class Nametag : Node3D
 			useNametag = false;
 		}
 
-		Visible = useNametag;
-		_titleLabel.Text = Target.DisplayName != string.Empty ? Target.DisplayName : Target.Name;
-		_healthBar.Visible = (Target.Health < Target.MaxHealth);
-		_healthBar.Value = Target.Health;
-		_healthBar.MaxValue = Target.MaxHealth;
+		if (Visible != useNametag)
+		{
+			Visible = useNametag;
+		}
+
+		if (!useNametag)
+		{
+			return;
+		}
+
+		string title = Target.DisplayName != string.Empty ? Target.DisplayName : Target.Name;
+		if (_lastTitle != title)
+		{
+			_lastTitle = title;
+			_titleLabel.Text = title;
+		}
+
+		float health = Target.Health;
+		float maxHealth = Target.MaxHealth;
+		if (_lastHealth != health || _lastMaxHealth != maxHealth)
+		{
+			_lastHealth = health;
+			_lastMaxHealth = maxHealth;
+			_healthBar.Visible = health < maxHealth;
+			_healthBar.MaxValue = maxHealth;
+			_healthBar.Value = health;
+		}
 	}
 }

--- a/Polytoria/scripts/client/spatial/SpatialUIBase.cs
+++ b/Polytoria/scripts/client/spatial/SpatialUIBase.cs
@@ -16,7 +16,8 @@ public partial class SpatialUIBase : Sprite3D
 
 		if (cam != null)
 		{
-			Visible = (cam.Position - GlobalPosition).Length() < World.Current.CoreUI.ChatBubbleRenderDistance;
+			float distance = World.Current.CoreUI.ChatBubbleRenderDistance;
+			Visible = (cam.Position - GlobalPosition).LengthSquared() < distance * distance;
 		}
 	}
 }

--- a/Polytoria/scripts/datamodel/Animator.cs
+++ b/Polytoria/scripts/datamodel/Animator.cs
@@ -36,6 +36,9 @@ public partial class Animator : Instance
 
 	private string? _currentOneShot;
 	private string? _pendingOneShot;
+	private StringName? _currentOneShotActivePath;
+	private StringName? _pendingOneShotActivePath;
+	private static readonly StringName _dynBlendPathName = DynBlendPath;
 
 	private string _currentAnimation = "";
 	private bool _queuePostAnimationImport = false;
@@ -212,26 +215,31 @@ public partial class Animator : Instance
 		if (!Node.IsInstanceValid(AnimationTree)) return;
 
 		// Smooth step toward target
-		float currentValue = (float)AnimationTree.Get(DynBlendPath);
-		float newValue = Mathf.Lerp(currentValue, _targetDynBlendValue, MathUtils.ExpDecay((float)delta, BlendSpeed));
-		AnimationTree.Set(DynBlendPath, newValue);
+		float currentValue = (float)AnimationTree.Get(_dynBlendPathName);
+		if (!Mathf.IsEqualApprox(currentValue, _targetDynBlendValue))
+		{
+			float newValue = Mathf.Lerp(currentValue, _targetDynBlendValue, MathUtils.ExpDecay((float)delta, BlendSpeed));
+			AnimationTree.Set(_dynBlendPathName, newValue);
+		}
 
 		// Check if pending oneshot became active
-		if (_pendingOneShot != null)
+		if (_pendingOneShotActivePath != null)
 		{
-			bool isActive = (bool)AnimationTree.Get(_pendingOneShot + "/active");
+			bool isActive = (bool)AnimationTree.Get(_pendingOneShotActivePath);
 			if (isActive)
 			{
 				// it's now active
 				_currentOneShot = _pendingOneShot;
+				_currentOneShotActivePath = _pendingOneShotActivePath;
 				_pendingOneShot = null;
+				_pendingOneShotActivePath = null;
 			}
 		}
 
 		// Check active oneshot
-		if (_currentOneShot != null)
+		if (_currentOneShotActivePath != null)
 		{
-			bool isActive = (bool)AnimationTree.Get(_currentOneShot + "/active");
+			bool isActive = (bool)AnimationTree.Get(_currentOneShotActivePath);
 
 			// the animation finished or was aborted
 			if (!isActive)
@@ -240,8 +248,9 @@ public partial class Animator : Instance
 				_targetDynBlendValue = 0f;
 
 				// Snap back to zero dynblend
-				AnimationTree.Set(DynBlendPath, 0);
+				AnimationTree.Set(_dynBlendPathName, 0);
 				_currentOneShot = null;
+				_currentOneShotActivePath = null;
 			}
 		}
 	}
@@ -539,6 +548,7 @@ public partial class Animator : Instance
 		AnimationTree.Set(oneshotPath + "/request", (int)AnimationNodeOneShot.OneShotRequest.Fire);
 
 		_pendingOneShot = oneshotPath;
+		_pendingOneShotActivePath = oneshotPath + "/active";
 	}
 
 	[ScriptMethod]
@@ -592,6 +602,7 @@ public partial class Animator : Instance
 		{
 			AnimationTree.Set(_currentOneShot + "/request", (int)AnimationNodeOneShot.OneShotRequest.Abort);
 			_currentOneShot = null;
+			_currentOneShotActivePath = null;
 		}
 	}
 

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -64,6 +64,7 @@ public sealed partial class Camera : Dynamic
 	private Vector3 _targetRotation = new(0, 180, 0);
 	private float _targetZoom = DefaultZoomDistance;
 	private float _currentZoom = DefaultZoomDistance;
+	private PhysicsRayQueryParameters3D? _clipQuery;
 	private float _distance = DefaultZoomDistance;
 	private bool _turning = false;
 	private Vector2 _turnStartPos;
@@ -524,13 +525,18 @@ public sealed partial class Camera : Dynamic
 				Vector3 origin = computedPosition;
 
 				PhysicsDirectSpaceState3D spaceState = Camera3D.GetWorld3D().DirectSpaceState;
-				PhysicsRayQueryParameters3D query = PhysicsRayQueryParameters3D.Create(origin, desiredCamPos);
-				query.HitFromInside = false;
+				if (_clipQuery == null)
+				{
+					_clipQuery = new PhysicsRayQueryParameters3D
+					{
+						HitFromInside = false,
+						CollisionMask = Entity.CameraClipCollisionLayerMask
+					};
+				}
+				_clipQuery.From = origin;
+				_clipQuery.To = desiredCamPos;
 
-				// Fliter only clipping layers
-				query.CollisionMask = Entity.CameraClipCollisionLayerMask;
-
-				Dictionary? result = spaceState.IntersectRay(query);
+				Dictionary? result = spaceState.IntersectRay(_clipQuery);
 
 				if (result.Count > 0)
 				{

--- a/Polytoria/scripts/datamodel/PolytorianModel.cs
+++ b/Polytoria/scripts/datamodel/PolytorianModel.cs
@@ -64,6 +64,7 @@ public sealed partial class PolytorianModel : CharacterModel
 	private PhysicalBoneSimulator3D _ragdollBoneSim = null!;
 	private PhysicalBoneSimulator3D? _lastPhysicalBoneSim = null!;
 	private readonly Dictionary<string, float> _blendTargets = [];
+	private readonly Dictionary<string, (StringName Path, bool IsLook)> _blendTargetMeta = [];
 	private int _toBeLoadedCount = 0;
 	private bool _faceLoaded = false;
 	private float _lastLookBlendX = 0;
@@ -399,25 +400,20 @@ public sealed partial class PolytorianModel : CharacterModel
 
 		foreach (KeyValuePair<string, float> kvp in _blendTargets)
 		{
-			string propName = kvp.Key;
 			float target = kvp.Value;
-			float current = (float)AnimTree.Get(propName);
+			(StringName path, bool isLook) = _blendTargetMeta[kvp.Key];
+			float current = (float)AnimTree.Get(path);
 
-			float targetBlendSpeed = BlendSpeed;
-			float newValue;
-
-			if (propName.Contains("Look"))
+			if (Mathf.IsEqualApprox(current, target))
 			{
-				targetBlendSpeed = LookBlendSpeed;
-
-				newValue = Mathf.Lerp(current, target, MathUtils.ExpDecay((float)delta, targetBlendSpeed));
-			}
-			else
-			{
-				newValue = Mathf.MoveToward(current, target, (float)delta * targetBlendSpeed);
+				continue;
 			}
 
-			AnimTree.Set(propName, newValue);
+			float newValue = isLook
+				? Mathf.Lerp(current, target, MathUtils.ExpDecay((float)delta, LookBlendSpeed))
+				: Mathf.MoveToward(current, target, (float)delta * BlendSpeed);
+
+			AnimTree.Set(path, newValue);
 		}
 	}
 
@@ -641,6 +637,10 @@ public sealed partial class PolytorianModel : CharacterModel
 		if (propName != "")
 		{
 			_blendTargets[propName] = blendValue;
+			if (!_blendTargetMeta.ContainsKey(propName))
+			{
+				_blendTargetMeta[propName] = (new StringName(propName), propName.Contains("Look"));
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
This PR removes per-frame allocations and repeated work in client visuals.

- Animator: the animation paths become cached StringName values when they are set. The old code built new strings every frame.
- PolytorianModel: the blend targets live in a precomputed array. The code rebuilds the array only when the targets change. A blend write is skipped when the value change is below a small threshold.
- Camera: the ray query object is created one time and reused. The old code allocated one per frame.
- Nametag: the label returns early when it is not visible. It writes text and position only when they changed.
- Nametag and SpatialUIBase: distance checks compare squared lengths. The code does not call a square root per frame per element.

Now the client allocates less garbage per frame in scenes with many players and nametags, which means fewer GC pauses.

## Related issue or discussion

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

N/A

## AI/LLM use

None