### PR TITLE
Relax Sound minimum pitch limit

### DIFF
--- a/Polytoria/scripts/datamodel/Sound.cs
+++ b/Polytoria/scripts/datamodel/Sound.cs
@@ -20,7 +20,7 @@ namespace Polytoria.Datamodel;
 public sealed partial class Sound : Dynamic
 {
 	public const float SoundDistanceMultipler = 1.25f;
-	private const float MinPitch = 0.001f;
+	private const float MinPitch = 1.17549435E-38f; // smallest float above denormals
 	private const float MaxVolume = 2f;
 	private AudioStreamPlayer? _audioPlayer;
 	private AudioStreamPlayer3D? _audioPlayer3D;


### PR DESCRIPTION
You can now freeze Sound playback in place for stuff like phase control and DC correction.

## Summary

I changed the minimum pitch to smallest possible float value that is not a denormal(best avoided in running maths).
Nothing has exploded, so I am happy with the change.

## Related issue or discussion

Fixes #
Related to #

## Type of change

- [ ] Bug fix
- [ x ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ x ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [ x ] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ x ] Added in-code documentation (where needed)
- [ x ] Ran `dotnet restore`
- [ x ] Ran `dotnet format`
- [ x ] Ran `dotnet build`
- [ x ] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [ x ] Tested the changes in a local environment
- [ x ] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

None

## AI/LLM use

None.