### PR TITLE
Limit _health to MaxHealth

### DIFF
--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -10,6 +10,7 @@ using Polytoria.Networking;
 using Polytoria.Scripting;
 using Polytoria.Shared;
 using Polytoria.Utils;
+using System;
 
 namespace Polytoria.Datamodel;
 
@@ -236,7 +237,7 @@ public partial class NPC : Physical
 		{
 			if (this is Player plr && !plr.IsReady) return;
 			float oldHealth = _health;
-			_health = System.Math.Clamp(value, 0f, MaxHealth);
+			_health = Math.Min(value, MaxHealth);
 			if (_health <= 0 && !IsDead)
 			{
 				TriggerNPCDead();

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -236,7 +236,7 @@ public partial class NPC : Physical
 		{
 			if (this is Player plr && !plr.IsReady) return;
 			float oldHealth = _health;
-			_health = value;
+			_health = System.Math.Clamp(value, 0f, MaxHealth);
 			if (_health <= 0 && !IsDead)
 			{
 				TriggerNPCDead();


### PR DESCRIPTION
Added `MaxHealth` limit to `Health` setter to avoid `Health` going over `MaxHealth`. which before `NPC:Heal()` would go over `MaxHealth` that has been fixed for the `Health` property setter overall.

Related bug issue: [[Bug]: NPC:Heal() doesn't check for exceeding max health](https://github.com/Polytoria/polytoria-game/issues/1235)