### PR TITLE
Restored 1.0's Stamina Drain & Fixed AllowAnimationWhileMoving

### DIFF
--- a/Polytoria/scripts/client/ui/UIHealthbar.cs
+++ b/Polytoria/scripts/client/ui/UIHealthbar.cs
@@ -20,11 +20,15 @@ public partial class UIHealthbar : Control
 
 	private Color _healthFullColor;
 	private Color _healthOutColor;
+	private Color _staminaFullColor;
+	private Color _staminaOutColor;
 
 	public override void _EnterTree()
 	{
 		_healthFullColor = Color.FromHtml("#4fe883");
 		_healthOutColor = Color.FromHtml("#DD5555");
+		_staminaFullColor = Color.FromHtml("#0097ff");
+		_staminaOutColor = Color.FromHtml("#026fbdff");
 		base._EnterTree();
 	}
 
@@ -43,6 +47,7 @@ public partial class UIHealthbar : Control
 			_staminaBar.Visible = localplayer.UseStamina;
 			_staminaBar.Value = localplayer.Stamina;
 			_staminaBar.MaxValue = localplayer.MaxStamina;
+			_staminaBar.SelfModulate = localplayer.StaminaDrained ? _staminaOutColor : _staminaFullColor;
 
 			_healthBar.Value = health;
 			_healthBar.MaxValue = maxHealth;

--- a/Polytoria/scripts/client/ui/UIHealthbar.cs
+++ b/Polytoria/scripts/client/ui/UIHealthbar.cs
@@ -47,7 +47,7 @@ public partial class UIHealthbar : Control
 			_staminaBar.Visible = localplayer.UseStamina;
 			_staminaBar.Value = localplayer.Stamina;
 			_staminaBar.MaxValue = localplayer.MaxStamina;
-			_staminaBar.SelfModulate = localplayer.StaminaDrained ? _staminaOutColor : _staminaFullColor;
+			_staminaBar.SelfModulate = localplayer.IsExhausted ? _staminaOutColor : _staminaFullColor;
 
 			_healthBar.Value = health;
 			_healthBar.MaxValue = maxHealth;

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -193,7 +193,7 @@ public sealed partial class Player : NPC
 		get => _staminaRegen;
 		set
 		{
-			_staminaRegen = Mathf.Max(value, 0f);
+			_staminaRegen = value;
 			OnPropertyChanged();
 		}
 	}
@@ -226,7 +226,7 @@ public sealed partial class Player : NPC
 		get => _exhaustionRegen;
 		set
 		{
-			_exhaustionRegen = Mathf.Max(value, 0f);
+			_exhaustionRegen = value;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -26,6 +26,7 @@ public sealed partial class Player : NPC
 {
 	private const double MaxAFKTime = 60 * 15;
 	private const float CameraHeight = 2f;
+	private const float StaminaRecovery = 0.6f;
 	public const string CreatorHeadScene = "res://scenes/creator/livecollab/head.tscn";
 	public const string BubbleChatScene = "res://scenes/client/spatial/chat/bubble_chat.tscn";
 	public const string BadgeImageDirPath = "res://assets/textures/client/ui/playerlist/badges/";
@@ -45,8 +46,8 @@ public sealed partial class Player : NPC
 	private float _stamina = 0;
 	private float _maxStamina = 3;
 	private bool _useStamina = true;
-	private float _staminaRegen = 1.2f;
-	private float _staminaBurn = 1.2f;
+	private float _staminaRegen = 1f / 1.2f;
+	private float _staminaBurn = 1f / 1.2f;
 	private bool _keepInventory = false;
 	private bool _useHeadTurning = false;
 	private int _userID;
@@ -61,6 +62,7 @@ public sealed partial class Player : NPC
 	internal bool SprintOverride = false;
 	private float _pingStartTime = 0;
 	internal bool SprintHoldAgain = false;
+	internal bool StaminaDrained = false;
 
 	private double _afkTimer;
 
@@ -614,10 +616,12 @@ public sealed partial class Player : NPC
 	internal void AddStaminaTick(double delta)
 	{
 		if (!UseStamina) { return; }
-		Stamina += (float)(delta * StaminaRegen);
+		float regenRate = StaminaRegen * (StaminaDrained ? StaminaRecovery : 1f);
+		Stamina += (float)(delta * regenRate);
 		if (Stamina > MaxStamina)
 		{
 			Stamina = MaxStamina;
+			StaminaDrained = false;
 		}
 	}
 
@@ -625,9 +629,10 @@ public sealed partial class Player : NPC
 	{
 		if (!UseStamina) { return; }
 		Stamina -= (float)(delta * StaminaBurn);
-		if (Stamina < 0)
+		if (Stamina <= 0)
 		{
 			Stamina = 0;
+			StaminaDrained = true;
 		}
 	}
 
@@ -757,7 +762,7 @@ public sealed partial class Player : NPC
 		}
 
 		// Stop animation on move
-		if (IsMoving && !AllowAnimationWhileMoving)
+		if ((IsMoving || !IsOnGround) && !AllowAnimationWhileMoving)
 		{
 			Character?.Animator?.StopAnimation();
 		}

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -26,7 +26,6 @@ public sealed partial class Player : NPC
 {
 	private const double MaxAFKTime = 60 * 15;
 	private const float CameraHeight = 2f;
-	private const float StaminaRecovery = 0.6f;
 	public const string CreatorHeadScene = "res://scenes/creator/livecollab/head.tscn";
 	public const string BubbleChatScene = "res://scenes/client/spatial/chat/bubble_chat.tscn";
 	public const string BadgeImageDirPath = "res://assets/textures/client/ui/playerlist/badges/";
@@ -43,11 +42,14 @@ public sealed partial class Player : NPC
 	private bool _canMove = true;
 	private bool _canJumpWhileClimbing = true;
 	private float _sprintSpeed;
-	private float _stamina = 0;
-	private float _maxStamina = 3;
+	private float _stamina = 3f;
+	private float _maxStamina = 3f;
 	private bool _useStamina = true;
 	private float _staminaRegen = 1f / 1.2f;
 	private float _staminaBurn = 1f / 1.2f;
+	private bool _useExhaustion = false;
+	private float _exhaustionRegen = 1f / 0.6f;
+	private float _exhaustionCeil = 0.5f;
 	private bool _keepInventory = false;
 	private bool _useHeadTurning = false;
 	private int _userID;
@@ -62,7 +64,6 @@ public sealed partial class Player : NPC
 	internal bool SprintOverride = false;
 	private float _pingStartTime = 0;
 	internal bool SprintHoldAgain = false;
-	internal bool StaminaDrained = false;
 
 	private double _afkTimer;
 
@@ -111,6 +112,12 @@ public sealed partial class Player : NPC
 	[ScriptProperty]
 	public PTSignal<Physical> Ungrabbed { get; private set; } = new();
 
+	[ScriptProperty]
+	public PTSignal Exhausted { get; private set; } = new();
+
+	[ScriptProperty]
+	public PTSignal Unexhausted { get; private set; } = new();
+
 	[SyncVar, ScriptProperty]
 	public int UserID
 	{
@@ -153,7 +160,7 @@ public sealed partial class Player : NPC
 		get => _stamina;
 		set
 		{
-			_stamina = value;
+			_stamina = Mathf.Clamp(value, 0f, MaxStamina);
 			OnPropertyChanged();
 		}
 	}
@@ -164,7 +171,7 @@ public sealed partial class Player : NPC
 		get => _maxStamina;
 		set
 		{
-			_maxStamina = value;
+			_maxStamina = Mathf.Max(value, 0f);
 			OnPropertyChanged();
 		}
 	}
@@ -186,7 +193,7 @@ public sealed partial class Player : NPC
 		get => _staminaRegen;
 		set
 		{
-			_staminaRegen = value;
+			_staminaRegen = Mathf.Max(value, 0f);
 			OnPropertyChanged();
 		}
 	}
@@ -197,7 +204,40 @@ public sealed partial class Player : NPC
 		get => _staminaBurn;
 		set
 		{
-			_staminaBurn = value;
+			_staminaBurn = Mathf.Max(value, 0f);
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool UseExhaustion
+	{
+		get => _useExhaustion;
+		set
+		{
+			_useExhaustion = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float ExhaustionRegen
+	{
+		get => _exhaustionRegen;
+		set
+		{
+			_exhaustionRegen = Mathf.Max(value, 0f);
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float ExhaustionCeil
+	{
+		get => _exhaustionCeil;
+		set
+		{
+			_exhaustionCeil = Mathf.Clamp(value, 0f, 1f);
 			OnPropertyChanged();
 		}
 	}
@@ -414,6 +454,9 @@ public sealed partial class Player : NPC
 	public bool IsClimbing { get; internal set; }
 
 	[SyncVar(AllowAuthorWrite = true), ScriptProperty]
+	public bool IsExhausted { get; internal set; }
+
+	[SyncVar(AllowAuthorWrite = true), ScriptProperty]
 	public Truss? ClimbingTruss { get; internal set; }
 
 	[SyncVar(ServerOnly = true)]
@@ -616,12 +659,18 @@ public sealed partial class Player : NPC
 	internal void AddStaminaTick(double delta)
 	{
 		if (!UseStamina) { return; }
-		float regenRate = StaminaRegen * (StaminaDrained ? StaminaRecovery : 1f);
+		bool exhaustionEnabled = UseExhaustion && ExhaustionRegen != 0f && ExhaustionCeil != 0f;
+		float regenRate = IsExhausted && exhaustionEnabled ? ExhaustionRegen : StaminaRegen;
 		Stamina += (float)(delta * regenRate);
+		if (IsExhausted && (!exhaustionEnabled || Stamina >= ExhaustionCeil * MaxStamina))
+		{
+			IsExhausted = false;
+			Unexhausted.Invoke();
+		}
+
 		if (Stamina > MaxStamina)
 		{
 			Stamina = MaxStamina;
-			StaminaDrained = false;
 		}
 	}
 
@@ -632,7 +681,11 @@ public sealed partial class Player : NPC
 		if (Stamina <= 0)
 		{
 			Stamina = 0;
-			StaminaDrained = true;
+			if (!IsExhausted && ExhaustionRegen != 0f && ExhaustionCeil != 0f)
+			{
+				IsExhausted = true;
+				Exhausted.Invoke();
+			}
 		}
 	}
 
@@ -1075,10 +1128,13 @@ public sealed partial class Player : NPC
 		WalkSpeed = Root.PlayerDefaults.WalkSpeed;
 		SprintSpeed = Root.PlayerDefaults.SprintSpeed;
 		UseStamina = Root.PlayerDefaults.UseStamina;
-		Stamina = Root.PlayerDefaults.Stamina;
 		MaxStamina = Root.PlayerDefaults.MaxStamina;
+		Stamina = Root.PlayerDefaults.MaxStamina;
 		StaminaRegen = Root.PlayerDefaults.StaminaRegen;
 		StaminaBurn = Root.PlayerDefaults.StaminaBurn;
+		UseExhaustion = Root.PlayerDefaults.UseExhaustion;
+		ExhaustionRegen = Root.PlayerDefaults.ExhaustionRegen;
+		ExhaustionCeil = Root.PlayerDefaults.ExhaustionCeil;
 		JumpPower = Root.PlayerDefaults.JumpPower;
 		RespawnTime = Root.PlayerDefaults.RespawnTime;
 		KeepInventory = Root.PlayerDefaults.KeepInventory;

--- a/Polytoria/scripts/datamodel/PlayerDefaults.cs
+++ b/Polytoria/scripts/datamodel/PlayerDefaults.cs
@@ -18,11 +18,13 @@ public sealed partial class PlayerDefaults : HiddenBase
 	private float _respawnTime;
 	private bool _canMove;
 	private float _sprintSpeed;
-	private float _stamina;
-	private float _maxStamina;
 	private bool _useStamina;
+	private float _maxStamina;
 	private float _staminaRegen;
 	private float _staminaBurn;
+	private bool _useExhaustion;
+	private float _exhaustionRegen;
+	private float _exhaustionCeil;
 	private bool _keepInventory;
 	private bool _useHeadTurning;
 	private bool _useBubbleChat;
@@ -96,13 +98,13 @@ public sealed partial class PlayerDefaults : HiddenBase
 		}
 	}
 
-
 	[Editable, ScriptProperty]
 	public bool ChatColorsEnabled
 	{
 		get => _chatColorsEnabled;
 		set { _chatColorsEnabled = value; OnPropertyChanged(); }
 	}
+
 	[Editable, ScriptProperty]
 	public bool CanMove
 	{
@@ -110,18 +112,6 @@ public sealed partial class PlayerDefaults : HiddenBase
 		set
 		{
 			_canMove = value;
-			OnPropertyChanged();
-		}
-	}
-
-
-	[Editable, ScriptProperty]
-	public float StaminaBurn
-	{
-		get => _staminaBurn;
-		set
-		{
-			_staminaBurn = value;
 			OnPropertyChanged();
 		}
 	}
@@ -137,25 +127,11 @@ public sealed partial class PlayerDefaults : HiddenBase
 		}
 	}
 
-	[Editable(IsHidden = true)]
-	public bool StaminaEnabled
-	{
-		get => UseStamina;
-		set
-		{
-			UseStamina = value;
-		}
-	}
-
-	[Editable, ScriptProperty, SyncVar(Unreliable = true)]
+	[Attributes.Obsolete("Use Player.Stamina instead.")]
 	public float Stamina
 	{
-		get => _stamina;
-		set
-		{
-			_stamina = value;
-			OnPropertyChanged();
-		}
+		get => 100f;
+		set { }
 	}
 
 	[Editable, ScriptProperty]
@@ -180,6 +156,49 @@ public sealed partial class PlayerDefaults : HiddenBase
 		}
 	}
 
+	[Editable, ScriptProperty]
+	public float StaminaBurn
+	{
+		get => _staminaBurn;
+		set
+		{
+			_staminaBurn = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool UseExhaustion
+	{
+		get => _useExhaustion;
+		set
+		{
+			_useExhaustion = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float ExhaustionRegen
+	{
+		get => _exhaustionRegen;
+		set
+		{
+			_exhaustionRegen = value;
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public float ExhaustionCeil
+	{
+		get => _exhaustionCeil;
+		set
+		{
+			_exhaustionCeil = Mathf.Clamp(value, 0f, 1f);
+			OnPropertyChanged();
+		}
+	}
 
 	[Editable, ScriptProperty]
 	public bool KeepInventory
@@ -191,7 +210,6 @@ public sealed partial class PlayerDefaults : HiddenBase
 			OnPropertyChanged();
 		}
 	}
-
 
 	[Editable, ScriptProperty]
 	public bool UseHeadTurning
@@ -267,11 +285,13 @@ public sealed partial class PlayerDefaults : HiddenBase
 		RespawnTime = 5.0f;
 		CanMove = true;
 		SprintSpeed = 25f;
-		Stamina = 0f;
 		MaxStamina = 3f;
 		UseStamina = true;
-		StaminaRegen = 1.2f;
-		StaminaBurn = 1.2f;
+		StaminaRegen = 1f / 1.2f;
+		StaminaBurn = 1f / 1.2f;
+		UseExhaustion = false;
+		ExhaustionRegen = 1f / 0.6f;
+		ExhaustionCeil = 0.5f;
 		UseHeadTurning = true;
 		UseBubbleChat = true;
 		AutoLoadAppearance = true;

--- a/Polytoria/scripts/datamodel/PlayerDefaults.cs
+++ b/Polytoria/scripts/datamodel/PlayerDefaults.cs
@@ -140,7 +140,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 		get => _maxStamina;
 		set
 		{
-			_maxStamina = value;
+			_maxStamina = Mathf.Max(value, 0f);
 			OnPropertyChanged();
 		}
 	}
@@ -151,7 +151,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 		get => _staminaRegen;
 		set
 		{
-			_staminaRegen = value;
+			_staminaRegen = Mathf.Max(value, 0f);
 			OnPropertyChanged();
 		}
 	}
@@ -162,7 +162,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 		get => _staminaBurn;
 		set
 		{
-			_staminaBurn = value;
+			_staminaBurn = Mathf.Max(value, 0f);
 			OnPropertyChanged();
 		}
 	}
@@ -184,7 +184,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 		get => _exhaustionRegen;
 		set
 		{
-			_exhaustionRegen = value;
+			_exhaustionRegen = Mathf.Max(value, 0f);
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/datamodel/PlayerDefaults.cs
+++ b/Polytoria/scripts/datamodel/PlayerDefaults.cs
@@ -151,7 +151,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 		get => _staminaRegen;
 		set
 		{
-			_staminaRegen = Mathf.Max(value, 0f);
+			_staminaRegen = value;
 			OnPropertyChanged();
 		}
 	}
@@ -184,7 +184,7 @@ public sealed partial class PlayerDefaults : HiddenBase
 		get => _exhaustionRegen;
 		set
 		{
-			_exhaustionRegen = Mathf.Max(value, 0f);
+			_exhaustionRegen = value;
 			OnPropertyChanged();
 		}
 	}

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -104,7 +104,7 @@ public class DefaultMovement : IPlayerMovement
 			// Sprint/Stamina
 			if (sprinting && moveDirection != Vector3.Zero)
 			{
-				bool canSprint = !Target.UseStamina || (Target.Stamina > 0 && !Target.StaminaDrained);
+				bool canSprint = !Target.UseStamina || (Target.Stamina > 0 && !Target.IsExhausted);
 				if (canSprint)
 				{
 					gdWalkSpeed = Target.SprintSpeed;
@@ -114,7 +114,7 @@ public class DefaultMovement : IPlayerMovement
 				{
 					sprinting = false;
 					Target.SprintOverride = false;
-					if (!Target.StaminaDrained)
+					if (!Target.IsExhausted)
 					{
 						Target.SprintHoldAgain = true;
 					}
@@ -171,7 +171,7 @@ public class DefaultMovement : IPlayerMovement
 
 
 				float animMoveAmount = Mathf.Max(Mathf.Clamp(moveDirection.Length(), 0f, 1f), 0.15f);
-				if (sprinting && Target.SprintSpeed != Target.WalkSpeed)
+				if (gdWalkSpeed > Mathf.Min(Target.WalkSpeed, Target.SprintSpeed))
 				{
 					finalState = CharacterModel.CharacterModelStateEnum.Running;
 					Target.Character?.SetAnimSpeed(gdWalkSpeed / 20 * animMoveAmount);

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -104,17 +104,22 @@ public class DefaultMovement : IPlayerMovement
 			// Sprint/Stamina
 			if (sprinting && moveDirection != Vector3.Zero)
 			{
-				if (Target.Stamina > 0 || !Target.UseStamina)
+				bool canSprint = !Target.UseStamina || (Target.Stamina > 0 && !Target.StaminaDrained);
+				if (canSprint)
 				{
 					gdWalkSpeed = Target.SprintSpeed;
+					Target.RemoveStaminaTick(delta);
 				}
 				else
 				{
 					sprinting = false;
-					Target.SprintHoldAgain = true;
+					Target.SprintOverride = false;
+					if (!Target.StaminaDrained)
+					{
+						Target.SprintHoldAgain = true;
+					}
+					Target.AddStaminaTick(delta);
 				}
-
-				Target.RemoveStaminaTick(delta);
 			}
 			else
 			{


### PR DESCRIPTION
## Summary

This PR restores the penalty 1.0 had when you fully ran out of stamina, and along that adds a grounded check to `AllowAnimationWhileMoving` so emotes get interrupted on jump/fall (which is the expected behaviour when you have this property on, leave it off if you don't want this).

Aditionally
* Made the minor change `#133` requested.
* Made the changes @The4codeblocks requested on their reply.
* Made stamina start full, and deprecated `PlayerDefaults.Stamina` to allow for this as it had practically no use.
* Made it so the walk/run behaviour is inverted when the player's walkspeed is greater than their sprint speed.
* Clamped stamina related setters.
* Rearranged the `PlayerDefaults` stamina related properties so they are easier for creators to read.
* Removed leftover `StaminaEnabled` property from PlayerDefaults (ScriptLegacyProperty("StaminaEnabled") already handles it).

## Related issue or discussion

Fixes #133

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

https://github.com/user-attachments/assets/45bac837-7691-41d0-a99e-374f2bb119a6

## AI/LLM use

None