### PR TITLE
Fix `print`/`warn`

### DIFF
--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -684,69 +684,41 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 	{
 		_gdToProxy[target] = proxy.GetMethod(nameof(IScriptGDObject.FromGDClass), BindingFlags.Public | BindingFlags.Static);
 	}
+	
+	private static string BuildLog(LuaState lua)
+	{
+		int n = lua.GetTop();
+		string?[] strings = new string?[n];
+		for (int i = 0; i < n; i++)
+		{
+			strings[i] = lua.LauxToString(i + 1);
+			lua.Pop(1);
+		}
+		return string.Join('\t', strings);
+	}
 
 	public static int LuaPrint(IntPtr L)
 	{
 		LuaState lua = LuaState.FromIntPtr(L);
+		string logInfo = BuildLog(lua);
+
 		Script script = GetScriptInstance(lua);
 		LogDispatcher logger = GetLogger(lua);
-
-		int n = lua.GetTop();
-		StringBuilder sb = new();
-
-		for (int i = 1; i <= n; i++)
-		{
-			if (i > 1)
-				sb.Append('\t');
-			LuaType dataType = lua.Type(i);
-			if (dataType == LuaType.Boolean)
-			{
-				sb.Append(lua.ToBoolean(i));
-			}
-			else if (dataType == LuaType.Number)
-			{
-				sb.Append(lua.ToNumber(i));
-			}
-			else
-			{
-				sb.Append(lua.ToString(i, true) ?? "<" + lua.TypeName(i) + ">");
-			}
-		}
-		string logInfo = sb.ToString();
 		logger.LogInfo(script, logInfo);
 		return 0;
 	}
+
 	public static int LuaWarn(IntPtr L)
 	{
 		LuaState lua = LuaState.FromIntPtr(L);
+		string logInfo = BuildLog(lua);
+
 		Script script = GetScriptInstance(lua);
 		LogDispatcher logger = GetLogger(lua);
-
-		int n = lua.GetTop();
-		StringBuilder sb = new();
-
-		for (int i = 1; i <= n; i++)
-		{
-			if (i > 1)
-				sb.Append('\t');
-			LuaType dataType = lua.Type(i);
-			if (dataType == LuaType.Boolean)
-			{
-				sb.Append(lua.ToBoolean(i));
-			}
-			else if (dataType == LuaType.Number)
-			{
-				sb.Append(lua.ToNumber(i));
-			}
-			else
-			{
-				sb.Append(lua.ToString(i, true) ?? "<" + lua.TypeName(i) + ">");
-			}
-		}
-		string logInfo = sb.ToString();
 		logger.LogWarning(script, logInfo);
 		return 0;
 	}
+
 	public static int LuaWait(IntPtr L)
 	{
 		LuaState lua = LuaState.FromIntPtr(L);

--- a/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
+++ b/Polytoria/scripts/scripting/languages/luau/LuauProvider.cs
@@ -684,7 +684,7 @@ public sealed partial class LuauProvider : IScriptLanguageProvider
 	{
 		_gdToProxy[target] = proxy.GetMethod(nameof(IScriptGDObject.FromGDClass), BindingFlags.Public | BindingFlags.Static);
 	}
-	
+
 	private static string BuildLog(LuaState lua)
 	{
 		int n = lua.GetTop();

--- a/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
+++ b/Polytoria/scripts/scripting/languages/luau/native/LuaState.cs
@@ -282,19 +282,38 @@ public partial class LuaState : IDisposable
 
 	public bool IsBuffer(int index) => Type(index) == LuaType.Buffer;
 
-	public string? ToString(int index, bool callMetamethod = false)
+	/// <summary>
+	/// Converts the string or number at the index to a string.
+	/// </summary>
+	/// <returns>
+	/// string on success and null on failure.
+	/// </returns>
+	/// <remarks>
+	/// If the value on the stack is a number, it is coerced to a string value,
+	/// changing the value at the index.
+	/// </remarks>
+	public string? ToString(int index)
 	{
-		if (callMetamethod)
-		{
-			if (CallMetamethod(index, "__tostring"))
-			{
-				index = -1;
-			}
-		}
 		lock (_lock)
 		{
-			IntPtr str = NativeBindings.lua_tolstring(_state, index, out IntPtr _);
-			return str != IntPtr.Zero ? Marshal.PtrToStringUTF8(str) : null;
+			IntPtr str = NativeBindings.lua_tolstring(_state, index, out nint len);
+			return str != 0 ? Marshal.PtrToStringUTF8(str, (int)len) : null;
+		}
+	}
+
+	/// <summary>
+	/// Converts the value at the index into a string that is placed on top of
+	/// the stack (original is kept on the stack).
+	/// </summary>
+	/// <remarks>
+	/// This conversion supports the __tostring metamethod of the value.
+	/// </remarks>
+	public string? LauxToString(int index)
+	{
+		lock (_lock)
+		{
+			IntPtr str = NativeBindings.luaL_tolstring(_state, index, out nint len);
+			return str != 0 ? Marshal.PtrToStringUTF8(str, (int)len) : null;
 		}
 	}
 


### PR DESCRIPTION
## Summary

makes `print` and `warn` use `luaL_tolstring` internally to fix a crash and be consistent with `tostring` (output will be a little different now but whaatever)

## Related issue or discussion

Fixes #1269

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [X] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [X] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [X] Added in-code documentation (where needed)
- [X] Ran `dotnet restore`
- [X] Ran `dotnet format`
- [X] Ran `dotnet build`
- [X] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [X] Tested the changes in a local environment
- [X] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use

None