### PR TITLE
Improve and optimize GUI3D

### DIFF
--- a/Polytoria/scripts/datamodel/GUI3D.cs
+++ b/Polytoria/scripts/datamodel/GUI3D.cs
@@ -54,6 +54,8 @@ public partial class GUI3D : Dynamic
 			_material.BillboardMode = value ? BaseMaterial3D.BillboardModeEnum.Enabled : BaseMaterial3D.BillboardModeEnum.Disabled;
 			UpdateSize();
 			SetProcess(value);
+			if (!value) { _area.Rotation = Vector3.Zero; }
+			
 			OnPropertyChanged();
 		}
 	}
@@ -224,6 +226,8 @@ public partial class GUI3D : Dynamic
 		mousePos3D = _area.GlobalTransform.AffineInverse() * mousePos3D;
 
 		Vector2 mousePos2D = new(mousePos3D.X, mousePos3D.Y);
+		if (FaceCamera) { mousePos2D.X *= -1; }
+
 		Vector2 viewportPos = new(Mathf.Remap(mousePos2D.X, 0.5f, -0.5f, 0, AbsoluteSize.X), Mathf.Remap(mousePos2D.Y, 0.5f, -0.5f, 0, AbsoluteSize.Y));
 		@event.Position = viewportPos;
 		@event.GlobalPosition = viewportPos;
@@ -314,6 +318,8 @@ public partial class GUI3D : Dynamic
 	{
 		_mesh.Scale = newSize;
 		_area.Scale = newSize;
+		UpdateSize();
+		UpdateCanvasSize();
 		base.OnNodeSizeChanged(newSize);
 	}
 
@@ -343,10 +349,6 @@ public partial class GUI3D : Dynamic
 				_area.LookAt(look);
 				_area.RotateObjectLocal(Vector3.Back, cam.Rotation.Z);
 			}
-		}
-		else
-		{
-			_area.Rotation = Vector3.Zero;
 		}
 	}
 }

--- a/Polytoria/scripts/datamodel/GUI3D.cs
+++ b/Polytoria/scripts/datamodel/GUI3D.cs
@@ -18,6 +18,10 @@ public partial class GUI3D : Dynamic
 	private bool _shaded = true;
 	private bool _faceCamera = false;
 	private bool _transparent = false;
+	private bool _doubleSided = false;
+	private bool _alwaysOnTop = false;
+	private bool _fixedSize = false;
+	private bool _visible = true;
 
 	private bool _mouseInArea = false;
 	private Vector2? _lastPos;
@@ -25,6 +29,8 @@ public partial class GUI3D : Dynamic
 	private SubViewport _subViewport = null!;
 	private PlaneMesh _plane = null!;
 	private Area3D _area = null!;
+
+	private int _maxViewportSize = 2048;
 
 	[Editable, ScriptProperty]
 	public bool Shaded
@@ -37,7 +43,6 @@ public partial class GUI3D : Dynamic
 			OnPropertyChanged();
 		}
 	}
-
 
 	[Editable, ScriptProperty]
 	public bool FaceCamera
@@ -66,13 +71,65 @@ public partial class GUI3D : Dynamic
 		}
 	}
 
+	[Editable, ScriptProperty]
+	public bool DoubleSided
+	{
+		get => _doubleSided;
+		set
+		{
+			_doubleSided = value;
+			_material.CullMode = value ? BaseMaterial3D.CullModeEnum.Disabled : BaseMaterial3D.CullModeEnum.Back;
+
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool AlwaysOnTop
+	{
+		get => _alwaysOnTop;
+		set
+		{
+			_alwaysOnTop = value;
+			_material.NoDepthTest = value;
+
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool FixedSize
+	{
+		get => _fixedSize;
+		set
+		{
+			_fixedSize = value;
+			_material.FixedSize = value;
+
+			OnPropertyChanged();
+		}
+	}
+
+	[Editable, ScriptProperty]
+	public bool Visible
+	{
+		get => _visible;
+		set
+		{
+			_visible = value;
+			_mesh.Visible = value;
+
+			OnPropertyChanged();
+		}
+	}
+
 	[ScriptProperty]
 	public Vector2 AbsoluteSize => _subViewport.Size;
 
 	public override Node CreateGDNode()
 	{
 		Node gui3D = Globals.LoadNetworkedObjectScene("GUI3D")!;
-		_subViewport = new() { HandleInputLocally = false };
+		_subViewport = new() { HandleInputLocally = false, Disable3D = true };
 		_area = gui3D.GetNode<Area3D>("Area3D");
 		gui3D.AddChild(_subViewport);
 		return gui3D;
@@ -95,6 +152,10 @@ public partial class GUI3D : Dynamic
 		Shaded = true;
 		FaceCamera = false;
 		Transparent = false;
+		DoubleSided = false;
+		AlwaysOnTop = false;
+		FixedSize = false;
+		Visible = true;
 
 		TransformChanged += UpdateCanvasSize;
 
@@ -105,13 +166,16 @@ public partial class GUI3D : Dynamic
 
 	public override void Ready()
 	{
+		UpdateSize();
 		UpdateCanvasSize();
 		base.Ready();
 	}
 
 	private void UpdateCanvasSize()
 	{
-		_subViewport.Size = new((int)(Size.X * 512), (int)(Size.Y * 512));
+		Vector2 initialSize = new((int)(Size.X * 128), (int)(Size.Y * 128));
+		float scale = Mathf.Min(1.0f, _maxViewportSize / Mathf.Max(initialSize.X, initialSize.Y));
+		_subViewport.Size = new((int)(initialSize.X * scale), (int)(initialSize.Y * scale));
 		RecomputeChildTransforms();
 	}
 
@@ -136,6 +200,7 @@ public partial class GUI3D : Dynamic
 
 	public void OnInput(InputEvent @event)
 	{
+		if (!_visible) return;
 		if (_mouseInArea)
 		{
 			GDNode.GetViewport().SetInputAsHandled();
@@ -160,7 +225,6 @@ public partial class GUI3D : Dynamic
 
 		Vector2 mousePos2D = new(mousePos3D.X, mousePos3D.Y);
 		Vector2 viewportPos = new(Mathf.Remap(mousePos2D.X, 0.5f, -0.5f, 0, AbsoluteSize.X), Mathf.Remap(mousePos2D.Y, 0.5f, -0.5f, 0, AbsoluteSize.Y));
-
 		@event.Position = viewportPos;
 		@event.GlobalPosition = viewportPos;
 
@@ -272,10 +336,13 @@ public partial class GUI3D : Dynamic
 		if (FaceCamera)
 		{
 			Camera3D cam = Globals.Singleton.GetViewport().GetCamera3D();
-			Vector3 look = cam.ToGlobal(new(0, 0, -100)) - cam.GlobalTransform.Origin;
+			if (cam != null)
+			{
+				Vector3 look = cam.ToGlobal(new(0, 0, -100)) - cam.GlobalTransform.Origin;
 
-			_area.LookAt(look);
-			_area.RotateObjectLocal(Vector3.Back, cam.Rotation.Z);
+				_area.LookAt(look);
+				_area.RotateObjectLocal(Vector3.Back, cam.Rotation.Z);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
## Summary
- Adds Visible, DoubleSided, AlwaysOnTop, and FixedSize properties to GUI3D
- Fixes a bunch of issues with scaling stuff, probably.
- Fixes issues with input/mousepos detection
- Set the limit of the max resolution for GUI3D's to 2048x2048 (retaining aspect ratio) since it would infinitely scale the resolution by 512*scale of GUI3D and eat all of your gpu, maybe a property for this would be better idk

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->

## Related issue or discussion

Fixes #943 
Fixes #772 
Fixes #696 
Fixes #1151 ?

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [x] Client
- [x] Creator
- [ ] Server
- [ ] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use
None.
<!-- Describe AI use, or write "None" if not applicable -->