### PR TITLE
Implement Physical.RayPassthrough

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -966,6 +966,13 @@ public sealed partial class Camera : Dynamic
 		}
 	}
 
+	public (Vector3, Vector3) ProjectFromScreen(Vector2 screenPos)
+	{
+		Vector3 origin = Camera3D.ProjectRayOrigin(screenPos);
+		Vector3 dir = Camera3D.ProjectRayNormal(screenPos);
+		return (origin, dir);
+	}
+
 	[ScriptMethod]
 	public bool IsPositionInView(Vector3 pos)
 	{

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -966,13 +966,6 @@ public sealed partial class Camera : Dynamic
 		}
 	}
 
-	public (Vector3, Vector3) ProjectFromScreen(Vector2 screenPos)
-	{
-		Vector3 origin = Camera3D.ProjectRayOrigin(screenPos);
-		Vector3 dir = Camera3D.ProjectRayNormal(screenPos);
-		return (origin, dir);
-	}
-
 	[ScriptMethod]
 	public bool IsPositionInView(Vector3 pos)
 	{
@@ -1158,7 +1151,7 @@ public sealed partial class Camera : Dynamic
 		}
 	}
 
-	public RayResult? GetPlacementRay(Instance[]? ignoreList = null, uint passthroughMask = 0)
+	public RayResult? GetPlacementRay(Instance[]? ignoreList = null)
 	{
 		if (World.Current == null) throw new InvalidOperationException("World is null");
 		Transform3D globalTransform = GetGlobalTransform();
@@ -1166,7 +1159,7 @@ public sealed partial class Camera : Dynamic
 		// In GoDot the Z axis points to the Camera
 		Vector3 direction = -globalTransform.Basis.Z;
 
-		return World.Current.Environment.Raycast(origin, direction, 20, ignoreList, passthroughMask);
+		return World.Current.Environment.Raycast(origin, direction, 20, ignoreList);
 	}
 #endif
 }

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -986,22 +986,22 @@ public sealed partial class Camera : Dynamic
 	}
 
 	[ScriptMethod]
-	public RayResult? ViewportPointToRay(Vector2 pos, Instance[]? ignoreList = null, float maxDistance = 10000f)
+	public RayResult? ViewportPointToRay(Vector2 pos, Instance[]? ignoreList = null, float maxDistance = 10000f, uint passthroughMask = 0)
 	{
 		Viewport viewport = GDNode.GetViewport();
 		Vector2 size = viewport.GetVisibleRect().Size;
 		Vector2 screenPos = new(pos.X * size.X, pos.Y * size.Y);
 		Vector3 rayOrigin = Camera3D.ProjectRayOrigin(screenPos);
 		Vector3 rayDir = Camera3D.ProjectRayNormal(screenPos);
-		return Root.Environment.Raycast(rayOrigin, rayDir, maxDistance, ignoreList);
+		return Root.Environment.Raycast(rayOrigin, rayDir, maxDistance, ignoreList, passthroughMask);
 	}
 
 	[ScriptMethod]
-	public RayResult? ScreenPointToRay(Vector2 pos, Instance[]? ignoreList = null, float maxDistance = 10000f)
+	public RayResult? ScreenPointToRay(Vector2 pos, Instance[]? ignoreList = null, float maxDistance = 10000f, uint passthroughMask = 0)
 	{
 		Vector3 rayOrigin = Camera3D.ProjectRayOrigin(pos);
 		Vector3 rayDir = Camera3D.ProjectRayNormal(pos);
-		return Root.Environment.Raycast(rayOrigin, rayDir, maxDistance, ignoreList);
+		return Root.Environment.Raycast(rayOrigin, rayDir, maxDistance, ignoreList, passthroughMask);
 	}
 
 	[ScriptMethod]
@@ -1158,7 +1158,7 @@ public sealed partial class Camera : Dynamic
 		}
 	}
 
-	public RayResult? GetPlacementRay(Instance[]? ignoreList = null)
+	public RayResult? GetPlacementRay(Instance[]? ignoreList = null, uint passthroughMask = 0)
 	{
 		if (World.Current == null) throw new InvalidOperationException("World is null");
 		Transform3D globalTransform = GetGlobalTransform();
@@ -1166,7 +1166,7 @@ public sealed partial class Camera : Dynamic
 		// In GoDot the Z axis points to the Camera
 		Vector3 direction = -globalTransform.Basis.Z;
 
-		return World.Current.Environment.Raycast(origin, direction, 20, ignoreList);
+		return World.Current.Environment.Raycast(origin, direction, 20, ignoreList, passthroughMask);
 	}
 #endif
 }

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -347,32 +347,9 @@ public sealed partial class Environment : Instance
 
 	public RayResult? PenetrateRaycast(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
 	{
-		RayResult? rayResult = null;
-		Func<RayResult, bool> handler = ray =>
-		{
-			rayResult = ray;
-			return false;
-		};
-		PenetrateRaycastCore(origin, direction, handler, maxDistance, ignoreList, passthroughMask);
-		return rayResult;
-	}
-
-	public RayResult[] PenetrateRaycastAll(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
-	{
-		List<RayResult> rayResults = [];
-		Func<RayResult, bool> handler = ray =>
-		{
-			rayResults.Add(ray);
-			return true;
-		};
-		PenetrateRaycastCore(origin, direction, handler, maxDistance, ignoreList, passthroughMask);
-		return [.. rayResults];
-	}
-
-	private void PenetrateRaycastCore(Vector3 origin, Vector3 direction, Func<RayResult, bool> handler, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
-	{
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
 		Godot.Collections.Array<Rid> ignoreRids = [];
+		RayResult? rayResult = null;
 
 		if (ignoreList != null)
 		{
@@ -405,7 +382,7 @@ public sealed partial class Environment : Instance
 
 			Vector3 hitPos = (Vector3)result["position"];
 			Vector3 normal = (Vector3)result["normal"];
-			RayResult rayResult = new()
+			rayResult = new()
 			{
 				Origin = origin,
 				Direction = direction.Normalized(),
@@ -414,10 +391,63 @@ public sealed partial class Environment : Instance
 				Distance = (origin - hitPos).Length(),
 				Instance = instance,
 			};
-
-			bool shouldContinue = handler(rayResult);
-			if (!shouldContinue) break;
+			break;
 		}
+
+		return rayResult;
+	}
+
+	public RayResult[] PenetrateRaycastGather(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
+	{
+		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
+		Godot.Collections.Array<Rid> ignoreRids = [];
+		List<RayResult> rayResults = [];
+
+		if (ignoreList != null)
+		{
+			ignoreRids = PhysicalsToArray(ignoreList);
+		}
+
+		while (true)
+		{
+			Godot.Collections.Dictionary result = spaceState.IntersectRay(new PhysicsRayQueryParameters3D
+			{
+				From = origin,
+				To = origin + direction.Normalized() * maxDistance,
+				CollideWithAreas = true,
+				CollideWithBodies = true,
+				Exclude = ignoreRids
+			});
+
+			if (result.Count == 0) break;
+
+
+			Node collider = (Node)(GodotObject)result["collider"];
+			Instance? instance = ColliderToInstance(collider);
+			Rid colliderRid = (Rid)result["rid"];
+			ignoreRids.Add(colliderRid);
+
+			Vector3 hitPos = (Vector3)result["position"];
+			Vector3 normal = (Vector3)result["normal"];
+			rayResults.Add(new()
+			{
+				Origin = origin,
+				Direction = direction.Normalized(),
+				Position = hitPos,
+				Normal = normal,
+				Distance = (origin - hitPos).Length(),
+				Instance = instance,
+			});
+
+			if (instance is Physical p)
+			{
+				Physical.MousePassthroughEnum partPass = (Physical.MousePassthroughEnum)p.MousePassthrough;
+				if ((partPass & passthroughMask) != Physical.MousePassthroughEnum.None) continue;
+			}
+			break;
+		}
+
+		return [.. rayResults];
 	}
 
 	private static Instance? ColliderToInstance(Node collider)

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -356,16 +356,18 @@ public sealed partial class Environment : Instance
 			ignoreRids = PhysicalsToArray(ignoreList);
 		}
 
+		PhysicsRayQueryParameters3D query = new()
+		{
+			From = origin,
+			To = origin + direction.Normalized() * maxDistance,
+			CollideWithAreas = true,
+			CollideWithBodies = true,
+		};
+
 		while (true)
 		{
-			Godot.Collections.Dictionary result = spaceState.IntersectRay(new PhysicsRayQueryParameters3D
-			{
-				From = origin,
-				To = origin + direction.Normalized() * maxDistance,
-				CollideWithAreas = true,
-				CollideWithBodies = true,
-				Exclude = ignoreRids
-			});
+			query.Exclude = ignoreRids;
+			Godot.Collections.Dictionary result = spaceState.IntersectRay(query);
 
 			if (result.Count == 0) break;
 
@@ -408,16 +410,18 @@ public sealed partial class Environment : Instance
 			ignoreRids = PhysicalsToArray(ignoreList);
 		}
 
+		PhysicsRayQueryParameters3D query = new()
+		{
+			From = origin,
+			To = origin + direction.Normalized() * maxDistance,
+			CollideWithAreas = true,
+			CollideWithBodies = true,
+		};
+
 		while (true)
 		{
-			Godot.Collections.Dictionary result = spaceState.IntersectRay(new PhysicsRayQueryParameters3D
-			{
-				From = origin,
-				To = origin + direction.Normalized() * maxDistance,
-				CollideWithAreas = true,
-				CollideWithBodies = true,
-				Exclude = ignoreRids
-			});
+			query.Exclude = ignoreRids;
+			Godot.Collections.Dictionary result = spaceState.IntersectRay(query);
 
 			if (result.Count == 0) break;
 

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -260,31 +260,43 @@ public sealed partial class Environment : Instance
 	}
 
 	[ScriptMethod]
-	public RayResult? Raycast(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null)
+	public RayResult? Raycast(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, uint passthroughMask = 0)
 	{
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
+		Godot.Collections.Array<Rid> ignoreRids = [];
+
+		if (ignoreList != null)
+		{
+			ignoreRids = PhysicalsToArray(ignoreList);
+		}
 
 		PhysicsRayQueryParameters3D query = new()
 		{
 			From = origin,
 			To = origin + direction.Normalized() * maxDistance,
 			CollideWithAreas = true,
-			CollideWithBodies = true
+			CollideWithBodies = true,
 		};
 
-		if (ignoreList != null)
+		while (true)
 		{
-			query.Exclude = PhysicalsToArray(ignoreList);
-		}
+			query.Exclude = ignoreRids;
+			Godot.Collections.Dictionary result = spaceState.IntersectRay(query);
 
-		Godot.Collections.Dictionary result = spaceState.IntersectRay(query);
+			if (result.Count == 0) break;
 
-		if (result.Count > 0)
-		{
+			Rid colliderRid = (Rid)result["rid"];
+			ignoreRids.Add(colliderRid);
+
+			Node collider = (Node)(GodotObject)result["collider"];
+			Instance? instance = ColliderToInstance(collider);
+			if (instance is Physical p)
+			{
+				if ((p.RayPassthrough & passthroughMask) != 0) continue;
+			}
+
 			Vector3 hitPos = (Vector3)result["position"];
 			Vector3 normal = (Vector3)result["normal"];
-			Node collider = (Node)(GodotObject)result["collider"];
-
 			return new()
 			{
 				Origin = origin,
@@ -292,7 +304,7 @@ public sealed partial class Environment : Instance
 				Position = hitPos,
 				Normal = normal,
 				Distance = (origin - hitPos).Length(),
-				Instance = ColliderToInstance(collider)
+				Instance = instance,
 			};
 		}
 
@@ -345,60 +357,7 @@ public sealed partial class Environment : Instance
 		return [.. rayResults];
 	}
 
-	public RayResult? PenetrateRaycast(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, uint passthrough = 0)
-	{
-		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
-		Godot.Collections.Array<Rid> ignoreRids = [];
-		RayResult? rayResult = null;
-
-		if (ignoreList != null)
-		{
-			ignoreRids = PhysicalsToArray(ignoreList);
-		}
-
-		PhysicsRayQueryParameters3D query = new()
-		{
-			From = origin,
-			To = origin + direction.Normalized() * maxDistance,
-			CollideWithAreas = true,
-			CollideWithBodies = true,
-		};
-
-		while (true)
-		{
-			query.Exclude = ignoreRids;
-			Godot.Collections.Dictionary result = spaceState.IntersectRay(query);
-
-			if (result.Count == 0) break;
-
-			Rid colliderRid = (Rid)result["rid"];
-			ignoreRids.Add(colliderRid);
-
-			Node collider = (Node)(GodotObject)result["collider"];
-			Instance? instance = ColliderToInstance(collider);
-			if (instance is Physical p)
-			{
-				if ((p.RayPassthrough & passthrough) != 0) continue;
-			}
-
-			Vector3 hitPos = (Vector3)result["position"];
-			Vector3 normal = (Vector3)result["normal"];
-			rayResult = new()
-			{
-				Origin = origin,
-				Direction = direction.Normalized(),
-				Position = hitPos,
-				Normal = normal,
-				Distance = (origin - hitPos).Length(),
-				Instance = instance,
-			};
-			break;
-		}
-
-		return rayResult;
-	}
-
-	public RayResult[] PenetrateRaycastGather(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, uint passthrough = 0)
+	public RayResult[] RaycastGather(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, uint passthroughMask = 0)
 	{
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
 		Godot.Collections.Array<Rid> ignoreRids = [];
@@ -448,7 +407,7 @@ public sealed partial class Environment : Instance
 
 			if (instance is Physical p)
 			{
-				if ((p.RayPassthrough & passthrough) != 0) continue;
+				if ((p.RayPassthrough & passthroughMask) != 0) continue;
 			}
 			break;
 		}

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -345,6 +345,59 @@ public sealed partial class Environment : Instance
 		return [.. rayResults];
 	}
 
+	public RayResult? PenetrateRaycast(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
+	{
+		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
+		Godot.Collections.Array<Rid> ignoreRids = [];
+		RayResult? rayResult = null;
+
+		if (ignoreList != null)
+		{
+			ignoreRids = PhysicalsToArray(ignoreList);
+		}
+
+		while (true)
+		{
+			Godot.Collections.Dictionary result = spaceState.IntersectRay(new PhysicsRayQueryParameters3D
+			{
+				From = origin,
+				To = origin + direction.Normalized() * maxDistance,
+				CollideWithAreas = true,
+				CollideWithBodies = true,
+				Exclude = ignoreRids
+			});
+
+			if (result.Count == 0)
+				break;
+
+			Rid colliderRid = (Rid)result["rid"];
+			ignoreRids.Add(colliderRid);
+
+			Node collider = (Node)(GodotObject)result["collider"];
+			Instance? instance = ColliderToInstance(collider);
+			if (instance is Physical p)
+			{
+				Physical.MousePassthroughEnum partPass = (Physical.MousePassthroughEnum)p.MousePassthrough;
+				if ((partPass & passthroughMask) != Physical.MousePassthroughEnum.None) continue;
+			}
+
+			Vector3 hitPos = (Vector3)result["position"];
+			Vector3 normal = (Vector3)result["normal"];
+			rayResult = new()
+			{
+				Origin = origin,
+				Direction = direction.Normalized(),
+				Position = hitPos,
+				Normal = normal,
+				Distance = (origin - hitPos).Length(),
+				Instance = instance,
+			};
+			break;
+		}
+
+		return rayResult;
+	}
+
 	private static Instance? ColliderToInstance(Node collider)
 	{
 		Instance? instance = null;

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -345,7 +345,7 @@ public sealed partial class Environment : Instance
 		return [.. rayResults];
 	}
 
-	public RayResult? PenetrateRaycast(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
+	public RayResult? PenetrateRaycast(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, uint passthrough = 0)
 	{
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
 		Godot.Collections.Array<Rid> ignoreRids = [];
@@ -376,8 +376,7 @@ public sealed partial class Environment : Instance
 			Instance? instance = ColliderToInstance(collider);
 			if (instance is Physical p)
 			{
-				Physical.MousePassthroughEnum partPass = (Physical.MousePassthroughEnum)p.MousePassthrough;
-				if ((partPass & passthroughMask) != Physical.MousePassthroughEnum.None) continue;
+				if ((p.RayPassthrough & passthrough) != 0) continue;
 			}
 
 			Vector3 hitPos = (Vector3)result["position"];
@@ -397,7 +396,7 @@ public sealed partial class Environment : Instance
 		return rayResult;
 	}
 
-	public RayResult[] PenetrateRaycastGather(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
+	public RayResult[] PenetrateRaycastGather(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, uint passthrough = 0)
 	{
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
 		Godot.Collections.Array<Rid> ignoreRids = [];
@@ -441,8 +440,7 @@ public sealed partial class Environment : Instance
 
 			if (instance is Physical p)
 			{
-				Physical.MousePassthroughEnum partPass = (Physical.MousePassthroughEnum)p.MousePassthrough;
-				if ((partPass & passthroughMask) != Physical.MousePassthroughEnum.None) continue;
+				if ((p.RayPassthrough & passthrough) != 0) continue;
 			}
 			break;
 		}

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -391,7 +391,7 @@ public sealed partial class Environment : Instance
 			ignoreRids.Add(colliderRid);
 
 			// possibly janky workaround for CanCollide=true parts being hit twice
-			if (instance == prevInstance) continue;
+			if (instance != null && instance == prevInstance) continue;
 			prevInstance = instance;
 
 			Vector3 hitPos = (Vector3)result["position"];

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -401,6 +401,7 @@ public sealed partial class Environment : Instance
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
 		Godot.Collections.Array<Rid> ignoreRids = [];
 		List<RayResult> rayResults = [];
+		Instance? prevInstance = null;
 
 		if (ignoreList != null)
 		{
@@ -420,11 +421,14 @@ public sealed partial class Environment : Instance
 
 			if (result.Count == 0) break;
 
-
 			Node collider = (Node)(GodotObject)result["collider"];
 			Instance? instance = ColliderToInstance(collider);
 			Rid colliderRid = (Rid)result["rid"];
 			ignoreRids.Add(colliderRid);
+
+			// possibly janky workaround for CanCollide=true parts being hit twice
+			if (instance == prevInstance) continue;
+			prevInstance = instance;
 
 			Vector3 hitPos = (Vector3)result["position"];
 			Vector3 normal = (Vector3)result["normal"];

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -357,6 +357,7 @@ public sealed partial class Environment : Instance
 		return [.. rayResults];
 	}
 
+	[ScriptMethod]
 	public RayResult[] RaycastGather(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, uint passthroughMask = 0)
 	{
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -347,9 +347,32 @@ public sealed partial class Environment : Instance
 
 	public RayResult? PenetrateRaycast(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
 	{
+		RayResult? rayResult = null;
+		Func<RayResult, bool> handler = ray =>
+		{
+			rayResult = ray;
+			return false;
+		};
+		PenetrateRaycastCore(origin, direction, handler, maxDistance, ignoreList, passthroughMask);
+		return rayResult;
+	}
+
+	public RayResult[] PenetrateRaycastAll(Vector3 origin, Vector3 direction, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
+	{
+		List<RayResult> rayResults = [];
+		Func<RayResult, bool> handler = ray =>
+		{
+			rayResults.Add(ray);
+			return true;
+		};
+		PenetrateRaycastCore(origin, direction, handler, maxDistance, ignoreList, passthroughMask);
+		return [.. rayResults];
+	}
+
+	private void PenetrateRaycastCore(Vector3 origin, Vector3 direction, Func<RayResult, bool> handler, float maxDistance = 10000f, Instance[]? ignoreList = null, Physical.MousePassthroughEnum passthroughMask = Physical.MousePassthroughEnum.None)
+	{
 		PhysicsDirectSpaceState3D spaceState = Root.World3D.DirectSpaceState;
 		Godot.Collections.Array<Rid> ignoreRids = [];
-		RayResult? rayResult = null;
 
 		if (ignoreList != null)
 		{
@@ -367,8 +390,7 @@ public sealed partial class Environment : Instance
 				Exclude = ignoreRids
 			});
 
-			if (result.Count == 0)
-				break;
+			if (result.Count == 0) break;
 
 			Rid colliderRid = (Rid)result["rid"];
 			ignoreRids.Add(colliderRid);
@@ -383,7 +405,7 @@ public sealed partial class Environment : Instance
 
 			Vector3 hitPos = (Vector3)result["position"];
 			Vector3 normal = (Vector3)result["normal"];
-			rayResult = new()
+			RayResult rayResult = new()
 			{
 				Origin = origin,
 				Direction = direction.Normalized(),
@@ -392,10 +414,10 @@ public sealed partial class Environment : Instance
 				Distance = (origin - hitPos).Length(),
 				Instance = instance,
 			};
-			break;
-		}
 
-		return rayResult;
+			bool shouldContinue = handler(rayResult);
+			if (!shouldContinue) break;
+		}
 	}
 
 	private static Instance? ColliderToInstance(Node collider)

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -285,7 +285,7 @@ public partial class Grabbable : Instance
 					}
 					else
 					{
-						RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: [Parent], passthroughMask: 1<<2);
+						RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: [Parent], passthroughMask: 1 << 2);
 						if (hit != null)
 						{
 							targetPos = hit.Value.Position;

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -285,7 +285,7 @@ public partial class Grabbable : Instance
 					}
 					else
 					{
-						RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: [Parent]);
+						RayResult? hit = Root.Environment.PenetrateRaycast(rayOrigin, rayDir, ignoreList: [Parent], passthroughMask: Physical.MousePassthroughEnum.Grabbable);
 						if (hit != null)
 						{
 							targetPos = hit.Value.Position;

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -285,7 +285,7 @@ public partial class Grabbable : Instance
 					}
 					else
 					{
-						RayResult? hit = Root.Environment.PenetrateRaycast(rayOrigin, rayDir, ignoreList: [Parent], passthroughMask: Physical.MousePassthroughEnum.Grabbable);
+						RayResult? hit = Root.Environment.PenetrateRaycast(rayOrigin, rayDir, ignoreList: [Parent], passthrough: 1<<2);
 						if (hit != null)
 						{
 							targetPos = hit.Value.Position;

--- a/Polytoria/scripts/datamodel/Grabbable.cs
+++ b/Polytoria/scripts/datamodel/Grabbable.cs
@@ -285,7 +285,7 @@ public partial class Grabbable : Instance
 					}
 					else
 					{
-						RayResult? hit = Root.Environment.PenetrateRaycast(rayOrigin, rayDir, ignoreList: [Parent], passthrough: 1<<2);
+						RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: [Parent], passthroughMask: 1<<2);
 						if (hit != null)
 						{
 							targetPos = hit.Value.Position;

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -328,7 +328,7 @@ public partial class Physical : Dynamic
 	[Editable(CustomPropertyControl = "Bitmap32"), ScriptProperty]
 	public uint RayPassthrough
 	{
-		get => (uint)_rayPassthrough;
+		get => _rayPassthrough;
 		set
 		{
 			_rayPassthrough = value;

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -44,7 +44,7 @@ public partial class Physical : Dynamic
 	private uint _collisionLayers = 1, _collisionMask = 1;
 	private Vector3 _velocity = Vector3.Zero;
 	private Vector3 _angularVelocity = Vector3.Zero;
-	private MousePassthroughEnum _mousePassthrough = MousePassthroughEnum.None;
+	private uint _rayPassthrough = 0;
 
 	private bool _netEnsureTouchArea = false;
 
@@ -326,12 +326,12 @@ public partial class Physical : Dynamic
 	}
 
 	[Editable(CustomPropertyControl = "Bitmap32"), ScriptProperty]
-	public uint MousePassthrough
+	public uint RayPassthrough
 	{
-		get => (uint)_mousePassthrough;
+		get => (uint)_rayPassthrough;
 		set
 		{
-			_mousePassthrough = (MousePassthroughEnum)value;
+			_rayPassthrough = value;
 			OnPropertyChanged();
 		}
 	}
@@ -1273,14 +1273,5 @@ public partial class Physical : Dynamic
 		Acceleration,
 		Impulse,
 		VelocityChange
-	}
-
-	[ScriptEnum("MousePassthrough"), Flags]
-	public enum MousePassthroughEnum : uint
-	{
-		None = 0,
-		Hover = 1,
-		Click = 2,
-		Grabbable = 4,
 	}
 }

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -44,6 +44,7 @@ public partial class Physical : Dynamic
 	private uint _collisionLayers = 1, _collisionMask = 1;
 	private Vector3 _velocity = Vector3.Zero;
 	private Vector3 _angularVelocity = Vector3.Zero;
+	private MousePassthroughEnum _mousePassthrough = MousePassthroughEnum.None;
 
 	private bool _netEnsureTouchArea = false;
 
@@ -320,6 +321,17 @@ public partial class Physical : Dynamic
 		set
 		{
 			_angularVelocity = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable(CustomPropertyControl = "Bitmap32"), ScriptProperty]
+	public uint MousePassthrough
+	{
+		get => (uint)_mousePassthrough;
+		set
+		{
+			_mousePassthrough = (MousePassthroughEnum)value;
 			OnPropertyChanged();
 		}
 	}
@@ -1261,5 +1273,14 @@ public partial class Physical : Dynamic
 		Acceleration,
 		Impulse,
 		VelocityChange
+	}
+
+	[ScriptEnum("MousePassthrough"), Flags]
+	public enum MousePassthroughEnum : uint
+	{
+		None = 0,
+		Hover = 1,
+		Click = 2,
+		Grabbable = 4,
 	}
 }

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -799,7 +799,7 @@ public sealed partial class Player : NPC
 			if (camera != null)
 			{
 				(Vector3 rayOrigin, Vector3 rayDirection) = camera.ProjectFromScreen(Root.Input.MousePosition);
-				Environment.RayResult[] hits = Root.Environment.PenetrateRaycastGather(rayOrigin, rayDirection, passthroughMask: Physical.MousePassthroughEnum.Click);
+				Environment.RayResult[] hits = Root.Environment.PenetrateRaycastGather(rayOrigin, rayDirection, passthrough: 1<<1);
 				foreach (Environment.RayResult result in hits)
 				{
 					if (result.Instance is Physical p)

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -795,10 +795,18 @@ public sealed partial class Player : NPC
 
 		if (@event.IsActionPressed("activate"))
 		{
-			Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition);
-			if (ray.HasValue && ray.Value.Instance is Physical p)
+			Camera? camera = Root.Environment.CurrentCamera;
+			if (camera != null)
 			{
-				p.InvokeClicked(this);
+				(Vector3 rayOrigin, Vector3 rayDirection) = camera.ProjectFromScreen(Root.Input.MousePosition);
+				Environment.RayResult[] hits = Root.Environment.PenetrateRaycastGather(rayOrigin, rayDirection, passthroughMask: Physical.MousePassthroughEnum.Click);
+				foreach (Environment.RayResult result in hits)
+				{
+					if (result.Instance is Physical p)
+					{
+						p.InvokeClicked(this);
+					}
+				}
 			}
 		}
 

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -799,7 +799,7 @@ public sealed partial class Player : NPC
 			if (camera != null)
 			{
 				(Vector3 rayOrigin, Vector3 rayDirection) = camera.ProjectFromScreen(Root.Input.MousePosition);
-				Environment.RayResult[] hits = Root.Environment.PenetrateRaycastGather(rayOrigin, rayDirection, passthrough: 1<<1);
+				Environment.RayResult[] hits = Root.Environment.RaycastGather(rayOrigin, rayDirection, passthroughMask: 1<<1);
 				foreach (Environment.RayResult result in hits)
 				{
 					if (result.Instance is Physical p)

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -677,7 +677,7 @@ public sealed partial class Player : NPC
 			return;
 		}
 
-		Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition, passthroughMask: 1<<0);
+		Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition, passthroughMask: 1 << 0);
 		if (ray.HasValue && ray.Value.Instance is Physical p)
 		{
 			if (_mouseHoveringOn != null && _mouseHoveringOn != p)
@@ -795,7 +795,7 @@ public sealed partial class Player : NPC
 
 		if (@event.IsActionPressed("activate"))
 		{
-			Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition, passthroughMask: 1<<1);
+			Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition, passthroughMask: 1 << 1);
 			if (ray.HasValue && ray.Value.Instance is Physical p)
 			{
 				p.InvokeClicked(this);

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -677,7 +677,7 @@ public sealed partial class Player : NPC
 			return;
 		}
 
-		Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition);
+		Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition, passthroughMask: 1<<0);
 		if (ray.HasValue && ray.Value.Instance is Physical p)
 		{
 			if (_mouseHoveringOn != null && _mouseHoveringOn != p)
@@ -795,18 +795,10 @@ public sealed partial class Player : NPC
 
 		if (@event.IsActionPressed("activate"))
 		{
-			Camera? camera = Root.Environment.CurrentCamera;
-			if (camera != null)
+			Environment.RayResult? ray = Root.Environment.CurrentCamera?.ScreenPointToRay(Root.Input.MousePosition, passthroughMask: 1<<1);
+			if (ray.HasValue && ray.Value.Instance is Physical p)
 			{
-				(Vector3 rayOrigin, Vector3 rayDirection) = camera.ProjectFromScreen(Root.Input.MousePosition);
-				Environment.RayResult[] hits = Root.Environment.RaycastGather(rayOrigin, rayDirection, passthroughMask: 1<<1);
-				foreach (Environment.RayResult result in hits)
-				{
-					if (result.Instance is Physical p)
-					{
-						p.InvokeClicked(this);
-					}
-				}
+				p.InvokeClicked(this);
 			}
 		}
 

--- a/Polytoria/scripts/datamodel/services/InputService.cs
+++ b/Polytoria/scripts/datamodel/services/InputService.cs
@@ -599,7 +599,7 @@ public sealed partial class InputService : Instance
 	}
 
 	[ScriptMethod]
-	public Vector3 GetMouseWorldPosition(Instance[]? ignoreList = null, uint passthroughMask = 1<<0)
+	public Vector3 GetMouseWorldPosition(Instance[]? ignoreList = null, uint passthroughMask = 1 << 0)
 	{
 		Viewport viewport = GDNode.GetViewport();
 		Camera3D camera = viewport.GetCamera3D();

--- a/Polytoria/scripts/datamodel/services/InputService.cs
+++ b/Polytoria/scripts/datamodel/services/InputService.cs
@@ -599,7 +599,7 @@ public sealed partial class InputService : Instance
 	}
 
 	[ScriptMethod]
-	public Vector3 GetMouseWorldPosition(Instance[]? ignoreList = null)
+	public Vector3 GetMouseWorldPosition(Instance[]? ignoreList = null, uint passthroughMask = 1<<0)
 	{
 		Viewport viewport = GDNode.GetViewport();
 		Camera3D camera = viewport.GetCamera3D();
@@ -610,7 +610,7 @@ public sealed partial class InputService : Instance
 		Vector3 rayOrigin = camera.ProjectRayOrigin(mousePos);
 		Vector3 rayDir = camera.ProjectRayNormal(mousePos);
 
-		RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: ignoreList);
+		RayResult? hit = Root.Environment.Raycast(rayOrigin, rayDir, ignoreList: ignoreList, passthroughMask: passthroughMask);
 		return hit != null ? hit.Value.Position : rayOrigin + rayDir * 1000f;
 	}
 


### PR DESCRIPTION
## Summary

This pr adds a bitfield to Physical that allows raycasts with the matching mask through.
This is useful in cases where a transparent or invisible part is used.

The first 3 "layers" in RayPassthrough are assigned special purposes:
- Layer 1 is used for Physical.MouseEnter and Physical.MouseExit signals.
- Layer 2 is used for Physical.Clicked signal.
- Layer 3 is used for Grabbable target positioning.

Finally, in terms of api changes:
- A passthrough mask parameter has been added to:
  - Camera.ViewportPointToRay
  - Camera.ScreenPointToRay
  - Input.GetMouseWorldPosition
  - Environment.Raycast
- Environment.RaycastGather is added, acts like .Raycast but it returns a list of parts that also includes every part that has been passed through.

## Related issue or discussion

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video
Hovering over a part through another part, then clicking a different part, then dragging a Grabbable through.

https://github.com/user-attachments/assets/4c388873-928d-4918-9694-3e42c7345236

## AI/LLM use

None