### PR TITLE
Fix I/O Zoom speed

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -458,11 +458,11 @@ public sealed partial class Camera : Dynamic
 			{
 				if (Input.IsActionPressed("zoom_in"))
 				{
-					_targetZoom -= ScrollSensitivity / 5;
+					_targetZoom -= ScrollSensitivity / 0.4f*(float)delta;
 				}
 				if (Input.IsActionPressed("zoom_out"))
 				{
-					_targetZoom += ScrollSensitivity / 5;
+					_targetZoom += ScrollSensitivity / 0.4f*(float)delta;
 				}
 
 				// Handle Controller Right stick input

--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -458,11 +458,11 @@ public sealed partial class Camera : Dynamic
 			{
 				if (Input.IsActionPressed("zoom_in"))
 				{
-					_targetZoom -= ScrollSensitivity / 0.4f*(float)delta;
+					_targetZoom -= ScrollSensitivity / 0.4f * (float)delta;
 				}
 				if (Input.IsActionPressed("zoom_out"))
 				{
-					_targetZoom += ScrollSensitivity / 0.4f*(float)delta;
+					_targetZoom += ScrollSensitivity / 0.4f * (float)delta;
 				}
 
 				// Handle Controller Right stick input


### PR DESCRIPTION
## Summary

previously having lower frames made zooming slower via the I and O Buttons and faster when frames are higher

## Related issue or discussion

Fixes #1160 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->



<!-- Describe AI use, or write "None" if not applicable -->

None