### PR TITLE
allow other up vectors for NPC/Player

### DIFF
--- a/Polytoria/scripts/datamodel/Camera.cs
+++ b/Polytoria/scripts/datamodel/Camera.cs
@@ -37,7 +37,7 @@ public sealed partial class Camera : Dynamic
 	private float _scrollLerpSpeed;
 	private float _orthographicSize;
 	private Vector3 _positionOffset;
-	private Vector3 _rotationOffset;
+	private Quaternion _rotationOffset;
 	private bool _isFirstPerson;
 	private float _sensitivityMultipler = 1f;
 	private bool _canLock = true;
@@ -230,12 +230,23 @@ public sealed partial class Camera : Dynamic
 	}
 
 	[Editable, ScriptProperty]
-	public Vector3 RotationOffset
+	public Quaternion QuaternionOffset
 	{
 		get => _rotationOffset;
 		set
 		{
 			_rotationOffset = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public Vector3 RotationOffset
+	{
+		get => MathUtils.Vector3RadToDeg(_rotationOffset.GetEuler());
+		set
+		{
+			_rotationOffset = Quaternion.FromEuler(MathUtils.Vector3DegToRad(value));
 			OnPropertyChanged();
 		}
 	}
@@ -474,10 +485,10 @@ public sealed partial class Camera : Dynamic
 			}
 
 			Vector3 computedPosition = Target.Position + PositionOffset;
-			Vector3 computedRotation = _targetRotation + RotationOffset;
+			Quaternion computedRotation = QuaternionOffset * Quaternion.FromEuler(MathUtils.Vector3DegToRad(_targetRotation));
 
 			_turnX.GlobalPosition = computedPosition;
-			_turnX.RotationDegrees = computedRotation;
+			_turnX.Quaternion = computedRotation;
 
 			LimitZoomDistance();
 

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -29,6 +29,7 @@ public partial class NPC : Physical
 	public const float ForwardRaycastRange = 1;
 	public const float StairForwardRaycastRange = 4;
 	public const float NameTagHeightMinus = 3f;
+	private Vector3 _vertical = Vector3.Up;
 	private Vector3 _seatOffset = new(0, 1.7f, 0);
 	private float _health = 100;
 	private RemoteTransform3D? _toolRemoteTransform;
@@ -388,6 +389,18 @@ public partial class NPC : Physical
 		internal set => _character = value;
 	}
 
+	[Editable, ScriptProperty, SyncVar]
+	public Vector3 Vertical
+	{
+		get => _vertical;
+		set
+		{
+			_vertical = value;
+			CharBody3D.UpDirection = value;
+			OnPropertyChanged();
+		}
+	}
+
 	[SyncVar, ScriptProperty]
 	public Dynamic? MoveTarget
 	{
@@ -585,6 +598,11 @@ public partial class NPC : Physical
 		_nametag.Position = NametagOffset + _fixedNametagOffset;
 	}
 
+	private static Vector3 SetAxisOf(Vector3 v, Vector3 axis, float value)
+	{
+		return v.Slide(axis) + value * axis;
+	}
+
 	public override void PhysicsProcess(double delta)
 	{
 		base.PhysicsProcess(delta);
@@ -608,13 +626,13 @@ public partial class NPC : Physical
 			{
 				Velocity = Vector3.Zero;
 				Position = SittingIn.Position + SeatOffset.Y * Up;
-				if (!SittingIn.SitDirectionLocked)
+				if (SittingIn.SitDirectionLocked)
 				{
-					Rotation = new Vector3(SittingIn.Rotation.X, Rotation.Y, SittingIn.Rotation.Z);
+					Quaternion = SittingIn.Quaternion;
 				}
 				else
 				{
-					Rotation = SittingIn.Rotation;
+					Quaternion = new Quaternion(Up, SittingIn.Up) * Quaternion;
 				}
 				Character?.PlayIdle();
 			}
@@ -664,15 +682,22 @@ public partial class NPC : Physical
 			{
 				walkTarget = _navAgent.GetNextPathPosition();
 
-				// Adjust Nav agent position in-case of unstable Y position changes
-				_navAgentContainer?.GlobalPosition = _navAgentContainer.GlobalPosition with { Y = walkTarget.Value.Y };
+				// Adjust Nav agent position in-case of unstable vertical changes
+				_navAgentContainer?.GlobalPosition = _navAgentContainer.GlobalPosition.Slide(Vertical) + walkTarget.Value.Project(Vertical);
 			}
 
 			if (walkTarget.HasValue)
 			{
-				Vector3 velo = GetGlobalPosition().DirectionTo(walkTarget.Value with { Y = Position.Y });
-				CharacterVelocity = new(velo.X * WalkSpeed, CharacterVelocity.Y, velo.Z * WalkSpeed);
-				GDNode3D.GlobalRotationDegrees = new Vector3(Rotation.X, Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Rotation.Y), Mathf.Atan2(CharacterVelocity.X, CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, BodyRotateLerp))), Rotation.Z);
+				Vector3 dir = (walkTarget.Value - GetGlobalPosition()).Slide(Vertical).Normalized();
+				CharacterVelocity = (dir * WalkSpeed).Slide(Vertical) + CharacterVelocity.Project(Vertical);
+				// Apply rotation by move direction
+				Vector3 a = new Quaternion(Up, Vertical) * Forward;
+				float angle = Mathf.Asin(a.Cross(dir).Dot(vertical));
+				if (a.Dot(dir) < 0) angle = Mathf.Pi - angle;
+				if (angle > Mathf.Pi) angle -= Mathf.Tau;
+				Quaternion = new Quaternion(vertical, angle * MathUtils.ExpDecay((float)delta, BodyRotateLerp)) * Quaternion;
+
+				Quaternion = (new Quaternion(new Quaternion(Up, Vertical) * Forward, dir).Log() * MathUtils.ExpDecay((float)delta, BodyRotateLerp)).Exp() * Quaternion;
 
 				float distanceToTarget = GetGlobalPosition().DistanceTo(walkTarget.Value);
 
@@ -685,7 +710,7 @@ public partial class NPC : Physical
 			}
 			else if (this is not Player || playerNPCOverride)
 			{
-				CharacterVelocity = new(0, CharacterVelocity.Y, 0);
+				CharacterVelocity = CharacterVelocity.Project(Vertical);
 			}
 
 			if (!isOnFloor)
@@ -702,18 +727,18 @@ public partial class NPC : Physical
 			// Apply gravity
 			if (!isOnFloor)
 			{
-				CharacterVelocity.Y += Root.Environment.Gravity.Y * (float)delta;
+				CharacterVelocity += Vertical * (Root.Environment.Gravity.Dot(Vertical) * (float)delta);
 			}
-			else if (isOnFloor && CharacterVelocity.Y < 0)
+			else if (isOnFloor && CharacterVelocity.Dot(Vertical) < 0)
 			{
 				// Cancel downward velocity when on floor
-				CharacterVelocity.Y = 0;
+				CharacterVelocity = CharacterVelocity.Slide(Vertical);
 			}
 
 			// Prevent sticking
-			if (isOnCeiling && CharacterVelocity.Y > 0)
+			if (isOnCeiling && CharacterVelocity.Dot(Vertical) > 0)
 			{
-				CharacterVelocity.Y = 0;
+				CharacterVelocity = CharacterVelocity.Slide(Vertical);
 			}
 
 			UpdateVelocityInternal(CharacterVelocity);
@@ -807,13 +832,13 @@ public partial class NPC : Physical
 		}
 
 		Vector3 desiredVelocity = Velocity;
-		Vector3 desiredXZ = new(desiredVelocity.X, 0f, desiredVelocity.Z);
+		Vector3 desiredXZ = desiredVelocity.Slide(Vertical);
 		if (desiredXZ.LengthSquared() < 0.0001f)
 		{
 			return false;
 		}
 
-		float groundY;
+		float groundAltitude;
 		{
 			var downHit = new KinematicCollision3D();
 			bool hasGround = CharBody3D.TestMove(CharBody3D.GlobalTransform, Vector3.Down * (StepHeight + 0.05f), downHit, 0.001f, true);
@@ -822,7 +847,7 @@ public partial class NPC : Physical
 				return false;
 			}
 
-			groundY = downHit.GetPosition().Y;
+			groundAltitude = downHit.GetPosition().Dot(Vertical);
 		}
 
 		const float stepSearchOvershoot = 0.05f;
@@ -835,20 +860,20 @@ public partial class NPC : Physical
 			Vector3 n = stepTest.GetNormal();
 			Vector3 p = stepTest.GetPosition();
 
-			if (Mathf.Abs(n.Y) >= 0.01f)
+			if (Mathf.Abs(n.Dot(Vertical)) >= 0.01f)
 			{
 				continue;
 			}
 
-			if (!(p.Y - groundY < StepHeight))
+			if (!(p.Dot(Vertical) - groundAltitude < StepHeight))
 			{
 				continue;
 			}
 
-			float stepHeight = p.Y + StepHeight + 0.0001f;
-			Vector3 stepTestInvDir = new Vector3(-n.X, 0, -n.Z).Normalized();
-			Vector3 origin = new Vector3(p.X, stepHeight, p.Z) + (stepTestInvDir * stepSearchOvershoot);
-			Vector3 direction = Vector3.Down * StepHeight;
+			float stepHeight = p.Dot(Vertical) + StepHeight + 0.0001f;
+			Vector3 stepTestInvDir = (-n).Slide(Vertical).Normalized();
+			Vector3 origin = SetAxisOf(p, Vertical, stepHeight) + (stepTestInvDir * stepSearchOvershoot);
+			Vector3 direction = Vertical * -StepHeight;
 
 			Dictionary result = spaceState.IntersectRay(new PhysicsRayQueryParameters3D()
 			{
@@ -866,8 +891,8 @@ public partial class NPC : Physical
 
 			Vector3 hitPos = result["position"].AsVector3();
 
-			Vector3 stepUpPoint = new Vector3(p.X, hitPos.Y + 0.01f, p.Z) + (stepTestInvDir * stepSearchOvershoot);
-			Vector3 stepUpPointOffset = stepUpPoint - new Vector3(p.X, groundY, p.Z);
+			Vector3 stepUpPoint = SetAxisOf(p, Vertical, hitPos.Dot(Vertical) + 0.01f) + (stepTestInvDir * stepSearchOvershoot);
+			Vector3 stepUpPointOffset = stepUpPoint - SetAxisOf(p, Vertical, groundAltitude);
 
 			CharBody3D.GlobalPosition += stepUpPointOffset;
 			CharBody3D.Velocity = desiredVelocity;
@@ -886,7 +911,7 @@ public partial class NPC : Physical
 		if (canJump)
 		{
 			_coyoteUsed = true;
-			CharacterVelocity.Y = JumpPower;
+			CharacterVelocity = SetAxisOf(CharacterVelocity, Vertical, JumpPower);
 			playJumpSound = true;
 			Jumped.Invoke();
 		}
@@ -913,7 +938,7 @@ public partial class NPC : Physical
 		Rpc(nameof(NetJumpFromSeat));
 
 		// Reset rotation
-		Rotation = new(0, Rotation.Y, 0);
+		Quaternion = new Quaternion(Up, Vertical) * Quaternion;
 
 		if (addForce)
 		{
@@ -1111,6 +1136,8 @@ public partial class NPC : Physical
 		if (_navAgent == null)
 		{
 			_navAgentContainer = new();
+			Quaternion q = Quaternion;
+			Quaternion = Quaternion.Identity;
 			_navAgent = new()
 			{
 				PathDesiredDistance = NavigationDistance,
@@ -1118,6 +1145,7 @@ public partial class NPC : Physical
 				PathHeightOffset = -(CalculateBounds().Size.Y / 2),
 				PathMaxDistance = 3f
 			};
+			Quaternion = q;
 
 			_navAgentContainer.AddChild(_navAgent);
 			GDNode3D.AddChild(_navAgentContainer);

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -692,10 +692,10 @@ public partial class NPC : Physical
 				CharacterVelocity = (dir * WalkSpeed).Slide(Vertical) + CharacterVelocity.Project(Vertical);
 				// Apply rotation by move direction
 				Vector3 a = new Quaternion(Up, Vertical) * Forward;
-				float angle = Mathf.Asin(a.Cross(dir).Dot(vertical));
+				float angle = Mathf.Asin(a.Cross(dir).Dot(Vertical));
 				if (a.Dot(dir) < 0) angle = Mathf.Pi - angle;
 				if (angle > Mathf.Pi) angle -= Mathf.Tau;
-				Quaternion = new Quaternion(vertical, angle * MathUtils.ExpDecay((float)delta, BodyRotateLerp)) * Quaternion;
+				Quaternion = new Quaternion(Vertical, angle * MathUtils.ExpDecay((float)delta, BodyRotateLerp)) * Quaternion;
 
 				float distanceToTarget = GetGlobalPosition().DistanceTo(walkTarget.Value);
 

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -697,8 +697,6 @@ public partial class NPC : Physical
 				if (angle > Mathf.Pi) angle -= Mathf.Tau;
 				Quaternion = new Quaternion(vertical, angle * MathUtils.ExpDecay((float)delta, BodyRotateLerp)) * Quaternion;
 
-				Quaternion = (new Quaternion(new Quaternion(Up, Vertical) * Forward, dir).Log() * MathUtils.ExpDecay((float)delta, BodyRotateLerp)).Exp() * Quaternion;
-
 				float distanceToTarget = GetGlobalPosition().DistanceTo(walkTarget.Value);
 
 				if (distanceToTarget > 0.5f)

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -976,12 +976,12 @@ public sealed partial class Player : NPC
 		{
 			Entity spawnpoint = ArrayUtils.GetRandom(Root.Environment.SpawnPoints);
 			Position = spawnpoint.Position + spawnpoint.Up * (spawnpoint.Size.Y / 2 + 3.0f);
-			Rotation = new(0, spawnpoint.Rotation.Y, 0);
+			Quaternion = new Quaternion(spawnpoint.Up, Vertical) * spawnpoint.Quaternion;
 		}
 		else
 		{
 			Position = DefaultSpawnLocation;
-			Rotation = new(0, 0, 0);
+			Quaternion = new Quaternion(Vector3.Up, Vertical);
 		}
 
 		// Spawn at custom position

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -14,7 +14,7 @@ public class DefaultMovement : IPlayerMovement
 	{
 		Camera? cam = Root.Environment.CurrentCamera;
 		Vector3 moveDirection = Vector3.Zero;
-		Vector3 camRotation = Vector3.Zero;
+		Quaternion camRotation = Quaternion.Identity;
 		float forwardInput = 0f;
 		bool jump = false;
 		bool sprint = false;
@@ -22,16 +22,15 @@ public class DefaultMovement : IPlayerMovement
 
 		if (cam != null && Root.Input.IsGameFocused && Target.CanMove && !Target.IsDead)
 		{
-			Vector3 facingRot = cam.Camera3D.GlobalRotation;
-			camRotation = facingRot;
+			Basis facingRot = cam.Camera3D.GlobalBasis;
+			camRotation = facingRot.Orthonormalized().GetRotationQuaternion();
 
 			float forwardStrength = Input.GetActionStrength("forward");
 			float backwardStrength = Input.GetActionStrength("backward");
 			forwardInput = forwardStrength - backwardStrength;
 
-			moveDirection.X = Input.GetActionStrength("rightward") - Input.GetActionStrength("leftward");
-			moveDirection.Z = backwardStrength - forwardStrength;
-			moveDirection = moveDirection.Rotated(Vector3.Up, facingRot.Y).LimitLength(1);
+			Quaternion verticalize = new(facingRot.Y, Target.Vertical);
+			moveDirection = verticalize * ((facingRot.Z * -forwardInput) + (facingRot.X * (Input.GetActionStrength("rightward") - Input.GetActionStrength("leftward")))).LimitLength(1);
 
 			bool initialSprintOverride = Target.SprintOverride;
 			jump = Input.IsActionPressed("jump");
@@ -82,8 +81,10 @@ public class DefaultMovement : IPlayerMovement
 
 		double delta = snapshot.Delta;
 
+		Vector3 vertical = Target.Vertical;
+
 		Vector3 externalVelocity = Target.ExternalVelocity;
-		bool hasExternalVelocity = externalVelocity.X != 0 || externalVelocity.Z != 0;
+		bool hasExternalVelocity = externalVelocity.Slide(vertical) != Vector3.Zero;
 
 		if (Target.CanMove && !Target.IsDead)
 		{
@@ -121,14 +122,10 @@ public class DefaultMovement : IPlayerMovement
 
 			if (Target.IsClimbing)
 			{
-				// Reset all vectors, lock to Y only
-				Target.CharacterVelocity.X = 0;
-				Target.CharacterVelocity.Z = 0;
-
 				float climbSpeed = forwardInput * gdWalkSpeed * Target.ClimbingTruss!.ClimbSpeed;
 
-				// Add y velocity
-				Target.CharacterVelocity.Y = climbSpeed;
+				// Lock to vertical only and add vertical velocity
+				Target.CharacterVelocity = vertical * climbSpeed;
 
 				finalState = CharacterModel.CharacterModelStateEnum.Climbing;
 				Target.Character?.SetAnimSpeed(climbSpeed / 8);
@@ -136,33 +133,34 @@ public class DefaultMovement : IPlayerMovement
 			else if (Target.JustFinishedClimbing)
 			{
 				Target.JustFinishedClimbing = false;
-				Target.CharacterVelocity.Y = 0;
+				Target.CharacterVelocity = Target.CharacterVelocity.Slide(vertical);
 			}
 
 			// Always rotate in first person
 			if (snapshot.CamLocked)
 			{
-				Target.Rotation = Target.Rotation with { Y = 180 + Mathf.RadToDeg(snapshot.CameraRotation.Y) };
+				Target.Quaternion = new Quaternion(vertical, Mathf.Pi) * (new Quaternion(snapshot.CameraRotation * Vector3.Up, vertical) * snapshot.CameraRotation);
 			}
 
 			Vector3 pushVelocity = hasExternalVelocity
-				? externalVelocity with { Y = 0 }
+				? externalVelocity.Slide(vertical)
 				: Vector3.Zero;
 
 			if (moveDirection != Vector3.Zero && !Target.IsClimbing)
 			{
 				Target.IsMoving = true;
 
-				Target.CharacterVelocity.X = (moveDirection.X * gdWalkSpeed) + pushVelocity.X;
-				Target.CharacterVelocity.Z = (moveDirection.Z * gdWalkSpeed) + pushVelocity.Z;
+				Target.CharacterVelocity = moveDirection * gdWalkSpeed + pushVelocity + Target.CharacterVelocity.Project(vertical);
 
 				if (!snapshot.CamLocked)
 				{
 					// Apply rotation by move direction
-					Target.Rotation = Target.Rotation with
-					{
-						Y = Mathf.RadToDeg(Mathf.LerpAngle(Mathf.DegToRad(Target.Rotation.Y), Mathf.Atan2(Target.CharacterVelocity.X, Target.CharacterVelocity.Z), MathUtils.ExpDecay((float)delta, NPC.BodyRotateLerp)))
-					};
+					Vector3 a = new Quaternion(Target.Up, vertical) * Target.Forward;
+					Vector3 b = Target.CharacterVelocity.Slide(vertical).Normalized();
+					float angle = Mathf.Asin(a.Cross(b).Dot(vertical));
+					if (a.Dot(b) < 0) angle = Mathf.Pi - angle;
+					if (angle > Mathf.Pi) angle -= Mathf.Tau;
+					Target.Quaternion = new Quaternion(vertical, angle * MathUtils.ExpDecay((float)delta, NPC.BodyRotateLerp)) * Target.Quaternion;
 				}
 
 
@@ -184,14 +182,12 @@ public class DefaultMovement : IPlayerMovement
 
 				if (hasExternalVelocity)
 				{
-					Target.CharacterVelocity.X = pushVelocity.X;
-					Target.CharacterVelocity.Z = pushVelocity.Z;
+					Target.CharacterVelocity = pushVelocity + Target.CharacterVelocity.Project(vertical);
 				}
 				else
 				{
 					// Stop horizontal movement when no input
-					Target.CharacterVelocity.X = Mathf.MoveToward(Target.CharacterVelocity.X, 0, gdWalkSpeed);
-					Target.CharacterVelocity.Z = Mathf.MoveToward(Target.CharacterVelocity.Z, 0, gdWalkSpeed);
+					Target.CharacterVelocity = Target.CharacterVelocity.Slide(vertical).MoveToward(Vector3.Zero, gdWalkSpeed) + Target.CharacterVelocity.Project(vertical);
 				}
 				Target.Character?.SetAnimSpeed(1);
 			}
@@ -215,7 +211,7 @@ public class DefaultMovement : IPlayerMovement
 		}
 		else
 		{
-			Target.CharacterVelocity = new Vector3(0, Target.CharacterVelocity.Y, 0);
+			Target.CharacterVelocity = Target.CharacterVelocity.Project(vertical);
 		}
 
 		Target.Character?.SetState(finalState);
@@ -223,11 +219,7 @@ public class DefaultMovement : IPlayerMovement
 		if (hasExternalVelocity)
 		{
 			float decay = Target.WalkSpeed * 60f * (float)delta;
-			Target.ExternalVelocity = new Vector3(
-				Mathf.MoveToward(externalVelocity.X, 0, decay),
-				externalVelocity.Y,
-				Mathf.MoveToward(externalVelocity.Z, 0, decay)
-			);
+			Target.ExternalVelocity = externalVelocity.Slide(vertical).MoveToward(Vector3.Zero, decay) + externalVelocity.Project(vertical);
 		}
 
 		Target.ApplyInternalVelocity(Target.CharacterVelocity);

--- a/Polytoria/scripts/providers/player_movement/IPlayerMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/IPlayerMovement.cs
@@ -16,7 +16,7 @@ public struct InputSnapshot
 	public uint SequenceNumber;
 	public double Delta;
 	public Vector3 MoveDirection;
-	public Vector3 CameraRotation;
+	public Quaternion CameraRotation;
 	public bool Jump;
 	public bool Sprint;
 	public float ForwardInput;


### PR DESCRIPTION
## Summary

- added `NPC.Vertical` (set it to set the up value for movement) (it doesn't set rotation or rotate camera, set those separately)
- added `Camera.QuaternionOffset` and fixed `RotationOffset` being broken (it was just adding the vector as-is)

## Related issue or discussion

fixes #1231 
resolves #1113 

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<img width="1152" height="680" alt="image" src="https://github.com/user-attachments/assets/7dad3289-4974-41d2-b8d6-fb48c06689b4" />

## AI/LLM use
none