### PR TITLE
[Bugfix]: Resolving (Un-)Focus Bug on the new Docks

### DIFF
--- a/Polytoria/scripts/creator/ui/ColorPicker.cs
+++ b/Polytoria/scripts/creator/ui/ColorPicker.cs
@@ -27,11 +27,28 @@ public sealed partial class ColorPicker : PanelContainer
 
 		GetViewport().GuiFocusChanged += focus =>
 		{
-			if (Visible && !IsAncestorOf(focus) && focus.Name != "Color")
-			{
-				Hide();
-			}
+			if (!Visible || focus == null)
+				return;
+
+			if (IsAncestorOf(focus) || focus == _button)
+				return;
+
+			Hide();
 		};
+	}
+
+	public override void _Input(InputEvent @event)
+	{
+		if (!Visible || @event is not InputEventMouseButton { Pressed: true, ButtonIndex: MouseButton.Left } mouseButton)
+			return;
+
+		if (GetGlobalRect().HasPoint(mouseButton.Position))
+			return;
+
+		if (_button != null && _button.GetGlobalRect().HasPoint(mouseButton.Position))
+			return;
+
+		Hide();
 	}
 
 	public void SwitchTo(Button button, Color current, ColorChangedEventHandler callback, Action? finishedCallback = null)

--- a/Polytoria/scripts/creator/ui/docking/DockRegion.cs
+++ b/Polytoria/scripts/creator/ui/docking/DockRegion.cs
@@ -31,6 +31,18 @@ public sealed partial class DockRegion : Control
 
 	public override void _ExitTree() => DockManager.UnregisterRegion(this);
 
+	public override void _Input(InputEvent @event)
+	{
+		if (!Visible || @event is not InputEventMouseButton { Pressed: true, ButtonIndex: MouseButton.Left } button)
+			return;
+
+		Control? focusOwner = GetViewport().GuiGetFocusOwner();
+		if (focusOwner == null || !GetGlobalRect().HasPoint(button.Position) || focusOwner.GetGlobalRect().HasPoint(button.Position))
+			return;
+
+		focusOwner.ReleaseFocus();
+	}
+
 	public static bool CanReadDockData(Variant data)
 	{
 		return data.VariantType == Variant.Type.Dictionary


### PR DESCRIPTION
## Summary

U can unfocus from The ColorPicker and InputBoxes again

## Related issue or discussion

Reported in the Contributor Discord

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [ ] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
--> Not up to date
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/f5ecd0d9-e576-484b-8184-f09bef7adc01

## AI/LLM use

None