### PR TITLE
add World:GetFPS() method

### DIFF
--- a/Polytoria/scripts/datamodel/World.cs
+++ b/Polytoria/scripts/datamodel/World.cs
@@ -224,6 +224,12 @@ public sealed partial class World : Instance
 		return await WaitForNetObjectAsync(networkID);
 	}
 
+	[ScriptMethod]
+	public double GetFPS()
+	{
+		return Engine.GetFramesPerSecond();
+	}
+
 	[SyncVar]
 	public bool ServerUnderLoad
 	{


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

`World:GetFPS() -> number`

only made this since `delta` in events like `World.Rendered` or `Hooks.Updated` lowest frequency is ~7 fps (see [here](https://github.com/user-attachments/assets/8b20d2eb-4b94-4a52-b372-b6595aa088ae))
works on both client and server side lo

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [x] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->

none