### PR TITLE
Add typed PTSignal overloads for Disconnect and Once

### DIFF
--- a/Polytoria/scripts/scripting/events/PTSignal.cs
+++ b/Polytoria/scripts/scripting/events/PTSignal.cs
@@ -262,6 +262,34 @@ public class PTSignal : IScriptObject
 		Disconnect(cb);
 	}
 
+	public void Disconnect<T>(Action<T> action)
+	{
+		var cb = _ptCallbacks?.FirstOrDefault(c => c.OriginalDelegate?.Equals(action) == true);
+		if (cb == null) return;
+		Disconnect(cb);
+	}
+
+	public void Disconnect<T1, T2>(Action<T1, T2> action)
+	{
+		var cb = _ptCallbacks?.FirstOrDefault(c => c.OriginalDelegate?.Equals(action) == true);
+		if (cb == null) return;
+		Disconnect(cb);
+	}
+
+	public void Disconnect<T1, T2, T3>(Action<T1, T2, T3> action)
+	{
+		var cb = _ptCallbacks?.FirstOrDefault(c => c.OriginalDelegate?.Equals(action) == true);
+		if (cb == null) return;
+		Disconnect(cb);
+	}
+
+	public void Disconnect<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action)
+	{
+		var cb = _ptCallbacks?.FirstOrDefault(c => c.OriginalDelegate?.Equals(action) == true);
+		if (cb == null) return;
+		Disconnect(cb);
+	}
+
 	[ScriptMetamethod(ScriptObjectMetamethod.ToString)]
 	public static string ToString(PTSignal? _)
 	{
@@ -320,6 +348,22 @@ public class PTSignal : IScriptObject
 		Connect(cb);
 	}
 
+	public void Once(Action action)
+	{
+		PTCallback? cb = null;
+
+		cb = new PTCallback(_ =>
+		{
+			Disconnect(cb!);
+			action();
+		})
+		{
+			OriginalDelegate = action
+		};
+
+		Connect(cb);
+	}
+
 	public void Once(Action<object?[]> action)
 	{
 		PTCallback? cb = null;
@@ -344,6 +388,66 @@ public class PTSignal : IScriptObject
 			del.DynamicInvoke(args ?? []);
 		})
 		{ OriginalDelegate = del };
+		Connect(cb);
+	}
+
+	public void Once<T>(Action<T> action)
+	{
+		PTCallback? cb = null;
+		cb = new PTCallback(args =>
+		{
+			Disconnect(cb!);
+			action((T)args[0]!);
+		})
+		{
+			OriginalDelegate = action
+		};
+
+		Connect(cb);
+	}
+
+	public void Once<T1, T2>(Action<T1, T2> action)
+	{
+		PTCallback? cb = null;
+		cb = new PTCallback(args =>
+		{
+			Disconnect(cb!);
+			action((T1)args[0]!, (T2)args[1]!);
+		})
+		{
+			OriginalDelegate = action
+		};
+
+		Connect(cb);
+	}
+
+	public void Once<T1, T2, T3>(Action<T1, T2, T3> action)
+	{
+		PTCallback? cb = null;
+		cb = new PTCallback(args =>
+		{
+			Disconnect(cb!);
+			action((T1)args[0]!, (T2)args[1]!, (T3)args[2]!);
+		})
+		{
+			OriginalDelegate = action
+		};
+
+		Connect(cb);
+	}
+
+	public void Once<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action)
+	{
+		PTCallback? cb = null;
+		cb = new PTCallback(args =>
+		{
+			Disconnect(cb!);
+			action((T1)args[0]!, (T2)args[1]!, (T3)args[2]!, (T4)args[3]!);
+		})
+		{
+			OriginalDelegate = action
+		};
+
 		Connect(cb);
 	}
 


### PR DESCRIPTION
## Summary

Same as #1276 but also for disconnect and once methods which i forgot

## Related issue or discussion
N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [x] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [ ] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

None