### PR TITLE
skip ticks for frozen and sleeping objects

### DIFF
--- a/Polytoria/scripts/client/DatamodelBridge.cs
+++ b/Polytoria/scripts/client/DatamodelBridge.cs
@@ -147,7 +147,8 @@ public partial class DatamodelBridge : Node3D
 
 				if (_handles.TryGetValue(part, out PartHandle? moved))
 				{
-					ChunkKey movedKey = GetKeyForPart(part);
+					Transform3D transform = part.GetGlobalTransform();
+					ChunkKey movedKey = GetKeyForPart(part, transform.Origin);
 					if (!movedKey.Equals(moved.Key))
 					{
 						RemoveFromBatch(part);
@@ -155,7 +156,7 @@ public partial class DatamodelBridge : Node3D
 						continue;
 					}
 
-					moved.Batch.MultiMesh.SetInstanceTransform(moved.Index, part.GetGlobalTransform());
+					moved.Batch.MultiMesh.SetInstanceTransform(moved.Index, transform);
 				}
 				continue;
 			}
@@ -203,11 +204,16 @@ public partial class DatamodelBridge : Node3D
 
 	private ChunkKey GetKeyForPart(Part part)
 	{
+		return GetKeyForPart(part, part.Position);
+	}
+
+	private ChunkKey GetKeyForPart(Part part, Vector3 position)
+	{
 		bool isDynamic = !part.Anchored;
 		bool split = !isDynamic && _groupCounts.GetValueOrDefault((part.Material, part.Shape)) >= SplitGroupSize;
 		float size = split ? ChunkBaseSize : CoarseChunkSize;
 
-		Vector3 pos = part.Position + new Vector3(size * 0.5f, size * 0.5f, size * 0.5f);
+		Vector3 pos = position + new Vector3(size * 0.5f, size * 0.5f, size * 0.5f);
 		Vector3I coord = new(
 			Mathf.FloorToInt(pos.X / size),
 			Mathf.FloorToInt(pos.Y / size),

--- a/Polytoria/scripts/datamodel/Dynamic.cs
+++ b/Polytoria/scripts/datamodel/Dynamic.cs
@@ -356,6 +356,10 @@ public partial class Dynamic : Instance
 		{
 			InvokeTransformChanged(old);
 		}
+		if (!_isDirty && this is not NPC { IsSitting: true })
+		{
+			SetPhysicsProcessWAuthor(false);
+		}
 	}
 
 	private void UpdateTransform(double delta)

--- a/Polytoria/scripts/datamodel/NPC.cs
+++ b/Polytoria/scripts/datamodel/NPC.cs
@@ -22,6 +22,7 @@ public partial class NPC : Physical
 	private const float StepHeight = 1.5f;
 	private Tool? _holdingTool;
 	private Seat? _sittingIn;
+	private CharacterModel? _sitPoseModel;
 	private CharacterModel? _character;
 	private Dynamic? _moveTarget;
 
@@ -624,6 +625,15 @@ public partial class NPC : Physical
 		{
 			if (!Root.Network.IsServer && SittingIn != null)
 			{
+				if (!OverrideNetworkTransform)
+				{
+					InternalSit(SittingIn);
+				}
+				else
+				{
+					ApplySitPose();
+				}
+
 				Velocity = Vector3.Zero;
 				Position = SittingIn.Position + SeatOffset.Y * Up;
 				if (SittingIn.SitDirectionLocked)
@@ -957,18 +967,30 @@ public partial class NPC : Physical
 
 	private void InternalSit(Seat seat)
 	{
-		if (IsSitting && SittingIn != null)
+		if (IsSitting && SittingIn != null && !ReferenceEquals(SittingIn, seat))
 		{
 			SittingIn.Occupant = null;
 			SittingIn.InvokeVacated(this);
 		}
 		IsSitting = true;
 		OverrideNetworkTransform = true;
+		SetPhysicsProcess(true);
 		SittingIn = seat;
 		seat.Occupant = this;
 		seat.InvokeSat(this);
-		Character?.SetBlendValue(CharacterModel.CharacterModelBlendEnum.Sitting, 1);
+		ApplySitPose();
 		Seated.Invoke(seat);
+	}
+
+	private void ApplySitPose()
+	{
+		if (Character == null || ReferenceEquals(_sitPoseModel, Character))
+		{
+			return;
+		}
+
+		_sitPoseModel = Character;
+		Character.SetBlendValue(CharacterModel.CharacterModelBlendEnum.Sitting, 1);
 	}
 
 	[NetRpc(AuthorityMode.Authority, TransferMode = TransferMode.Reliable, CallLocal = true)]
@@ -979,6 +1001,7 @@ public partial class NPC : Physical
 			// Unsit the NPC
 			IsSitting = false;
 			OverrideNetworkTransform = false;
+			_sitPoseModel = null;
 
 			if (SittingIn != null)
 			{

--- a/Polytoria/scripts/datamodel/Physical.cs
+++ b/Polytoria/scripts/datamodel/Physical.cs
@@ -225,8 +225,10 @@ public partial class Physical : Dynamic
 	{
 		if (OverridePhysicsProcess) return;
 
-		SetPhysicsProcess(!_anchored && !IsAsleep);
+		SetPhysicsProcess(!_anchored && !IsAsleep && !IsFrozen);
 	}
+
+	internal virtual bool IsFrozen => false;
 
 	protected virtual void ApplyFreeze(bool to) { }
 

--- a/Polytoria/scripts/datamodel/RigidBody.cs
+++ b/Polytoria/scripts/datamodel/RigidBody.cs
@@ -367,4 +367,5 @@ public partial class RigidBody : Physical
 	}
 
 	internal override bool IsAsleep => !GDRigidBody.Freeze && GDRigidBody.Sleeping;
+	internal override bool IsFrozen => GDRigidBody.Freeze;
 }


### PR DESCRIPTION
## Summary

<!-- What changed and why? Please provide a brief description of the changes made in this pull request. -->
fixes ticking physics for sleeping/frozen objects and also fixes sit animation when player joins mid session
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [ ] Build/export/tooling
- [ ] Other

## Area affected

- [ ] Client
- [ ] Creator
- [ ] Server
- [x] Networking / replication
- [ ] Scripting API
- [ ] Scripting runtimes
- [x] Datamodel
- [ ] UI / UX
- [ ] Build / export
- [ ] Other

## Checklist

- [x] I have read the [contributing guidelines](https://v2docs.polytoria.com/contributing/)
- [x] Added in-code documentation (where needed)
- [x] Ran `dotnet restore`
- [x] Ran `dotnet format`
- [x] Ran `dotnet build`
- [x] Ran `dotnet test --project Polytoria.Tests/Polytoria.Tests.csproj`
- [x] Tested the changes in a local environment
- [x] Ensured all commits are [signed off](https://v2docs.polytoria.com/contributing/software/contributor/dco/)

## Screenshots / video

<!-- Required for visual changes. Provide screenshots or a short video demonstrating the changes. -->

## AI/LLM use

<!-- Describe AI use, or write "None" if not applicable -->