### PR TITLE
Pin function names

### DIFF
--- a/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
@@ -439,8 +439,25 @@ public partial class LuaState : IDisposable
 
 		_pinnedFunctions[handlePtr] = func;
 
+		// + 1 for userdata
+		n++;
+
+		IntPtr debugNamePtr;
+		if (name != null)
+		{
+			// make lua handle the debugname for us
+			PushString(name);
+			debugNamePtr = NativeBindings.lua_tolstring(_state, -1, out nint _);
+			// + 1 for name
+			n++;
+		}
+		else
+		{
+			debugNamePtr = IntPtr.Zero;
+		}
+
 		lock (_lock)
-			NativeBindings.lua_pushcclosurek(_state, func, name, n + 1, null);
+			NativeBindings.lua_pushcclosurek(_state, func, debugNamePtr, n, null);
 	}
 
 	private static void FunctionGarbageCollect(IntPtr ud)

--- a/Polytoria/scripts/scripting/languages/luau/native/NativeBindings.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/NativeBindings.cs
@@ -162,9 +162,9 @@ internal partial class NativeBindings
 	[UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
 	internal static partial void lua_pushboolean(IntPtr L, int b);
 
-	[LibraryImport(LuaLibraryName, StringMarshalling = StringMarshalling.Utf8)]
+	[LibraryImport(LuaLibraryName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	internal static partial void lua_pushcclosurek(IntPtr L, LuaFunction fn, string? debugname, int nup, LuaContinuation? cont);
+	internal static partial void lua_pushcclosurek(IntPtr L, LuaFunction fn, IntPtr debugname, int nup, LuaContinuation? cont);
 
 	[LibraryImport(LuaLibraryName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]


### PR DESCRIPTION
## Summary

pins function names by making them an upvalue of the function. the luau GC doesn't move stuff around from what I can tell so this should be Ok

## Related issue or discussion

Fixes #1266

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [X] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None