### PR TITLE
!Datamodel!: Remove flips from AngularVelocity

### DIFF
--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -42,11 +42,11 @@ public partial class RigidBody : Physical
 	{
 		get
 		{
-			return GDRigidBody.AngularVelocity.FlipEuler();
+			return GDRigidBody.AngularVelocity;
 		}
 		set
 		{
-			GDRigidBody.AngularVelocity = value.FlipEuler();
+			GDRigidBody.AngularVelocity = value;
 			OnPropertyChanged();
 		}
 	}


### PR DESCRIPTION
## Summary

<img width="1280" height="720" alt="NO-FLIPS" src="https://github.com/user-attachments/assets/526ac37b-2eee-43ba-a12a-aff28988dd52" />

This pull request removes the flips used in AngularVelocity, preventing more headaches with the engine in the future.

**Please note that this change will be a breaking change, as all uses of AngularVelocity will need to be flipped for future games to work!**

## Related issue or discussion

Fixes #1252

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [X] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

*Rotating without flips:*
<img width="420" height="316" alt="no-flips" src="https://github.com/user-attachments/assets/101d1a16-17ed-4916-818f-eb4d9e8d53e7" />

Here's the test place used for this pull request: [FlipTest.zip](https://github.com/user-attachments/files/31928666/FlipTest.zip)

## AI/LLM use

No AI/LLMs were used in the making of this incredibly stupid simple change.