### PR TITLE
shrinkwrap bounding boxes a bit

### DIFF
--- a/Polytoria/scripts/creator/spatial/gizmos/SelectionBox.cs
+++ b/Polytoria/scripts/creator/spatial/gizmos/SelectionBox.cs
@@ -23,11 +23,19 @@ public partial class SelectionBox : Node
 			if (_target != value)
 			{
 				_target?.TransformChanged -= UpdateBox;
+				if (_target is Part p)
+				{
+					p.ShapeChanged -= UpdateBox;
+				}
 				_target = value;
-				// When the target changes drop the cache so the new target recalculates it's bounds.
+				// When the target changes drop the cache so the new target recalculates its bounds.
 				InvalidateBoundCache();
 				UpdateBox();
 				_target?.TransformChanged += UpdateBox;
+				if (_target is Part p2)
+				{
+					p2.ShapeChanged += UpdateBox;
+				}
 			}
 		}
 	}

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -1007,30 +1007,7 @@ public partial class Dynamic : Instance
 		{
 			if (item is Part part)
 			{
-				Transform3D t = part.GetGlobalTransform();
-
-				Vector3 localSize = part.Size;
-				Vector3 he = localSize / 2f;
-
-				Vector3 basisScale = t.Basis.Scale;
-
-				// get pure rotation matrix
-				Basis rot = t.Basis;
-				rot.X /= basisScale.X;
-				rot.Y /= basisScale.Y;
-				rot.Z /= basisScale.Z;
-
-				// some dark magic
-				Vector3 worldExtents = new(
-					Mathf.Abs(rot.X.X) * he.X + Mathf.Abs(rot.Y.X) * he.Y + Mathf.Abs(rot.Z.X) * he.Z,
-					Mathf.Abs(rot.X.Y) * he.X + Mathf.Abs(rot.Y.Y) * he.Y + Mathf.Abs(rot.Z.Y) * he.Z,
-					Mathf.Abs(rot.X.Z) * he.X + Mathf.Abs(rot.Y.Z) * he.Y + Mathf.Abs(rot.Z.Z) * he.Z
-				);
-
-				Vector3 center = t.Origin;
-
-				Aabb pBounds = new(center - worldExtents, worldExtents * 2);
-
+				Aabb pBounds = part.GetSelfBound();
 
 				if (bounds == null)
 				{

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -284,6 +284,7 @@ public sealed partial class Environment : Instance
 			Vector3 hitPos = (Vector3)result["position"];
 			Vector3 normal = (Vector3)result["normal"];
 			Node collider = (Node)(GodotObject)result["collider"];
+			int shapeIndex = (int)result["shape"];
 
 			return new()
 			{
@@ -292,7 +293,7 @@ public sealed partial class Environment : Instance
 				Position = hitPos,
 				Normal = normal,
 				Distance = (origin - hitPos).Length(),
-				Instance = ColliderToInstance(collider)
+				Instance = ColliderToInstance(collider, shapeIndex)
 			};
 		}
 
@@ -330,6 +331,7 @@ public sealed partial class Environment : Instance
 			Rid colliderRid = (Rid)result["rid"];
 			ignoreRids.Add(colliderRid);
 			Node collider = (Node)(GodotObject)result["collider"];
+			int shapeIndex = (int)result["shape"];
 
 			rayResults.Add(new()
 			{
@@ -338,14 +340,14 @@ public sealed partial class Environment : Instance
 				Position = hitPos,
 				Normal = normal,
 				Distance = (origin - hitPos).Length(),
-				Instance = ColliderToInstance(collider)
+				Instance = ColliderToInstance(collider, shapeIndex)
 			});
 		}
 
 		return [.. rayResults];
 	}
 
-	private static Instance? ColliderToInstance(Node collider)
+	private static Instance? ColliderToInstance(Node collider, int shapeIndex)
 	{
 		Instance? instance = null;
 
@@ -415,7 +417,8 @@ public sealed partial class Environment : Instance
 		foreach (Godot.Collections.Dictionary result in results)
 		{
 			Node collider = (Node)(GodotObject)result["collider"];
-			Instance? i = ColliderToInstance(collider);
+			int shapeIndex = (int)result["shape"];
+			Instance? i = ColliderToInstance(collider, shapeIndex);
 
 			if (i != null)
 			{

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -5,6 +5,7 @@
 using Godot;
 using Polytoria.Attributes;
 using Polytoria.Shared;
+using System;
 
 namespace Polytoria.Datamodel;
 
@@ -23,6 +24,7 @@ public partial class Part : Entity
 	private Node3D _nRemoteAt = null!; // Remote collider proxy
 
 	internal Shape3D ColliderShape => _collider.Shape;
+	public event Action? ShapeChanged;
 
 	public bool IsMeshSeparated => _isSeparateMesh;
 	public int BridgeID = -1;
@@ -138,6 +140,7 @@ public partial class Part : Entity
 
 			_shape = value;
 
+			ShapeChanged?.Invoke();
 			UpdateShape();
 			OnPropertyChanged();
 		}
@@ -208,12 +211,8 @@ public partial class Part : Entity
 		if (_isSeparateMesh)
 		{
 			_mesh?.Mesh = mesh;
-			_collider.Shape = shape;
 		}
-		else
-		{
-			_collider.Shape = shape;
-		}
+		_collider.Shape = shape;
 		PostCollisionShapeUpdate(_collider);
 	}
 
@@ -255,6 +254,18 @@ public partial class Part : Entity
 		}
 	}
 
+	private Aabb PointsToBound(Vector3[] points, Basis transform)
+	{
+		Aabb bound = new(Vector3.Zero, Vector3.Zero);
+
+		foreach (Vector3 point in points)
+		{
+			bound = bound.Expand(transform * point);
+		}
+
+		return bound;
+	}
+
 	public override Aabb GetSelfBound()
 	{
 		Transform3D t = GetGlobalTransform();
@@ -262,24 +273,73 @@ public partial class Part : Entity
 		Vector3 localSize = Size;
 		Vector3 he = localSize / 2f;
 
-		Vector3 basisScale = t.Basis.Scale;
-
 		// get pure rotation matrix
-		Basis rot = t.Basis;
-		rot.X /= basisScale.X;
-		rot.Y /= basisScale.Y;
-		rot.Z /= basisScale.Z;
-
-		// some dark magic
-		Vector3 worldExtents = new(
-			Mathf.Abs(rot.X.X) * he.X + Mathf.Abs(rot.Y.X) * he.Y + Mathf.Abs(rot.Z.X) * he.Z,
-			Mathf.Abs(rot.X.Y) * he.X + Mathf.Abs(rot.Y.Y) * he.Y + Mathf.Abs(rot.Z.Y) * he.Z,
-			Mathf.Abs(rot.X.Z) * he.X + Mathf.Abs(rot.Y.Z) * he.Y + Mathf.Abs(rot.Z.Z) * he.Z
-		);
+		Basis rot = t.Basis.Orthonormalized();
 
 		Vector3 center = t.Origin;
 
-		return new(center - worldExtents, worldExtents * 2);
+		Aabb bound;
+		switch (Shape)
+		{
+			case ShapeEnum.Wedge:
+				bound = PointsToBound([
+					new( 1,-1, 1 ),
+					new(-1, 1, 1 ),
+					new(-1,-1, 1 ),
+					new( 1,-1,-1 ),
+					new(-1, 1,-1 ),
+					new(-1,-1,-1 ),
+				], rot.ScaledLocal(he));
+				bound.Position += center;
+				return bound;
+			case ShapeEnum.Corner:
+				bound = PointsToBound([
+					new( 1,-1, 1 ),
+					new(-1,-1, 1 ),
+					new( 1,-1,-1 ),
+					new(-1,-1,-1 ),
+					new(-1, 1,-1 ),
+				], rot.ScaledLocal(he));
+				bound.Position += center;
+				return bound;
+			case ShapeEnum.Concave:
+				bound = PointsToBound([
+					new( 1,-1,-1 ),
+					new( 1, 1, 1 ),
+					new( 1,-1, 1 ),
+					new(-1,-1,-1 ),
+					new(-1, 1, 1 ),
+					new(-1,-1, 1 ),
+				], rot.ScaledLocal(he));
+				bound.Position += center;
+				return bound;
+			case ShapeEnum.ConcaveCorner:
+				bound = PointsToBound([
+					new( 1,-1,-1 ),
+					new( 1,-1, 1 ),
+					new(-1,-1,-1 ),
+					new(-1, 1, 1 ),
+					new(-1,-1, 1 ),
+				], rot.ScaledLocal(he));
+				bound.Position += center;
+				return bound;
+			case ShapeEnum.TriangleCorner:
+			case ShapeEnum.TriangleConcaveCorner:
+				bound = PointsToBound([
+					new( 1,-1, 1 ),
+					new(-1,-1,-1 ),
+					new(-1, 1, 1 ),
+					new(-1,-1, 1 ),
+				], rot.ScaledLocal(he));
+				bound.Position += center;
+				return bound;
+			case ShapeEnum.Brick:
+			case ShapeEnum.Truss:
+			case ShapeEnum.Frame:
+			default: // Sphere Cylinder Cone Bevel Octant Torus BeveledCorner are currently unimplemented
+				Vector3 worldExtents = rot.X.Abs() * he.X + rot.Y.Abs() * he.Y + rot.Z.Abs() * he.Z;
+				return new(center - worldExtents, worldExtents * 2);
+		}
 	}
 
 	[ScriptEnum("PartShape")]

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -106,6 +106,7 @@ public partial class Part : Entity
 	internal override void OnNodeSizeChanged(Vector3 newSize)
 	{
 		UpdateMeshSize();
+		ShapeChanged?.Invoke();
 		base.OnNodeSizeChanged(newSize);
 	}
 

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -24,6 +24,7 @@ public partial class Physical : Dynamic
 	private static readonly Dictionary<Node, Physical> _proxyToPhysical = [];
 	private static readonly ConditionalWeakTable<CollisionShape3D, RemoteLinkConfig> _remoteLinkConfigs = [];
 	private static readonly ConditionalWeakTable<CollisionShape3D, TrackedNodesState> _trackedNodes = [];
+	internal readonly Dictionary<int, Physical> _rootShapeIndexToPhysical = [];
 
 	private sealed class RemoteLinkConfig
 	{


### PR DESCRIPTION
## Summary

makes bounding boxes in creator shrink to fit parts that aren't bricks, where simple (not bevels)

also updates them when resizing

## Related issue or discussion

none apparently

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="219" height="155" alt="image" src="https://github.com/user-attachments/assets/7c44ff38-ec66-494d-9d14-6a31979a3471" />

## AI/LLM use
none