### PR TITLE
Dynamic Thumbnail and MaxPlayers count in PresenceService(Discord RPC)

### DIFF
--- a/Polytoria/scripts/datamodel/services/PresenceService.cs
+++ b/Polytoria/scripts/datamodel/services/PresenceService.cs
@@ -184,7 +184,7 @@ public sealed partial class PresenceService : Instance
 			details = "Testing a game";
 		}
 
-		string defaultImg = "multiplayer";
+		string defaultImg = Root.WorldInfo?.Thumbnail ?? "multiplayer";
 		string defaultSmallImg = "poly-sm";
 		string defaultSmallText = "Polytoria";
 
@@ -218,7 +218,7 @@ public sealed partial class PresenceService : Instance
 				Size =
 				{
 					CurrentSize = Root.Players.PlayersCount,
-					MaxSize = 20,
+					MaxSize = Root.WorldInfo?.MaxPlayers ?? 8,
 				},
 			},
 			Instance = true


### PR DESCRIPTION
Reopened because GitHub closed it due to branch changes. I think I understand it now kinda.

so the changes..
before the Discord RPC would always say `{PlayersCount}/20` which the 20 is static. i've fixed that by using Root.WorldInfo. which is already used for like `details` and `largeText`.
so for `defaultImg` it uses either `Root.WorldInfo.` or fallsback to "multiplayer".
and for the Players count `CurrentSize` / `MaxSize` it also uses the `Root.WorldInfo.` for `MaxPlayers` count and also fallsback to 8 which is Polytoria's default when making a game.