### PR TITLE
added Playerlist Pfp Icons and Badges moved behind Username. Context Menu added Red "Report User" Button and Icons

### DIFF
--- a/Polytoria/scenes/client/ui/playerlist/leaderboard_user_item.tscn
+++ b/Polytoria/scenes/client/ui/playerlist/leaderboard_user_item.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://dnev3eaahxpav" path="res://scripts/client/ui/playerlist/UILeaderboardUserItem.cs" id="1_dghsi"]
 
-[node name="UserItem" type="Button" unique_id=1315937502 node_paths=PackedStringArray("_usernameLabel", "_statsBox", "_badgeRect")]
+[node name="UserItem" type="Button" unique_id=1315937502 node_paths=PackedStringArray("_iconRect", "_usernameLabel", "_statsBox", "_badgeRect")]
 custom_minimum_size = Vector2(0, 20)
 anchors_preset = 10
 anchor_right = 1.0
@@ -11,6 +11,7 @@ grow_horizontal = 2
 mouse_default_cursor_shape = 2
 flat = true
 script = ExtResource("1_dghsi")
+_iconRect = NodePath("Item/PlayerInfo/Icon")
 _usernameLabel = NodePath("Item/PlayerInfo/Username")
 _statsBox = NodePath("Item/Stats")
 _badgeRect = NodePath("Item/PlayerInfo/Badge")
@@ -29,22 +30,31 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 0
 
-[node name="Badge" type="TextureRect" parent="Item/PlayerInfo" unique_id=1331594007]
-custom_minimum_size = Vector2(16, 0)
+[node name="Icon" type="TextureRect" parent="Item/PlayerInfo" unique_id=2006527676]
+custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
 expand_mode = 1
 stretch_mode = 5
 
-[node name="Spacer" type="Control" parent="Item/PlayerInfo" unique_id=1343074699]
+[node name="Spacer2" type="Control" parent="Item/PlayerInfo" unique_id=1343074699]
 custom_minimum_size = Vector2(3, 0)
 layout_mode = 2
 
 [node name="Username" type="Label" parent="Item/PlayerInfo" unique_id=693001233]
 layout_mode = 2
-size_flags_horizontal = 3
+size_flags_horizontal = 0
 theme_override_font_sizes/font_size = 13
 text = "Username"
-text_overrun_behavior = 5
+
+[node name="Spacer" type="Control" parent="Item/PlayerInfo" unique_id=16462861]
+custom_minimum_size = Vector2(3, 0)
+layout_mode = 2
+
+[node name="Badge" type="TextureRect" parent="Item/PlayerInfo" unique_id=1331594007]
+custom_minimum_size = Vector2(16, 0)
+layout_mode = 2
+expand_mode = 1
+stretch_mode = 5
 
 [node name="Spacer" type="Control" parent="Item" unique_id=366019082]
 custom_minimum_size = Vector2(8, 0)

--- a/Polytoria/scenes/client/ui/playerlist/leaderboard_user_item.tscn
+++ b/Polytoria/scenes/client/ui/playerlist/leaderboard_user_item.tscn
@@ -1,6 +1,7 @@
 [gd_scene format=3 uid="uid://dobfkys8wf0uc"]
 
 [ext_resource type="Script" uid="uid://dnev3eaahxpav" path="res://scripts/client/ui/playerlist/UILeaderboardUserItem.cs" id="1_dghsi"]
+[ext_resource type="StyleBox" uid="uid://bwksp3bsrvcf6" path="res://resources/styles/card_rounded.tres" id="2_fs1my"]
 
 [node name="UserItem" type="Button" unique_id=1315937502 node_paths=PackedStringArray("_iconRect", "_usernameLabel", "_statsBox", "_badgeRect")]
 custom_minimum_size = Vector2(0, 20)
@@ -11,7 +12,7 @@ grow_horizontal = 2
 mouse_default_cursor_shape = 2
 flat = true
 script = ExtResource("1_dghsi")
-_iconRect = NodePath("Item/PlayerInfo/Icon")
+_iconRect = NodePath("Item/PlayerInfo/Clip/Icon")
 _usernameLabel = NodePath("Item/PlayerInfo/Username")
 _statsBox = NodePath("Item/Stats")
 _badgeRect = NodePath("Item/PlayerInfo/Badge")
@@ -30,11 +31,22 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 0
 
-[node name="Icon" type="TextureRect" parent="Item/PlayerInfo" unique_id=2006527676]
+[node name="Clip" type="Panel" parent="Item/PlayerInfo" unique_id=455449318]
+clip_children = 1
 custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
+theme_override_styles/panel = ExtResource("2_fs1my")
+
+[node name="Icon" type="TextureRect" parent="Item/PlayerInfo/Clip" unique_id=1075661095]
+custom_minimum_size = Vector2(20, 0)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 expand_mode = 1
-stretch_mode = 5
+stretch_mode = 6
 
 [node name="Spacer2" type="Control" parent="Item/PlayerInfo" unique_id=1343074699]
 custom_minimum_size = Vector2(3, 0)

--- a/Polytoria/scenes/client/ui/playerlist/user_card.tscn
+++ b/Polytoria/scenes/client/ui/playerlist/user_card.tscn
@@ -54,20 +54,19 @@ stretch_mode = 6
 custom_minimum_size = Vector2(8, 0)
 layout_mode = 2
 
-[node name="Badge" type="TextureRect" parent="Layout" unique_id=856622248]
-custom_minimum_size = Vector2(16, 0)
+[node name="Username" type="Label" parent="Layout" unique_id=627039506]
 layout_mode = 2
-expand_mode = 1
-stretch_mode = 5
+text = "Username"
 
 [node name="Spacer3" type="Control" parent="Layout" unique_id=1829698442]
 custom_minimum_size = Vector2(4, 0)
 layout_mode = 2
 
-[node name="Username" type="Label" parent="Layout" unique_id=627039506]
+[node name="Badge" type="TextureRect" parent="Layout" unique_id=856622248]
+custom_minimum_size = Vector2(16, 0)
 layout_mode = 2
-size_flags_horizontal = 3
-text = "Username"
+expand_mode = 1
+stretch_mode = 5
 
 [node name="Spacer2" type="Control" parent="Layout" unique_id=1845676044]
 custom_minimum_size = Vector2(15, 0)

--- a/Polytoria/scenes/client/ui/playerlist/user_options.tscn
+++ b/Polytoria/scenes/client/ui/playerlist/user_options.tscn
@@ -2,6 +2,8 @@
 
 [ext_resource type="Script" uid="uid://3bvn0pq3nupi" path="res://scripts/client/ui/playerlist/UILeaderboardUserOptions.cs" id="1_31oub"]
 [ext_resource type="PackedScene" uid="uid://dbaked5s53qqn" path="res://scenes/shared/loader.tscn" id="2_48ua2"]
+[ext_resource type="Texture2D" uid="uid://cktwlpkglqh01" path="res://assets/textures/ui-icons/external-link.svg" id="2_cvoej"]
+[ext_resource type="Texture2D" uid="uid://b723rf2mv3taw" path="res://assets/textures/ui-icons/flag.svg" id="3_1ps21"]
 [ext_resource type="Texture2D" uid="uid://dyef4qa4syg37" path="res://assets/textures/client/ui/chat/bubble_arrow.svg" id="3_3wcmt"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4fqi5"]
@@ -135,7 +137,7 @@ _data = {
 &"disappear": SubResource("Animation_31oub")
 }
 
-[node name="UserOptions" type="Control" unique_id=1089935845 node_paths=PackedStringArray("_animPlay", "_optionsLayout", "_addFriendBtn", "_removeFriendBtn", "_viewProfileBtn", "_loaderView")]
+[node name="UserOptions" type="Control" unique_id=1089935845 node_paths=PackedStringArray("_animPlay", "_optionsLayout", "_addFriendBtn", "_removeFriendBtn", "_viewProfileBtn", "_reportUserBtn", "_loaderView")]
 layout_mode = 3
 anchors_preset = 1
 anchor_left = 1.0
@@ -151,6 +153,7 @@ _optionsLayout = NodePath("Pivot/PanelContainer/Layout")
 _addFriendBtn = NodePath("Pivot/PanelContainer/Layout/AddFriend")
 _removeFriendBtn = NodePath("Pivot/PanelContainer/Layout/RemoveFriend")
 _viewProfileBtn = NodePath("Pivot/PanelContainer/Layout/ViewProfile")
+_reportUserBtn = NodePath("Pivot/PanelContainer/Layout/ReportUser")
 _loaderView = NodePath("Pivot/PanelContainer/LoaderView")
 
 [node name="Pivot" type="Control" parent="." unique_id=923873893]
@@ -175,6 +178,7 @@ theme_override_constants/separation = 0
 [node name="AddFriend" type="Button" parent="Pivot/PanelContainer/Layout" unique_id=29708534]
 visible = false
 layout_mode = 2
+offset_transform_position = Vector2(-8, 0)
 mouse_default_cursor_shape = 2
 theme_override_styles/normal = SubResource("StyleBoxEmpty_4fqi5")
 text = "Add Friend"
@@ -183,7 +187,9 @@ alignment = 0
 
 [node name="RemoveFriend" type="Button" parent="Pivot/PanelContainer/Layout" unique_id=270774084]
 visible = false
+self_modulate = Color(0.8666667, 0.33333334, 0.33333334, 1)
 layout_mode = 2
+offset_transform_position = Vector2(-8, 0)
 mouse_default_cursor_shape = 2
 theme_override_styles/normal = SubResource("StyleBoxEmpty_4fqi5")
 text = "Remove Friend"
@@ -192,9 +198,24 @@ alignment = 0
 
 [node name="ViewProfile" type="Button" parent="Pivot/PanelContainer/Layout" unique_id=124750535]
 layout_mode = 2
+offset_transform_enabled = true
+offset_transform_position = Vector2(-4, 0)
 mouse_default_cursor_shape = 2
 theme_override_styles/normal = SubResource("StyleBoxEmpty_4fqi5")
 text = "View Profile"
+icon = ExtResource("2_cvoej")
+flat = true
+alignment = 0
+
+[node name="ReportUser" type="Button" parent="Pivot/PanelContainer/Layout" unique_id=1771117854]
+self_modulate = Color(0.8666667, 0.33333334, 0.33333334, 1)
+layout_mode = 2
+offset_transform_enabled = true
+offset_transform_position = Vector2(-4, 0)
+mouse_default_cursor_shape = 2
+theme_override_styles/normal = SubResource("StyleBoxEmpty_4fqi5")
+text = "Report User"
+icon = ExtResource("3_1ps21")
 flat = true
 alignment = 0
 

--- a/Polytoria/scripts/client/ui/playerlist/UILeaderboardUserItem.cs
+++ b/Polytoria/scripts/client/ui/playerlist/UILeaderboardUserItem.cs
@@ -6,6 +6,7 @@ using Godot;
 using Polytoria.Datamodel;
 using Polytoria.Schemas.API;
 using System.Collections.Generic;
+using Polytoria.Datamodel.Resources;
 
 namespace Polytoria.Client.UI.Playerlist;
 
@@ -13,16 +14,24 @@ public partial class UILeaderboardUserItem : Button
 {
 	private readonly Dictionary<Stat, Label> _statToLabel = [];
 
+	[Export] private TextureRect _iconRect = null!;
 	[Export] private Label _usernameLabel = null!;
 	[Export] private Control _statsBox = null!;
 	[Export] private TextureRect _badgeRect = null!;
 
 	public Player TargetPlayer = null!;
 	public UILeaderboard Leaderboard = null!;
+	
+	private readonly PTImageAsset _plrIconAsset = new();
 
 	public override void _Ready()
 	{
 		_usernameLabel.Text = TargetPlayer.Name;
+		
+		_plrIconAsset.ResourceLoaded += OnAvatarLoaded;
+		_plrIconAsset.ImageType = ImageTypeEnum.UserAvatarHeadshot;
+		_plrIconAsset.ImageID = (uint)TargetPlayer.UserID;
+		_plrIconAsset.LoadResource();
 
 		if (TargetPlayer.UserInfo.HasValue)
 		{
@@ -36,6 +45,13 @@ public partial class UILeaderboardUserItem : Button
 		TargetPlayer.StatChanged.Connect(OnStatChanged);
 
 		UpdateBadge();
+	}
+	
+	private void OnAvatarLoaded(Resource resource)
+	{
+		if (resource is Texture2D texture){
+			_iconRect.Texture = texture;
+		}
 	}
 
 	private void OnStatChanged(Stat s, object? _)

--- a/Polytoria/scripts/client/ui/playerlist/UILeaderboardUserOptions.cs
+++ b/Polytoria/scripts/client/ui/playerlist/UILeaderboardUserOptions.cs
@@ -14,6 +14,7 @@ public partial class UILeaderboardUserOptions : Control
 	[Export] private Button _addFriendBtn = null!;
 	[Export] private Button _removeFriendBtn = null!;
 	[Export] private Button _viewProfileBtn = null!;
+	[Export] private Button _reportUserBtn = null!;
 	[Export] private Control _loaderView = null!;
 	public bool Active { get; private set; } = false;
 	public UILeaderboardUserItem? Target;
@@ -24,6 +25,7 @@ public partial class UILeaderboardUserOptions : Control
 	{
 		Visible = false;
 		_viewProfileBtn.Pressed += OnViewProfile;
+		_reportUserBtn.Pressed += OnReportUser;
 		_addFriendBtn.Pressed += OnAddFriend;
 		_removeFriendBtn.Pressed += OnRemoveFriend;
 		base._Ready();
@@ -50,6 +52,13 @@ public partial class UILeaderboardUserOptions : Control
 		// Open profile on Polytoria
 		OS.ShellOpen($"https://polytoria.com/u/{Target.TargetPlayer.Name}");
 
+		Disappear();
+	}
+	
+	private void OnReportUser()
+	{
+		if (Target == null) return;
+		OS.ShellOpen("https://polytoria.com/report/user/" + Target.TargetPlayer.UserID);
 		Disappear();
 	}
 


### PR DESCRIPTION
added Playerlist Pfp Icons and Badges moved behind Username. Context Menu added Red "Report User" Button and Icons

I've tested it and works not a single fail ever.

Moved Player Badge from left to right of Username which username resizes itself with the same spacers on both sides where i also added the Pfp Icon Rect on the left Which uses the same pfp function as the user card does. report button is also the same as the Menu Players page. which has a red flag for report so i did the same with context ` 🚩 Report User ` in all Red. ` ↗️ View Profile ` the same but with external-link svg used. and both has -4 X Offset transform to look clean still without the left looking so spacious. i may of also only modified colour of "Remove Friend" context to red too and I'll be adding it in later too.

Examples
<img width="462" height="224" alt="Screenshot 2026-09-02 180035" src="https://github.com/user-attachments/assets/af162c75-543e-42ff-a5ed-2a8a4e48a935" />
<img width="446" height="406" alt="Screenshot 2026-09-02 180125" src="https://github.com/user-attachments/assets/1e996098-9aff-4c6e-b4a5-0ff2629e0819" />

<img width="643" height="632" alt="image" src="https://github.com/user-attachments/assets/9a91e2a8-3b3a-4503-9289-d74ec3a37f9d" />
<img width="400" height="447" alt="Screenshot 2026-09-02 105954" src="https://github.com/user-attachments/assets/6f462f2f-5ccf-4e3a-890f-086586487928" />
Some Pfps not loading is a Polytoria backend issue with CloudFlare CDN. not related to the code here.