### PR TITLE
Creator: Use built-in format over StyLua format

### DIFF
--- a/Polytoria/scripts/creator/lsp/LuaFormatService.cs
+++ b/Polytoria/scripts/creator/lsp/LuaFormatService.cs
@@ -4,6 +4,7 @@
 
 using Godot;
 using Polytoria.Creator.LSP.Schemas;
+using Polytoria.Creator.Settings;
 using Polytoria.Shared;
 using System;
 using System.Collections.Generic;
@@ -20,10 +21,24 @@ public static class LuaFormatService
 	{
 		try
 		{
+			string formatArgs = "";
+			if (!LuaFormatService.HasFormatConfig(scriptPath))
+			{
+				IndentationModeEnum indentationMode = CreatorSettingsService.Instance.Get<IndentationModeEnum>(CreatorSettingKeys.CodeEditor.IndentationMode);
+				int indentationSize = CreatorSettingsService.Instance.Get<int>(CreatorSettingKeys.CodeEditor.IndentationSize);
+				string indentModeString = indentationMode == IndentationModeEnum.Tabs
+					? "tabs"
+					: "spaces";
+
+				formatArgs +=
+					$"--indent-type {indentModeString} " +
+					$"--indent-width {indentationSize}";
+			}
+
 			var process = Process.Start(new ProcessStartInfo
 			{
 				FileName = NativeBinHelper.ResolveStyLuaBinPath(),
-				Arguments = $"--stdin-filepath \"{scriptPath}\" -",
+				Arguments = $"{formatArgs} --stdin-filepath \"{scriptPath}\" -",
 				RedirectStandardInput = true,
 				RedirectStandardOutput = true,
 				RedirectStandardError = true,
@@ -51,5 +66,20 @@ public static class LuaFormatService
 			PT.PrintErr($"Formatting failed: {ex.Message}");
 			return scriptText;
 		}
+	}
+
+	public static bool HasFormatConfig(string scriptPath)
+	{
+		string? dir = Path.GetDirectoryName(scriptPath);
+		while (dir != null)
+		{
+			if (
+				File.Exists(Path.Join(dir, "stylua.toml")) ||
+				File.Exists(Path.Join(dir, ".stylua.toml")) ||
+				File.Exists(Path.Join(dir, ".editorconfig"))
+			) return true;
+			dir = Path.GetDirectoryName(dir);
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
## Summary

This pull request forces StyLua to use the built-in editor format over it's own format as long as if a `stylua.toml`, `.stylua.toml`, or `.editorconfig` isn't present within the currently formatted file's parent directory.

## Related issue or discussion

Fixes #1238

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [X] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

No screenshots available. Don't think it's necessary.

## AI/LLM use

No AI/LLMs were used in the making of this pull request.