### PR TITLE
Use typed PTSignal connections

### DIFF
--- a/Polytoria/scripts/scripting/events/PTSignal.cs
+++ b/Polytoria/scripts/scripting/events/PTSignal.cs
@@ -139,7 +139,7 @@ public class PTSignal : IScriptObject
 			GD.PushWarning("This delegate already exists");
 			return;
 		}
-		
+
 		PTCallback cb = new(args =>
 		{
 			action((T)args[0]!);

--- a/Polytoria/scripts/scripting/events/PTSignal.cs
+++ b/Polytoria/scripts/scripting/events/PTSignal.cs
@@ -132,6 +132,78 @@ public class PTSignal : IScriptObject
 		Connect(cb);
 	}
 
+	public void Connect<T>(Action<T> action)
+	{
+		if (_ptCallbacks?.Any(c => c.OriginalDelegate?.Equals(action) == true) == true)
+		{
+			GD.PushWarning("This delegate already exists");
+			return;
+		}
+		
+		PTCallback cb = new(args =>
+		{
+			action((T)args[0]!);
+		})
+		{
+			OriginalDelegate = action
+		};
+		Connect(cb);
+	}
+
+	public void Connect<T1, T2>(Action<T1, T2> action)
+	{
+		if (_ptCallbacks?.Any(c => c.OriginalDelegate?.Equals(action) == true) == true)
+		{
+			GD.PushWarning("This delegate already exists");
+			return;
+		}
+
+		PTCallback cb = new(args =>
+		{
+			action((T1)args[0]!, (T2)args[1]!);
+		})
+		{
+			OriginalDelegate = action
+		};
+		Connect(cb);
+	}
+
+	public void Connect<T1, T2, T3>(Action<T1, T2, T3> action)
+	{
+		if (_ptCallbacks?.Any(c => c.OriginalDelegate?.Equals(action) == true) == true)
+		{
+			GD.PushWarning("This delegate already exists");
+			return;
+		}
+
+		PTCallback cb = new(args =>
+		{
+			action((T1)args[0]!, (T2)args[1]!, (T3)args[2]!);
+		})
+		{
+			OriginalDelegate = action
+		};
+		Connect(cb);
+	}
+
+	public void Connect<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action)
+	{
+		if (_ptCallbacks?.Any(c => c.OriginalDelegate?.Equals(action) == true) == true)
+		{
+			GD.PushWarning("This delegate already exists");
+			return;
+		}
+
+		PTCallback cb = new(args =>
+		{
+			action((T1)args[0]!, (T2)args[1]!, (T3)args[2]!, (T4)args[3]!);
+		})
+		{
+			OriginalDelegate = action
+		};
+		Connect(cb);
+	}
+
 	[ScriptMethod]
 	public void Disconnect(PTCallback action)
 	{


### PR DESCRIPTION
## Summary

Adds typed PTSignal.Connect overloads. Old path used reflection which causes crashes on macOS builds, notably during playtesting

## Related issue or discussion

Fixes #367

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None