### PR TITLE
Disallow setting `NetworkParent` to `this`

### DIFF
--- a/Polytoria/scripts/datamodel/NetworkedObject.cs
+++ b/Polytoria/scripts/datamodel/NetworkedObject.cs
@@ -57,7 +57,7 @@ public partial class NetworkedObject : IScriptObject
 		get => _networkParent;
 		set
 		{
-			if (value == _networkParent) return;
+			if (value == _networkParent || value == this) return;
 			if (_networkParent != null)
 			{
 				InvokeExitTree();


### PR DESCRIPTION
## Summary

disallows setting `NetworkedObject.NetworkParent` to `this`, preventing a freeze

## Related issue or discussion

N/A (discovered this bug from [this discord msg](https://discord.com/channels/587167555068624915/710789603627630613/1545514238951297076))

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None