### PR TITLE
quaternions for all

### DIFF
--- a/Polytoria/scripts/datamodel/BodyRotation.cs
+++ b/Polytoria/scripts/datamodel/BodyRotation.cs
@@ -15,6 +15,17 @@ public partial class BodyRotation : Instance
 	private float _force = 0;
 	private float _acceptanceAngle = 5;
 
+	[ScriptProperty, CloneIgnore, SaveIgnore]
+	public Quaternion TargetQuaternion
+	{
+		get => _targetQuaternion;
+		set
+		{
+			_targetQuaternion = value;
+			OnPropertyChanged();
+		}
+	}
+
 	[Editable, ScriptProperty]
 	public Vector3 TargetRotation
 	{

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -486,7 +486,7 @@ public partial class Dynamic : Instance
 	}
 
 	[ScriptMethod]
-	public void RotateAroundQuaternion(Vector3 point, Quaternion q)
+	public void RotateAround(Vector3 point, Quaternion q)
 	{
 		RotateAroundBasis(point, new(q));
 	}
@@ -507,7 +507,7 @@ public partial class Dynamic : Instance
 	}
 
 	[ScriptMethod]
-	public void RotateQuaternion(Quaternion q)
+	public void Rotate(Quaternion q)
 	{
 		GDNode3D.Basis = new Basis(q) * GDNode3D.Basis;
 		if (AutoUpdateNetTransform)

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -460,14 +460,11 @@ public partial class Dynamic : Instance
 		}
 	}
 
-	[ScriptMethod]
-	public void RotateAround(Vector3 point, Vector3 axis, float angle)
+	private void RotateAroundBasis(Vector3 point, Basis rotation)
 	{
 		Transform3D transform = GetGlobalTransform();
 
 		transform.Origin -= point;
-
-		Basis rotation = new(axis.Normalized(), Mathf.DegToRad(angle));
 
 		transform.Basis = rotation * transform.Basis;
 		transform.Origin = rotation.Xform(transform.Origin);
@@ -483,6 +480,18 @@ public partial class Dynamic : Instance
 	}
 
 	[ScriptMethod]
+	public void RotateAround(Vector3 point, Vector3 axis, float angle)
+	{
+		RotateAroundBasis(point, new(axis.Normalized(), Mathf.DegToRad(angle)));
+	}
+
+	[ScriptMethod]
+	public void RotateAroundQuaternion(Vector3 point, Quaternion q)
+	{
+		RotateAroundBasis(point, new(q));
+	}
+
+	[ScriptMethod]
 	public void Rotate(Vector3 eulerAngles)
 	{
 		Vector3 radians = eulerAngles * Mathf.DegToRad(1.0f);
@@ -491,6 +500,16 @@ public partial class Dynamic : Instance
 		GDNode3D.RotateObjectLocal(Vector3.Up, radians.Y);
 		GDNode3D.RotateObjectLocal(Vector3.Back, radians.Z);
 
+		if (AutoUpdateNetTransform)
+		{
+			UpdateNetTransformReliable();
+		}
+	}
+
+	[ScriptMethod]
+	public void RotateQuaternion(Quaternion q)
+	{
+		GDNode3D.Basis = new Basis(q) * GDNode3D.Basis;
 		if (AutoUpdateNetTransform)
 		{
 			UpdateNetTransformReliable();

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -450,13 +450,12 @@ public sealed partial class Environment : Instance
 	}
 
 	[ScriptMethod]
-	public Instance[] OverlapBox(Vector3 pos, Vector3 size, Vector3 rot, Instance[]? ignoreList = null)
+	public Instance[] OverlapBoxQuaternion(Vector3 pos, Vector3 size, Quaternion q, Instance[]? ignoreList = null)
 	{
 		Transform3D t = new()
 		{
 			Origin = pos
 		};
-		Quaternion q = Quaternion.FromEuler(rot.FlipEuler());
 		Basis basis = new(q);
 		t.Basis = basis;
 		t = t.Scaled(Vector3.One);
@@ -470,6 +469,12 @@ public sealed partial class Environment : Instance
 		};
 
 		return PerformOverlap(ignoreList, query);
+	}
+
+	[ScriptMethod]
+	public Instance[] OverlapBox(Vector3 pos, Vector3 size, Vector3 rot, Instance[]? ignoreList = null)
+	{
+		return OverlapBoxQuaternion(pos, size, Quaternion.FromEuler(rot.FlipEuler()), ignoreList);
 	}
 
 	private Instance[] PerformOverlap(Instance[]? ignoreList, PhysicsShapeQueryParameters3D query)

--- a/Polytoria/scripts/datamodel/Environment.cs
+++ b/Polytoria/scripts/datamodel/Environment.cs
@@ -450,7 +450,7 @@ public sealed partial class Environment : Instance
 	}
 
 	[ScriptMethod]
-	public Instance[] OverlapBoxQuaternion(Vector3 pos, Vector3 size, Quaternion q, Instance[]? ignoreList = null)
+	public Instance[] OverlapBox(Vector3 pos, Vector3 size, Quaternion q, Instance[]? ignoreList = null)
 	{
 		Transform3D t = new()
 		{
@@ -474,7 +474,7 @@ public sealed partial class Environment : Instance
 	[ScriptMethod]
 	public Instance[] OverlapBox(Vector3 pos, Vector3 size, Vector3 rot, Instance[]? ignoreList = null)
 	{
-		return OverlapBoxQuaternion(pos, size, Quaternion.FromEuler(rot.FlipEuler()), ignoreList);
+		return OverlapBox(pos, size, Quaternion.FromEuler(rot.FlipEuler()), ignoreList);
 	}
 
 	private Instance[] PerformOverlap(Instance[]? ignoreList, PhysicsShapeQueryParameters3D query)

--- a/Polytoria/scripts/datamodel/services/CaptureService.cs
+++ b/Polytoria/scripts/datamodel/services/CaptureService.cs
@@ -163,6 +163,92 @@ public sealed partial class CaptureService : Instance
 	}
 
 	[ScriptMethod]
+	public async Task TakePhotoAtQuaternion(Vector3 pos, Quaternion rot, Vector2? photoSize = null, UIField? overlay = null)
+	{
+		if (_debounce) throw new Exception("TakePhoto is on cooldown");
+		if (!CanCapture)
+		{
+			Root.CoreUI.CoreUI.NotificationCenter.FireMessage("Capture is disabled at this time");
+			return;
+		}
+		_debounce = true;
+		PrePhotoTake();
+
+		overlay ??= DefaultCaptureOverlay;
+
+		CurrentPhotoPath = null;
+		SubViewport subview = new();
+		Node3D pivot = new();
+		Camera3D cam = new();
+
+		Camera3D activeCam = GDNode.GetViewport().GetCamera3D();
+
+		cam.Fov = activeCam.Fov;
+		cam.Projection = activeCam.Projection;
+
+		pivot.AddChild(cam);
+		subview.AddChild(pivot);
+		GDNode.AddChild(subview, @internal: Node.InternalMode.Back);
+
+		GUI? guiOverlay = null;
+
+		if (overlay != null)
+		{
+			guiOverlay = New<GUI>();
+			UIField clone = (UIField)overlay.Clone();
+			clone.Visible = true;
+			clone.Parent = guiOverlay;
+			guiOverlay.Parent = this;
+
+			// Wait one frame for all node control to init
+			await Globals.Singleton.WaitFrame();
+
+			// Override parent check for visible
+			foreach (Instance des in guiOverlay.GetDescendants())
+			{
+				if (des is UIField field)
+				{
+					field.OverrideParentCheck = true;
+					field.RecomputeVisible();
+				}
+			}
+
+			guiOverlay.GDNode.Reparent(subview);
+		}
+
+		pivot.GlobalPosition = pos;
+		pivot.GlobalBasis = new(rot);
+		cam.RotationDegrees = new Vector3(0, 0, 0);
+		if (photoSize != null && photoSize != Vector2.Zero && !(photoSize > _photoSizeLimit))
+		{
+			subview.Size = (Vector2I)photoSize;
+		}
+		else
+		{
+			subview.Size = Globals.Singleton.GetWindow().Size;
+		}
+
+		subview.RenderTargetClearMode = SubViewport.ClearMode.Once;
+		subview.RenderTargetUpdateMode = SubViewport.UpdateMode.Once;
+
+		await Globals.Singleton.ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
+
+		guiOverlay?.Delete();
+
+		Image img = subview.GetTexture().GetImage();
+		img.FixAlphaEdges();
+		img.GenerateMipmaps();
+
+
+		CurrentPhoto?.Dispose();
+		CurrentPhoto = ImageTexture.CreateFromImage(img);
+
+		subview.QueueFree();
+
+		PostPhotoTaken();
+	}
+
+	[ScriptMethod]
 	public async Task TakePhotoAt(Vector3 pos, Vector3 rot, Vector2? photoSize = null, UIField? overlay = null)
 	{
 		if (_debounce) throw new Exception("TakePhoto is on cooldown");

--- a/Polytoria/scripts/datamodel/services/CaptureService.cs
+++ b/Polytoria/scripts/datamodel/services/CaptureService.cs
@@ -163,7 +163,7 @@ public sealed partial class CaptureService : Instance
 	}
 
 	[ScriptMethod]
-	public async Task TakePhotoAtQuaternion(Vector3 pos, Quaternion rot, Vector2? photoSize = null, UIField? overlay = null)
+	public async Task TakePhotoAt(Vector3 pos, Quaternion rot, Vector2? photoSize = null, UIField? overlay = null)
 	{
 		if (_debounce) throw new Exception("TakePhoto is on cooldown");
 		if (!CanCapture)


### PR DESCRIPTION
## Summary

added:
- `:Rotate`'s `:RotateQuaternion`
- `:RotateAround`'s `:RotateAroundQuaternion`
- `BodyRotation.TargetRotation`'s `BodyRotation.TargetQuaternion`
- `Environment:OverlapBox`'s `Environment:OverlapBoxQuaternion`

## Related issue or discussion

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## AI/LLM use
none