### PR TITLE
Datamodel: Remove velocity reset on transform update

### DIFF
--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -355,11 +355,6 @@ public partial class Dynamic : Instance
 			_currentTransform = _netTransform;
 			_isFirstUpdate = false;
 			_isDirty = false;
-
-			// Reset velocity on snapped
-			if (this is Physical phy)
-				phy.Velocity = Vector3.Zero;
-
 			SetLocalTransform(_currentTransform);
 		}
 		else


### PR DESCRIPTION
## Summary

This change removes the velocity reset from `Dynamic.UpdateTransform()`, allowing velocity to properly replicate from server to client.

## Related issue or discussion

Fixes #111

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [X] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

No screenshots. This change is pretty straight forward.

## AI/LLM use

No AI/LLMs were used in the making of this very, very, very, very, very, very, very, very tiny pull request. Do I really need it for this small of a pull request?