### PR TITLE
Restore legacy Luau namecalls for datastore and achievement APIs

### DIFF
--- a/Polytoria/scripts/datamodel/data/Datastore.cs
+++ b/Polytoria/scripts/datamodel/data/Datastore.cs
@@ -51,7 +51,7 @@ public partial class Datastore : IScriptObject
 		await Provider.WriteData(key, null);
 	}
 
-	[ScriptLegacyMethod(nameof(Get))]
+	[ScriptMethod, ScriptLegacyMethod(nameof(Get))]
 	public void Get(string key, PTCallback? callback)
 	{
 		_ = GetAsync(key).ContinueWith(tsk =>
@@ -68,7 +68,7 @@ public partial class Datastore : IScriptObject
 		});
 	}
 
-	[ScriptLegacyMethod(nameof(Set))]
+	[ScriptMethod, ScriptLegacyMethod(nameof(Set))]
 	public void Set(string key, object value, PTCallback? callback)
 	{
 		_ = SetAsync(key, value).ContinueWith(tsk =>
@@ -84,7 +84,7 @@ public partial class Datastore : IScriptObject
 		});
 	}
 
-	[ScriptLegacyMethod(nameof(Remove))]
+	[ScriptMethod, ScriptLegacyMethod(nameof(Remove))]
 	public void Remove(string key, PTCallback? callback)
 	{
 		_ = RemoveAsync(key).ContinueWith(tsk =>

--- a/Polytoria/scripts/datamodel/services/AchievementsService.cs
+++ b/Polytoria/scripts/datamodel/services/AchievementsService.cs
@@ -73,7 +73,7 @@ public sealed partial class AchievementsService : Instance
 		}
 	}
 
-	[ScriptLegacyMethod("Award")]
+	[ScriptMethod, ScriptLegacyMethod("Award")]
 	public void Award(int userID, int achievementID, PTCallback? callback)
 	{
 		_ = AwardAsync(userID, achievementID).ContinueWith(tsk =>
@@ -124,7 +124,7 @@ public sealed partial class AchievementsService : Instance
 		GotAchievement.Invoke(id);
 	}
 
-	[ScriptLegacyMethod("HasAchievement")]
+	[ScriptMethod, ScriptLegacyMethod("HasAchievement")]
 	public void HasAchievement(int userID, int achievementID, PTCallback callback)
 	{
 		_ = HasAchievementAsync(userID, achievementID).ContinueWith(tsk =>


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [x] Scripting runtimes
- [ ] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->