### PR TITLE
Fix explosions on NPCs and movement regression

### DIFF
--- a/Polytoria/scripts/datamodel/Explosion.cs
+++ b/Polytoria/scripts/datamodel/Explosion.cs
@@ -193,12 +193,12 @@ public partial class Explosion : Dynamic
 						}
 					}
 				}
-				else if (item is Player plr)
+				else if (item is NPC npc)
 				{
-					if (plr.IsDead) continue;
+					if (npc.IsDead) continue;
 
-					plr.TakeDamage(Damage);
-					AddPlrExplosionForce(plr);
+					npc.TakeDamage(Damage);
+					AddNPCExplosionForce(npc);
 				}
 			}
 		}
@@ -217,16 +217,16 @@ public partial class Explosion : Dynamic
 		}
 	}
 
-	private void AddPlrExplosionForce(Player player)
+	private void AddNPCExplosionForce(NPC npc)
 	{
 		float force = Force * 0.02f;
-		Vector3 dir = player.GetGlobalTransform().Origin - GetGlobalTransform().Origin;
+		Vector3 dir = npc.GetGlobalTransform().Origin - GetGlobalTransform().Origin;
 		float wearoff = 1 - (dir.Length() / (Radius * 2f));
 		wearoff = Mathf.Max(Mathf.Clamp(wearoff, 0, 1), 0.1f);
 		Vector3 f = dir.Normalized() * force;
 		f.X *= 1.5f;
 		f.Z *= 1.5f;
 
-		player.CharacterVelocity = f * wearoff;
+		npc.CharacterVelocity += f * wearoff;
 	}
 }

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -32,10 +32,10 @@ public class DefaultMovement : IPlayerMovement
 			Vector3 vertical = Target.Vertical;
 
 			Quaternion verticalize = new(facingRot.Y, vertical);
-			moveDirection = verticalize * (
+			moveDirection = (verticalize * (
 				(facingRot.Z * -forwardInput) +
 				(facingRot.X * (Input.GetActionStrength("rightward") - Input.GetActionStrength("leftward")))
-			).Slide(vertical).LimitLength(1);
+			)).Slide(vertical).LimitLength(1);
 
 			bool initialSprintOverride = Target.SprintOverride;
 			jump = Input.IsActionPressed("jump");

--- a/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
+++ b/Polytoria/scripts/providers/player_movement/DefaultMovement.cs
@@ -29,9 +29,13 @@ public class DefaultMovement : IPlayerMovement
 			float backwardStrength = Input.GetActionStrength("backward");
 			forwardInput = forwardStrength - backwardStrength;
 
-			Vector3 camForward = facingRot.Z.Slide(Target.Vertical).Normalized();
-			Vector3 camRight = facingRot.X.Slide(Target.Vertical).Normalized();
-			moveDirection = ((camForward * -forwardInput) + (camRight * (Input.GetActionStrength("rightward") - Input.GetActionStrength("leftward")))).LimitLength(1);
+			Vector3 vertical = Target.Vertical;
+
+			Quaternion verticalize = new(facingRot.Y, vertical);
+			moveDirection = verticalize * (
+				(facingRot.Z * -forwardInput) +
+				(facingRot.X * (Input.GetActionStrength("rightward") - Input.GetActionStrength("leftward")))
+			).Slide(vertical).LimitLength(1);
 
 			bool initialSprintOverride = Target.SprintOverride;
 			jump = Input.IsActionPressed("jump");


### PR DESCRIPTION
## Summary

- explosions now damage and move NPCs, they also accelerate rather than set velocity (yay relativity)
- sideways movement is now more intutitive (always rotating movement plane, never reflecting it)
- - no regressions in the above

## Related issue or discussion

fixes #1273
fixes unintuitiveness and possible normalization of null vector introduced in #1249 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use
none