### PR TITLE
take parts as individual when <any>casting

### DIFF
--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -388,7 +388,8 @@ public sealed partial class Environment : Instance
 			if (result.Count == 0) break;
 
 			Node collider = (Node)(GodotObject)result["collider"];
-			Instance? instance = ColliderToInstance(collider);
+			int shape = (int)result["shape"];
+			Instance? instance = ColliderToInstance(collider, shape);
 			Rid colliderRid = (Rid)result["rid"];
 			ignoreRids.Add(colliderRid);
 

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -284,6 +284,7 @@ public sealed partial class Environment : Instance
 			Vector3 hitPos = (Vector3)result["position"];
 			Vector3 normal = (Vector3)result["normal"];
 			Node collider = (Node)(GodotObject)result["collider"];
+			int shape = (int)result["shape"];
 
 			return new()
 			{
@@ -292,7 +293,7 @@ public sealed partial class Environment : Instance
 				Position = hitPos,
 				Normal = normal,
 				Distance = (origin - hitPos).Length(),
-				Instance = ColliderToInstance(collider)
+				Instance = ColliderToInstance(collider, shape)
 			};
 		}
 
@@ -330,6 +331,7 @@ public sealed partial class Environment : Instance
 			Rid colliderRid = (Rid)result["rid"];
 			ignoreRids.Add(colliderRid);
 			Node collider = (Node)(GodotObject)result["collider"];
+			int shape = (int)result["shape"];
 
 			rayResults.Add(new()
 			{
@@ -338,25 +340,24 @@ public sealed partial class Environment : Instance
 				Position = hitPos,
 				Normal = normal,
 				Distance = (origin - hitPos).Length(),
-				Instance = ColliderToInstance(collider)
+				Instance = ColliderToInstance(collider, shape)
 			});
 		}
 
 		return [.. rayResults];
 	}
 
-	private static Instance? ColliderToInstance(Node collider)
+	private static Instance? ColliderToInstance(Node collider, int shape)
 	{
 		Instance? instance = null;
 
-		if (collider is Area3D a3d)
+		if (collider is CollisionObject3D col)
 		{
-			instance = Physical.GetPhysicalFromCollider(a3d);
-		}
-
-		if (collider is RigidBody3D r)
-		{
-			instance = (Instance?)GetNetObjFromProxy(r);
+			CollisionShape3D colshape = (CollisionShape3D)col.ShapeOwnerGetOwner(col.ShapeFindOwner(shape));
+			PT.Print(colshape);
+			Physical? p = null;
+			Physical.ShapeToPhysical.TryGetValue(colshape, out p);
+			instance = p;
 		}
 
 		return instance;
@@ -415,7 +416,8 @@ public sealed partial class Environment : Instance
 		foreach (Godot.Collections.Dictionary result in results)
 		{
 			Node collider = (Node)(GodotObject)result["collider"];
-			Instance? i = ColliderToInstance(collider);
+			int shape = (int)result["shape"];
+			Instance? i = ColliderToInstance(collider, shape);
 
 			if (i != null)
 			{

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -426,7 +426,6 @@ public sealed partial class Environment : Instance
 		if (collider is CollisionObject3D col)
 		{
 			CollisionShape3D colshape = (CollisionShape3D)col.ShapeOwnerGetOwner(col.ShapeFindOwner(shape));
-			PT.Print(colshape);
 			Physical? p = null;
 			Physical.ShapeToPhysical.TryGetValue(colshape, out p);
 			instance = p;

--- a/Polytoria/scripts/datamodel/Mesh.cs
+++ b/Polytoria/scripts/datamodel/Mesh.cs
@@ -487,6 +487,7 @@ public sealed partial class Mesh : Entity
 						Shape = boxShape,
 					};
 					GDNode3D.AddChild(collisionShape);
+					Physical.ShapeToPhysical.Add(collisionShape, this);
 
 					SetRemoteLinkTarget(collisionShape, meshInstance);
 					SetRemoteLinkOffset(collisionShape, meshInstance.GetAabb().GetCenter());
@@ -526,6 +527,7 @@ public sealed partial class Mesh : Entity
 					};
 
 					GDNode3D.AddChild(collisionShape);
+					Physical.ShapeToPhysical.Add(collisionShape, this);
 					SetRemoteLinkTarget(collisionShape, meshInstance);
 					AddCollisionShape(collisionShape);
 				}

--- a/Polytoria/scripts/datamodel/Part.cs
+++ b/Polytoria/scripts/datamodel/Part.cs
@@ -48,6 +48,7 @@ public partial class Part : Entity
 		base.Init();
 		GDNode3D.AddChild(_collider = new(), false, Node.InternalMode.Back);
 		GDNode3D.AddChild(_nRemoteAt = new(), false, Node.InternalMode.Back);
+		Physical.ShapeToPhysical.Add(_collider, this);
 		SetRemoteLinkTarget(_collider, _nRemoteAt);
 		_nRemoteAt.Rotation = Vector3.Zero;
 

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -24,6 +24,7 @@ public partial class Physical : Dynamic
 	private static readonly Dictionary<Node, Physical> _proxyToPhysical = [];
 	private static readonly ConditionalWeakTable<CollisionShape3D, RemoteLinkConfig> _remoteLinkConfigs = [];
 	private static readonly ConditionalWeakTable<CollisionShape3D, TrackedNodesState> _trackedNodes = [];
+	public static readonly ConditionalWeakTable<CollisionShape3D, Physical> ShapeToPhysical = [];
 
 	private sealed class RemoteLinkConfig
 	{
@@ -845,6 +846,7 @@ public partial class Physical : Dynamic
 				Disabled = IsHidden,
 			};
 
+			ShapeToPhysical.Add(newShape, this);
 			parent.AddChild(newShape);
 			createdNodes.Add(newShape);
 


### PR DESCRIPTION
## Summary

it should be that colliders that are children of other Physicals now get their own result when caught in a cast rather than being cast to an ancestor

it was both harder (structurally uh oh) and easier (thanks godot for shape owners) than expected

## Related issue or discussion

Fixes #733

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use
none