### PR TITLE
character visibility controls

### DIFF
--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -74,6 +74,17 @@ public partial class CharacterModel : Dynamic
 		set => _animator = value;
 	}
 
+	[Editable, ScriptProperty]
+	public bool Visible
+	{
+		get => return GDNode3D.Visible;
+		set
+		{
+			GDNode3D.Visible = value;
+			OnPropertyChanged();
+		}
+	}
+
 	private bool _peerReadySubscribed = false;
 
 	public override void Init()

--- a/Polytoria/scripts/datamodel/CharacterModel.cs
+++ b/Polytoria/scripts/datamodel/CharacterModel.cs
@@ -77,7 +77,7 @@ public partial class CharacterModel : Dynamic
 	[Editable, ScriptProperty]
 	public bool Visible
 	{
-		get => return GDNode3D.Visible;
+		get => GDNode3D.Visible;
 		set
 		{
 			GDNode3D.Visible = value;

--- a/Polytoria/scripts/datamodel/Player.cs
+++ b/Polytoria/scripts/datamodel/Player.cs
@@ -51,6 +51,7 @@ public sealed partial class Player : NPC
 	private bool _useHeadTurning = false;
 	private int _userID;
 	private bool _useBubbleChat = true;
+	private bool _chatBubbleVisible = true;
 	private bool _autoLoadAppearance = true;
 	private bool _allowAnimationWhileMoving = false;
 	private PlayerMovementModeEnum _movementMode = PlayerMovementModeEnum.Default;
@@ -240,7 +241,7 @@ public sealed partial class Player : NPC
 		set
 		{
 			_useBubbleChat = value;
-			_bubbleChat?.Visible = _useBubbleChat;
+			UpdateChatBubbleVisibility();
 			OnPropertyChanged();
 		}
 	}
@@ -318,6 +319,23 @@ public sealed partial class Player : NPC
 			_rotationMode = value;
 			OnPropertyChanged();
 		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool ChatBubbleVisible
+	{
+		get => _chatBubbleVisible;
+		set
+		{
+			_chatBubbleVisible = value;
+			UpdateChatBubbleVisibility();
+			OnPropertyChanged();
+		}
+	}
+
+	private void UpdateChatBubbleVisibility()
+	{
+		_bubbleChat.Visible = _useBubbleChat && _chatBubbleVisible;
 	}
 
 	[ScriptProperty]
@@ -504,7 +522,7 @@ public sealed partial class Player : NPC
 
 		_bubbleChat = Globals.CreateInstanceFromScene<BubbleChat>(BubbleChatScene);
 		_bubbleChat.TargetPlayer = this;
-		_bubbleChat.Visible = _useBubbleChat;
+		ChatBubbleVisible = _useBubbleChat;
 		GDNode.AddChild(_bubbleChat, @internal: Node.InternalMode.Back);
 		excludedBoundNodes.Add(_bubbleChat);
 	}
@@ -958,16 +976,14 @@ public sealed partial class Player : NPC
 
 	private void OnFirstPersonEntered()
 	{
-		if (Character == null) return;
-		Character.GDNode3D.Visible = false;
-		_bubbleChat.Visible = false;
+		Character?.Visible = false;
+		ChatBubbleVisible = false;
 	}
 
 	private void OnFirstPersonExited()
 	{
-		if (Character == null) return;
-		Character.GDNode3D.Visible = true;
-		_bubbleChat.Visible = true;
+		Character?.Visible = true;
+		ChatBubbleVisible = true;
 	}
 
 	public void WarpToSpawnPoint()


### PR DESCRIPTION
## Summary

adds `CharacterModel.Visible` (will be obviated if #1283) and `Player.ChatBubbleVisible` (will be obviated if #1317) properties, to be used as in how entering 1st person hides them

## Related issue or discussion

resolves #1279 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use
none